### PR TITLE
refactor: bring every production function under the local-bindings cap and enforce the rule

### DIFF
--- a/dylint.toml
+++ b/dylint.toml
@@ -42,12 +42,7 @@ ignore = [
 
 [perfectionist]
 enable = ["unordered_derives", "core_instead_of_std"]
-disable = [
-    "needless_borrowed_parameters",
-    # Configured below and adopted refactor by refactor; re-enabled by
-    # the pull request that brings the production sites to zero.
-    "too_many_local_bindings",
-]
+disable = ["needless_borrowed_parameters"]
 
 # Code spans read fine in `--help` and stay useful as `cargo doc` docs, so
 # keep them; links and HTML remain forbidden and are cleaned from help text.

--- a/pnpm/crates/auth-commands/src/login/classic_login.rs
+++ b/pnpm/crates/auth-commands/src/login/classic_login.rs
@@ -108,20 +108,11 @@ async fn add_user(
     credentials: Credentials<'_>,
     otp: Option<&str>,
 ) -> Result<String, AddUserError> {
-    let Credentials { username, password, email } = credentials;
     let url = registry_join(
         registry,
-        &format!("-/user/org.couchdb.user:{}", encode_uri_component(username)),
+        &format!("-/user/org.couchdb.user:{}", encode_uri_component(credentials.username)),
     )
     .map_err(|error| AddUserError::Transport { reason: error.to_string() })?;
-    let document = json!({
-        "_id": format!("org.couchdb.user:{username}"),
-        "name": username,
-        "password": password,
-        "email": email,
-        "type": "user",
-    });
-    let body = serde_json::to_string(&document).expect("serialize addUser document");
 
     let guard = http_client.acquire_for_url(&url).await;
     let mut request = guard
@@ -129,7 +120,7 @@ async fn add_user(
         .header("content-type", "application/json")
         .header("accept", "application/json")
         .header("npm-auth-type", "web")
-        .body(body);
+        .body(add_user_document(&credentials));
     if let Some(otp) = otp {
         request = request.header("npm-otp", otp);
     }
@@ -140,26 +131,44 @@ async fn add_user(
         .map_err(|error| AddUserError::Transport { reason: error.to_string() })?;
     let ok = response.status().is_success();
     let status = response.status().as_u16();
-    // Join every `WWW-Authenticate` header the way the Fetch `Headers.get`
-    // pnpm relies on does, so an `otp` challenge that isn't the first of
-    // several challenge headers is still detected.
-    let www_authenticate = {
-        let joined = response
-            .headers()
-            .get_all(reqwest::header::WWW_AUTHENTICATE)
-            .iter()
-            .filter_map(|value| value.to_str().ok())
-            .collect::<Vec<_>>()
-            .join(", ");
-        (!joined.is_empty()).then_some(joined)
-    };
+    let www_authenticate = joined_www_authenticate(&response);
     let text = response.text().await.unwrap_or_default();
 
     if !ok {
         return Err(AddUserError::Http { status, text, www_authenticate });
     }
 
-    match serde_json::from_str::<Value>(&text) {
+    token_from_response(&text)
+}
+
+fn add_user_document(credentials: &Credentials<'_>) -> String {
+    let Credentials { username, password, email } = *credentials;
+    let document = json!({
+        "_id": format!("org.couchdb.user:{username}"),
+        "name": username,
+        "password": password,
+        "email": email,
+        "type": "user",
+    });
+    serde_json::to_string(&document).expect("serialize addUser document")
+}
+
+/// Join every `WWW-Authenticate` header the way the Fetch `Headers.get`
+/// pnpm relies on does, so an `otp` challenge that isn't the first of
+/// several challenge headers is still detected.
+fn joined_www_authenticate(response: &reqwest::Response) -> Option<String> {
+    let joined = response
+        .headers()
+        .get_all(reqwest::header::WWW_AUTHENTICATE)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .collect::<Vec<_>>()
+        .join(", ");
+    (!joined.is_empty()).then_some(joined)
+}
+
+fn token_from_response(text: &str) -> Result<String, AddUserError> {
+    match serde_json::from_str::<Value>(text) {
         Ok(parsed) => match parsed.get("token").and_then(Value::as_str) {
             Some(token) if !token.is_empty() => Ok(token.to_owned()),
             _ => Err(AddUserError::NoToken),

--- a/pnpm/crates/cargo-resolver/src/features.rs
+++ b/pnpm/crates/cargo-resolver/src/features.rs
@@ -169,17 +169,10 @@ fn collect_feature_selections(
     while let Some(dependency) = pending.pop_front() {
         registry.validate_dependency_source(dependency.registry.as_deref())?;
         let versions = registry.package(&dependency.name)?;
-        let compatibility = matching_versions(versions, &dependency.requirement)
-            .next_back()
-            .map(|version| compatibility_line(&version.version))
-            .ok_or_else(|| {
-                miette::miette!(
-                    "no non-yanked version of {} satisfies {}",
-                    dependency.name,
-                    dependency.requirement,
-                )
-            })?;
-        let package = PackageKey::Registry { name: dependency.name.clone(), compatibility };
+        let package = PackageKey::Registry {
+            name: dependency.name.clone(),
+            compatibility: newest_compatibility(versions, &dependency)?,
+        };
         let requested = dependency.feature_selection();
         let previous = selections.get(&package).cloned();
         let selection = selections.entry(package.clone()).or_default();
@@ -191,17 +184,37 @@ fn collect_feature_selections(
         let Some(selected_version) = solution.and_then(|solution| solution.get(&package)) else {
             continue;
         };
-        let selected = versions
-            .iter()
-            .find(|candidate| candidate.version == *selected_version)
-            .ok_or_else(|| {
-                miette::miette!(
-                    "selected {} {} is absent from the index",
-                    dependency.name,
-                    selected_version,
-                )
-            })?;
+        let selected = indexed_version(versions, &dependency.name, selected_version)?;
         pending.extend(active_dependencies(selected, selection)?);
     }
     Ok(selections)
+}
+
+/// The compatibility line of the newest non-yanked version satisfying the
+/// dependency's requirement.
+fn newest_compatibility(
+    versions: &[RegistryVersion],
+    dependency: &RegistryDependency,
+) -> Result<String> {
+    matching_versions(versions, &dependency.requirement)
+        .next_back()
+        .map(|version| compatibility_line(&version.version))
+        .ok_or_else(|| {
+            miette::miette!(
+                "no non-yanked version of {} satisfies {}",
+                dependency.name,
+                dependency.requirement,
+            )
+        })
+}
+
+pub(crate) fn indexed_version<'v>(
+    versions: &'v [RegistryVersion],
+    name: &str,
+    version: &Version,
+) -> Result<&'v RegistryVersion> {
+    versions
+        .iter()
+        .find(|candidate| candidate.version == *version)
+        .ok_or_else(|| miette::miette!("selected {name} {version} is absent from the index"))
 }

--- a/pnpm/crates/cargo-resolver/src/lockfile.rs
+++ b/pnpm/crates/cargo-resolver/src/lockfile.rs
@@ -1,5 +1,5 @@
 use crate::{
-    features::active_dependencies,
+    features::{active_dependencies, indexed_version},
     metadata::active_metadata_dependencies,
     model::{CargoMetadata, FeatureSelection, PackageKey, RegistryVersion},
     registry::{Registry, compatibility_line, matching_versions},
@@ -29,11 +29,7 @@ pub(crate) fn lockfile_from_solution(
         let PackageKey::Registry { name, .. } = key else {
             continue;
         };
-        let registry_version = registry
-            .package(name)?
-            .iter()
-            .find(|candidate| candidate.version == **version)
-            .ok_or_else(|| miette::miette!("selected {name} {version} is absent from the index"))?;
+        let registry_version = indexed_version(registry.package(name)?, name, version)?;
         let selection = feature_selections.get(*key).cloned().unwrap_or_default();
         let dependencies = locked_registry_dependencies(
             registry_version,
@@ -52,6 +48,27 @@ pub(crate) fn lockfile_from_solution(
         });
     }
 
+    packages.extend(workspace_packages(metadata, registry, &selected, &source)?);
+
+    packages.sort();
+    let lockfile = Lockfile {
+        version: ResolveVersion::V4,
+        packages,
+        root: None,
+        metadata: Metadata::default(),
+        patch: Patch::default(),
+    };
+    Ok(lockfile.to_string())
+}
+
+/// The lock entries for the workspace's own members.
+fn workspace_packages(
+    metadata: &CargoMetadata,
+    registry: &Registry,
+    selected: &BTreeMap<&PackageKey, &Version>,
+    source: &cargo_lock::SourceId,
+) -> Result<Vec<Package>> {
+    let mut packages = Vec::new();
     for package in
         metadata.packages.iter().filter(|package| metadata.workspace_members.contains(&package.id))
     {
@@ -63,8 +80,8 @@ pub(crate) fn lockfile_from_solution(
                         &dependency.name,
                         &dependency.requirement,
                         registry,
-                        &selected,
-                        &source,
+                        selected,
+                        source,
                     )
                 } else {
                     locked_workspace_dependency(&dependency.name, &dependency.requirement, metadata)
@@ -81,15 +98,7 @@ pub(crate) fn lockfile_from_solution(
         });
     }
 
-    packages.sort();
-    let lockfile = Lockfile {
-        version: ResolveVersion::V4,
-        packages,
-        root: None,
-        metadata: Metadata::default(),
-        patch: Patch::default(),
-    };
-    Ok(lockfile.to_string())
+    Ok(packages)
 }
 
 fn locked_registry_dependencies(

--- a/pnpm/crates/cli/src/cargo_deps.rs
+++ b/pnpm/crates/cli/src/cargo_deps.rs
@@ -287,40 +287,40 @@ struct DownloadOptions {
 async fn download_crates<Reporter: self::Reporter + 'static>(
     options: DownloadOptions,
 ) -> Result<Vec<(String, PathBuf)>> {
-    let DownloadOptions { config, packages, http_client, logged_methods, requester } = options;
-    if packages.is_empty() {
+    if options.packages.is_empty() {
         return Ok(Vec::new());
     }
+    let config = options.config;
     let store_dir = &config.store_dir;
     let store_index = StoreIndex::shared_for(store_dir, config.frozen_store);
     let (store_index_writer, writer_task) =
         StoreIndexWriter::spawn_for(store_dir, config.frozen_store);
 
     let cargo_auth_headers = cargo_auth_headers(config)?;
-    let registry_config = fetch_registry_config(config, &http_client, &cargo_auth_headers).await?;
+    let registry_config =
+        fetch_registry_config(config, &options.http_client, &cargo_auth_headers).await?;
     let auth_headers = download_auth_headers(config, &registry_config);
     let verified_files_cache = SharedVerifiedFilesCache::default();
-    let retry_opts = config.retry_opts();
     let concurrency = config.network_concurrency.clamp(1, 16);
 
-    let slots = stream::iter(packages)
+    let slots = stream::iter(options.packages)
         .map(|package| {
             materialize::<Reporter>(MaterializeOptions {
                 package,
                 store_dir,
                 store_index: store_index.as_ref().map(Arc::clone),
                 store_index_writer: Arc::clone(&store_index_writer),
-                http_client: Arc::clone(&http_client),
+                http_client: Arc::clone(&options.http_client),
                 auth_headers: Arc::clone(&auth_headers),
                 download_template: registry_config.dl.clone(),
                 verified_files_cache: Arc::clone(&verified_files_cache),
-                logged_methods: Arc::clone(&logged_methods),
+                logged_methods: Arc::clone(&options.logged_methods),
                 package_import_method: config.package_import_method,
-                retry_opts,
+                retry_opts: config.retry_opts(),
                 verify_store_integrity: config.verify_store_integrity,
                 strict_store_pkg_content_check: config.strict_store_pkg_content_check,
                 offline: config.offline,
-                requester: requester.clone(),
+                requester: options.requester.clone(),
             })
         })
         .buffer_unordered(concurrency)
@@ -766,54 +766,37 @@ struct MaterializeOptions {
 async fn materialize<Reporter: self::Reporter + 'static>(
     options: MaterializeOptions,
 ) -> Result<(String, PathBuf)> {
-    let MaterializeOptions {
-        package,
-        store_dir,
-        store_index,
-        store_index_writer,
-        http_client,
-        auth_headers,
-        download_template,
-        verified_files_cache,
-        logged_methods,
-        package_import_method,
-        retry_opts,
-        verify_store_integrity,
-        strict_store_pkg_content_check,
-        offline,
-        requester,
-    } = options;
-    let link_name = package.link_name();
-    let slot = package.store_slot(store_dir.root());
+    let link_name = options.package.link_name();
+    let slot = options.package.store_slot(options.store_dir.root());
     let package_url = pnpm_cargo_resolver::download_url(
-        &download_template,
-        &package.name,
-        &package.version,
-        &package.checksum,
+        &options.download_template,
+        &options.package.name,
+        &options.package.version,
+        &options.package.checksum,
     );
-    let package_id = format!("crate:{}@{}", package.name, package.version);
-    let integrity = Integrity::from_hex(&package.checksum, Algorithm::Sha256)
+    let package_id = format!("crate:{}@{}", options.package.name, options.package.version);
+    let integrity = Integrity::from_hex(&options.package.checksum, Algorithm::Sha256)
         .into_diagnostic()
         .wrap_err_with(|| format!("decode checksum for {package_id}"))?;
     let mut cas_paths = IngestTarballToStore {
-        http_client: &http_client,
-        store_dir,
-        store_index: store_index.as_ref().map(Arc::clone),
-        store_index_writer: Some(Arc::clone(&store_index_writer)),
-        verify_store_integrity,
-        strict_store_pkg_content_check,
-        verified_files_cache: Arc::clone(&verified_files_cache),
+        http_client: &options.http_client,
+        store_dir: options.store_dir,
+        store_index: options.store_index.as_ref().map(Arc::clone),
+        store_index_writer: Some(Arc::clone(&options.store_index_writer)),
+        verify_store_integrity: options.verify_store_integrity,
+        strict_store_pkg_content_check: options.strict_store_pkg_content_check,
+        verified_files_cache: Arc::clone(&options.verified_files_cache),
         package_integrity: Some(&integrity),
         package_unpacked_size: None,
         package_file_count: None,
         package_url: &package_url,
         package_id: &package_id,
-        auth_headers: &auth_headers,
-        requester: &requester,
+        auth_headers: &options.auth_headers,
+        requester: &options.requester,
         prefetched_cas_paths: None,
-        retry_opts,
+        retry_opts: options.retry_opts,
         ignore_file_pattern: None,
-        offline,
+        offline: options.offline,
         progress_reported: None,
         store_projection: ArchiveStoreProjection::RawArchive,
     }
@@ -822,19 +805,18 @@ async fn materialize<Reporter: self::Reporter + 'static>(
     .into_diagnostic()
     .wrap_err_with(|| format!("download {package_id}"))?;
 
-    let checksum = package.checksum;
     let slot_for_import = slot.clone();
     tokio::task::spawn_blocking(move || {
         checksum_cache::ChecksumCache {
-            store_dir,
-            index: store_index.as_ref(),
-            writer: &store_index_writer,
-            verified_files: &verified_files_cache,
+            store_dir: options.store_dir,
+            index: options.store_index.as_ref(),
+            writer: &options.store_index_writer,
+            verified_files: &options.verified_files_cache,
         }
-        .add(&mut cas_paths, &checksum)?;
+        .add(&mut cas_paths, &options.package.checksum)?;
         import_indexed_dir::<Reporter>(
-            &logged_methods,
-            package_import_method,
+            &options.logged_methods,
+            options.package_import_method,
             &slot_for_import,
             &cas_paths,
             ImportIndexedDirOpts {

--- a/pnpm/crates/cli/src/cargo_deps/git.rs
+++ b/pnpm/crates/cli/src/cargo_deps/git.rs
@@ -205,19 +205,10 @@ struct VendorSourceOptions<'a> {
 fn vendor_source<Reporter: self::Reporter>(
     options: &VendorSourceOptions<'_>,
 ) -> Result<Vec<(String, PathBuf)>> {
-    let &VendorSourceOptions {
-        source,
-        packages,
-        store_dir,
-        git_shallow_hosts,
-        package_import_method,
-        logged_methods,
-        offline,
-    } = options;
-    let mut linked = Vec::with_capacity(packages.len());
+    let mut linked = Vec::with_capacity(options.packages.len());
     let mut missing = Vec::new();
-    for package in packages {
-        let slot = package.store_slot(store_dir.root());
+    for package in options.packages {
+        let slot = package.store_slot(options.store_dir.root());
         // The checksum manifest sorts first among a crate's files, which
         // makes it the completion marker `import_indexed_dir` writes last.
         if slot.join(".cargo-checksum.json").exists() {
@@ -229,11 +220,11 @@ fn vendor_source<Reporter: self::Reporter>(
     if missing.is_empty() {
         return Ok(linked);
     }
-    let repository = redact_and_sanitize(&source.url);
-    if offline {
+    let repository = redact_and_sanitize(&options.source.url);
+    if options.offline {
         return Err(miette::miette!(
             "cannot check out {repository} at {} while offline",
-            source.commit,
+            options.source.commit,
         ));
     }
 
@@ -241,9 +232,9 @@ fn vendor_source<Reporter: self::Reporter>(
         .into_diagnostic()
         .wrap_err_with(|| format!("create a checkout directory for {repository}"))?;
     checkout_commit(&CheckoutOptions {
-        repo: &source.url,
-        commit: &source.commit,
-        git_shallow_hosts,
+        repo: &options.source.url,
+        commit: &options.source.commit,
+        git_shallow_hosts: options.git_shallow_hosts,
         git_bin: None,
         dest: checkout.path(),
     })
@@ -251,7 +242,7 @@ fn vendor_source<Reporter: self::Reporter>(
         let error = redact_and_sanitize(&error.to_string());
         miette::miette!("{error}")
     })
-    .wrap_err_with(|| format!("check out {repository} at {}", source.commit))?;
+    .wrap_err_with(|| format!("check out {repository} at {}", options.source.commit))?;
     let checked_out = Checkout::read(checkout.path())?;
     let package_dirs = checked_out.package_dirs();
     let checkout_root = dunce::canonicalize(checkout.path())
@@ -262,15 +253,15 @@ fn vendor_source<Reporter: self::Reporter>(
         let found = checked_out.find(&package.name, &package.version)?.ok_or_else(|| {
             miette::miette!(
                 "{repository} at {} holds no crate {} {}",
-                source.commit,
+                options.source.commit,
                 package.name,
                 package.version,
             )
         })?;
-        let cas_paths = import_package(store_dir, &checkout_root, &found, &package_dirs)?;
+        let cas_paths = import_package(options.store_dir, &checkout_root, &found, &package_dirs)?;
         import_indexed_dir::<Reporter>(
-            logged_methods,
-            package_import_method,
+            options.logged_methods,
+            options.package_import_method,
             &slot,
             &cas_paths,
             ImportIndexedDirOpts {

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -424,7 +424,7 @@ impl AddArgs {
     pub(crate) async fn run_selected<Reporter: self::Reporter + 'static>(
         self,
         mut state: State,
-        selection: InstallFamilySelection,
+        mut selection: InstallFamilySelection,
     ) -> miette::Result<()> {
         // Which package manager a project uses is that project's own
         // declaration, so it is recorded where the command runs rather
@@ -458,45 +458,35 @@ impl AddArgs {
             .clone()
             .with_save_peer_setting(state.config.save_peer)
             .save_target();
-        let InstallFamilySelection {
-            workspace_root: _,
-            workspace_cycles: _,
-            mut projects,
-            project_dependencies,
-            ordered_dirs,
-            selected_dirs,
-            install_dirs,
-            active_manifest_is_standin,
-        } = selection;
         let lockfile_path = state.lockfile_path();
-        let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
-            &mut state;
-        let lockfile =
-            lockfile.get().map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
+        let lockfile = state
+            .lockfile
+            .get()
+            .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
 
         Add {
-            tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
-            http_client,
-            http_client_arc: std::sync::Arc::clone(http_client),
-            config,
-            manifest,
+            tarball_mem_cache: std::sync::Arc::clone(&state.tarball_mem_cache),
+            http_client: &state.http_client,
+            http_client_arc: std::sync::Arc::clone(&state.http_client),
+            config: state.config,
+            manifest: &mut state.manifest,
             lockfile,
             lockfile_path: Some(&lockfile_path),
             dependency_groups,
             package_names: &package_names,
             range_spec_style,
             save_catalog_name,
-            resolved_packages,
+            resolved_packages: &state.resolved_packages,
             supported_architectures,
             lockfile_only: self.lockfile_only,
         }
         .run_selected::<Reporter>(pnpm_package_manager::SelectedProjects {
-            projects: &mut projects,
-            project_dependencies: &project_dependencies,
-            ordered_dirs: &ordered_dirs,
-            selected_dirs: selected_dirs.as_ref(),
-            install_dirs: install_dirs.as_ref(),
-            active_manifest_is_standin,
+            projects: &mut selection.projects,
+            project_dependencies: &selection.project_dependencies,
+            ordered_dirs: &selection.ordered_dirs,
+            selected_dirs: selection.selected_dirs.as_ref(),
+            install_dirs: selection.install_dirs.as_ref(),
+            active_manifest_is_standin: selection.active_manifest_is_standin,
         })
         .await
         .wrap_err("adding a new package")

--- a/pnpm/crates/cli/src/cli_args/audit.rs
+++ b/pnpm/crates/cli/src/cli_args/audit.rs
@@ -418,33 +418,7 @@ impl AuditArgs {
         let include = self.dependency_options.include(state.config.optional);
         let lockfile_dir = state.lockfile_dir().to_path_buf();
 
-        let packages = {
-            let lockfile = state
-                .lockfile
-                .get()
-                .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
-            let Some(lockfile) = lockfile else {
-                return Err(AuditError::NoLockfile.into());
-            };
-            let env_lockfile = EnvLockfile::read(&lockfile_dir)
-                .map_err(|err| miette::Report::new(err).wrap_err("load the env lockfile"))?;
-            let audit_request = lockfile_to_audit_request(lockfile, env_lockfile.as_ref(), include);
-            let registries: HashMap<String, String> =
-                state.config.resolved_registries().into_iter().collect();
-            audit_request
-                .request
-                .iter()
-                .flat_map(|(name, versions)| {
-                    let registry = pick_registry_for_package(&registries, name, None);
-                    versions.iter().map(move |version| signatures::SignaturePackage {
-                        name: name.clone(),
-                        registry: registry.clone(),
-                        version: version.clone(),
-                    })
-                })
-                .collect::<Vec<_>>()
-        };
-
+        let packages = signature_packages(&state, include, &lockfile_dir)?;
         if packages.is_empty() {
             return Err(AuditError::NoPackages.into());
         }
@@ -480,6 +454,39 @@ fn audit_outcome(report: &AuditReport, audit_level: ConfigAuditLevel) -> AuditOu
     } else {
         AuditOutcome::Clean
     }
+}
+
+/// Every installed package version the lockfile and env lockfile record,
+/// with the registry that serves it.
+fn signature_packages(
+    state: &State,
+    include: Include,
+    lockfile_dir: &std::path::Path,
+) -> miette::Result<Vec<signatures::SignaturePackage>> {
+    let lockfile = state
+        .lockfile
+        .get()
+        .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
+    let Some(lockfile) = lockfile else {
+        return Err(AuditError::NoLockfile.into());
+    };
+    let env_lockfile = EnvLockfile::read(lockfile_dir)
+        .map_err(|err| miette::Report::new(err).wrap_err("load the env lockfile"))?;
+    let audit_request = lockfile_to_audit_request(lockfile, env_lockfile.as_ref(), include);
+    let registries: HashMap<String, String> =
+        state.config.resolved_registries().into_iter().collect();
+    Ok(audit_request
+        .request
+        .iter()
+        .flat_map(|(name, versions)| {
+            let registry = pick_registry_for_package(&registries, name, None);
+            versions.iter().map(move |version| signatures::SignaturePackage {
+                name: name.clone(),
+                registry: registry.clone(),
+                version: version.clone(),
+            })
+        })
+        .collect())
 }
 
 /// Drop ignored GHSAs that no longer appear in the report, mirroring
@@ -532,51 +539,60 @@ async fn audit(
 ) -> Result<AuditReport, AuditError> {
     let audit_request = lockfile_to_audit_request(lockfile, env_lockfile, include);
     let registry = normalize_registry(&config.registry);
-    let audit_url = format!("{registry}-/npm/v1/security/advisories/bulk");
     let body = serde_json::to_vec(&audit_request.request)
         .expect("audit request is a map of package names to version strings");
     let authorization = config.auth_headers.for_url(&registry);
-    let retry_opts = retry_opts_from_config(config);
-    let request_url = redact_url_userinfo(&audit_url);
-    let display_audit_url = request_url.clone();
-    let (_, response) = send_with_retry(http_client, &display_audit_url, retry_opts, |client| {
-        let mut request =
-            client.post(&request_url).header("content-type", "application/json").body(body.clone());
-        if let Some(value) = &authorization {
-            request = request.header("authorization", value);
-        }
-        request
-    })
-    .await
-    .map_err(|source| AuditError::Network { url: display_audit_url.clone(), source })?;
+    let request_url = redact_url_userinfo(&format!("{registry}-/npm/v1/security/advisories/bulk"));
+    let (_, response) =
+        send_with_retry(http_client, &request_url, retry_opts_from_config(config), |client| {
+            let mut request = client
+                .post(&request_url)
+                .header("content-type", "application/json")
+                .body(body.clone());
+            if let Some(value) = &authorization {
+                request = request.header("authorization", value);
+            }
+            request
+        })
+        .await
+        .map_err(|source| AuditError::Network { url: request_url.clone(), source })?;
 
     let status = response.status().as_u16();
     let raw_body = response
         .text()
         .await
-        .map_err(|source| AuditError::Network { url: display_audit_url.clone(), source })?;
+        .map_err(|source| AuditError::Network { url: request_url.clone(), source })?;
     match status {
-        200 => {
-            let parsed: serde_json::Value =
-                serde_json::from_str(&raw_body).map_err(|source| AuditError::InvalidJson {
-                    url: display_audit_url.clone(),
-                    reason: source.to_string(),
-                    body: sanitize_response_body(&raw_body),
-                })?;
-            let bulk: BTreeMap<String, Vec<RawBulkAdvisory>> =
-                serde_json::from_value(parsed.clone()).map_err(|_| AuditError::UnexpectedBody {
-                    url: display_audit_url.clone(),
-                    body: sanitize_response_body(&parsed.to_string()),
-                })?;
-            Ok(bulk_response_to_audit_report(bulk, &audit_request, lockfile, env_lockfile, include))
-        }
-        404 => Err(AuditError::EndpointNotExists { url: display_audit_url }),
+        200 => Ok(bulk_response_to_audit_report(
+            parse_bulk_advisories(&raw_body, &request_url)?,
+            &audit_request,
+            lockfile,
+            env_lockfile,
+            include,
+        )),
+        404 => Err(AuditError::EndpointNotExists { url: request_url }),
         _ => Err(AuditError::BadStatus {
-            url: display_audit_url,
+            url: request_url,
             status,
             body: sanitize_response_body(&raw_body),
         }),
     }
+}
+
+fn parse_bulk_advisories(
+    raw_body: &str,
+    url: &str,
+) -> Result<BTreeMap<String, Vec<RawBulkAdvisory>>, AuditError> {
+    let parsed: serde_json::Value =
+        serde_json::from_str(raw_body).map_err(|source| AuditError::InvalidJson {
+            url: url.to_string(),
+            reason: source.to_string(),
+            body: sanitize_response_body(raw_body),
+        })?;
+    serde_json::from_value(parsed.clone()).map_err(|_| AuditError::UnexpectedBody {
+        url: url.to_string(),
+        body: sanitize_response_body(&parsed.to_string()),
+    })
 }
 
 /// Write one command result to stdout, appending the newline it lacks. Mirrors

--- a/pnpm/crates/cli/src/cli_args/audit/fix.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/fix.rs
@@ -218,16 +218,20 @@ pub(crate) async fn fetch_publish_times(
     if response.status().as_u16() != 200 {
         return None;
     }
+    fn deprecated_versions(versions: HashMap<String, PackumentVersion>) -> HashSet<Version> {
+        versions
+            .into_iter()
+            .filter(|(_, manifest)| manifest.deprecated.is_some())
+            .filter_map(|(version, _)| version.parse::<Version>().ok())
+            .collect()
+    }
+
     let body = response.json::<PackumentTimes>().await.ok()?;
     let time = body.time?;
-    let deprecated = body
-        .versions
-        .unwrap_or_default()
-        .into_iter()
-        .filter(|(_, manifest)| manifest.deprecated.is_some())
-        .filter_map(|(version, _)| version.parse::<Version>().ok())
-        .collect();
-    Some(PackumentPublishInfo { time, deprecated })
+    Some(PackumentPublishInfo {
+        time,
+        deprecated: deprecated_versions(body.versions.unwrap_or_default()),
+    })
 }
 
 /// Compute the age-gate exclusions for `advisories` using the publish-time
@@ -501,8 +505,7 @@ pub(crate) async fn fix_with_update<Reporter: self::Reporter + 'static>(
     settings_dir: &std::path::Path,
     publish_infos: &HashMap<String, Option<PackumentPublishInfo>>,
 ) -> miette::Result<(Vec<u64>, Vec<u64>, Vec<String>)> {
-    let UpdateClassification { vulnerabilities, unfixable, unparsable } =
-        classify_for_update(advisories);
+    let classification = classify_for_update(advisories);
 
     // When `minimumReleaseAge` is set, the patched versions are likely
     // fresher than the cutoff; record the ones that actually are as
@@ -510,30 +513,19 @@ pub(crate) async fn fix_with_update<Reporter: self::Reporter + 'static>(
     // picker may install them.
     let age_excludes = persist_age_excludes(state, advisories, settings_dir, publish_infos)?;
 
-    let guard_ranges: HashMap<String, Vec<Range>> = vulnerabilities
-        .iter()
-        .map(|(name, entries)| {
-            (name.clone(), entries.iter().map(|(_, range)| range.clone()).collect())
-        })
-        .collect();
-    let observer: Arc<dyn ResolutionObserver> = Arc::new(AuditFixObserver {
-        guard: Arc::new(VulnerabilityGuard { ranges_by_name: guard_ranges }),
-        age_excludes: age_excludes.clone(),
-    });
-
     {
         let lockfile_path = state.lockfile_path();
-        let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
-            state;
-        let lockfile =
-            lockfile.get().map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
+        let lockfile = state
+            .lockfile
+            .get()
+            .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
         Update {
-            tarball_mem_cache: Arc::clone(tarball_mem_cache),
-            resolved_packages,
-            http_client,
-            http_client_arc: Arc::clone(http_client),
-            config,
-            manifest,
+            tarball_mem_cache: Arc::clone(&state.tarball_mem_cache),
+            resolved_packages: &state.resolved_packages,
+            http_client: &state.http_client,
+            http_client_arc: Arc::clone(&state.http_client),
+            config: state.config,
+            manifest: &mut state.manifest,
             lockfile,
             lockfile_path: Some(&lockfile_path),
             packages: &[],
@@ -548,9 +540,12 @@ pub(crate) async fn fix_with_update<Reporter: self::Reporter + 'static>(
             ],
             depth: usize::MAX,
             workspace_packages: None,
-            supported_architectures: config.supported_architectures.clone(),
+            supported_architectures: state.config.supported_architectures.clone(),
             lockfile_only: false,
-            resolution_observer: Some(observer),
+            resolution_observer: Some(fix_observer(
+                &classification.vulnerabilities,
+                age_excludes.clone(),
+            )),
         }
         .run::<Reporter>()
         .await
@@ -568,10 +563,32 @@ pub(crate) async fn fix_with_update<Reporter: self::Reporter + 'static>(
         return Err(AuditError::NoLockfileAfterUpdate.into());
     };
     let installed = installed_packages(&updated);
-    let (fixed, remaining) =
-        report_fixed_remaining(&vulnerabilities, &unfixable, &unparsable, &installed);
+    let (fixed, remaining) = report_fixed_remaining(
+        &classification.vulnerabilities,
+        &classification.unfixable,
+        &classification.unparsable,
+        &installed,
+    );
 
     Ok((fixed, remaining, age_excludes))
+}
+
+/// The resolver-time guard rejecting every vulnerable range, carrying the
+/// age exclusions that let the patched versions through.
+fn fix_observer(
+    vulnerabilities: &HashMap<String, Vec<(u64, Range)>>,
+    age_excludes: Vec<String>,
+) -> Arc<dyn ResolutionObserver> {
+    let guard_ranges: HashMap<String, Vec<Range>> = vulnerabilities
+        .iter()
+        .map(|(name, entries)| {
+            (name.clone(), entries.iter().map(|(_, range)| range.clone()).collect())
+        })
+        .collect();
+    Arc::new(AuditFixObserver {
+        guard: Arc::new(VulnerabilityGuard { ranges_by_name: guard_ranges }),
+        age_excludes,
+    })
 }
 
 /// When `minimumReleaseAge` is set, the patched versions are likely

--- a/pnpm/crates/cli/src/cli_args/audit/signatures.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/signatures.rs
@@ -164,30 +164,9 @@ pub(super) async fn verify_signatures(
     config: &Config,
     http_client: &ThrottledClient,
 ) -> Result<SignatureVerificationResult, SignaturesError> {
-    let registries: BTreeSet<&str> = packages.iter().map(|pkg| pkg.registry.as_str()).collect();
-    let key_fetches = registries.into_iter().map(|registry| async move {
-        fetch_registry_keys(registry, config, http_client)
-            .await
-            .map(|keys| (registry.to_string(), keys))
-    });
-    let keys_by_registry: HashMap<String, Vec<RegistryKey>> =
-        futures_util::future::try_join_all(key_fetches).await?.into_iter().collect();
-
-    // Only fetch packuments for registries that advertise signing keys; a
-    // registry without keys is skipped entirely.
-    let needed: BTreeSet<(&str, &str)> = packages
-        .iter()
-        .filter(|pkg| keys_by_registry.get(&pkg.registry).is_some_and(|keys| !keys.is_empty()))
-        .map(|pkg| (pkg.registry.as_str(), pkg.name.as_str()))
-        .collect();
-    let packument_fetches = needed.into_iter().map(|(registry, name)| async move {
-        let result = fetch_packument(name, registry, config, http_client)
-            .await
-            .map_err(|err| err.to_string());
-        ((registry.to_string(), name.to_string()), result)
-    });
-    let packuments: HashMap<(String, String), Result<Option<Packument>, String>> =
-        futures_util::future::join_all(packument_fetches).await.into_iter().collect();
+    let keys_by_registry = fetch_keys_by_registry(packages, config, http_client).await?;
+    let packuments =
+        fetch_needed_packuments(packages, &keys_by_registry, config, http_client).await;
 
     let mut result = SignatureVerificationResult::default();
     for pkg in packages {
@@ -211,6 +190,42 @@ pub(super) async fn verify_signatures(
     Ok(result)
 }
 
+async fn fetch_keys_by_registry(
+    packages: &[SignaturePackage],
+    config: &Config,
+    http_client: &ThrottledClient,
+) -> Result<HashMap<String, Vec<RegistryKey>>, SignaturesError> {
+    let registries: BTreeSet<&str> = packages.iter().map(|pkg| pkg.registry.as_str()).collect();
+    let key_fetches = registries.into_iter().map(|registry| async move {
+        fetch_registry_keys(registry, config, http_client)
+            .await
+            .map(|keys| (registry.to_string(), keys))
+    });
+    Ok(futures_util::future::try_join_all(key_fetches).await?.into_iter().collect())
+}
+
+/// The packuments of the packages whose registry advertises signing keys;
+/// a registry without keys is skipped entirely.
+async fn fetch_needed_packuments(
+    packages: &[SignaturePackage],
+    keys_by_registry: &HashMap<String, Vec<RegistryKey>>,
+    config: &Config,
+    http_client: &ThrottledClient,
+) -> HashMap<(String, String), Result<Option<Packument>, String>> {
+    let needed: BTreeSet<(&str, &str)> = packages
+        .iter()
+        .filter(|pkg| keys_by_registry.get(&pkg.registry).is_some_and(|keys| !keys.is_empty()))
+        .map(|pkg| (pkg.registry.as_str(), pkg.name.as_str()))
+        .collect();
+    let packument_fetches = needed.into_iter().map(|(registry, name)| async move {
+        let result = fetch_packument(name, registry, config, http_client)
+            .await
+            .map_err(|err| err.to_string());
+        ((registry.to_string(), name.to_string()), result)
+    });
+    futures_util::future::join_all(packument_fetches).await.into_iter().collect()
+}
+
 fn process_version(
     pkg: &SignaturePackage,
     packument: &Packument,
@@ -225,20 +240,10 @@ fn process_version(
     let resolved = dist.and_then(|dist| dist.tarball.clone());
     let raw_signatures = dist.and_then(|dist| dist.signatures.as_ref());
 
-    if raw_signatures.is_some_and(|value| !value.is_array()) {
+    let Some(signatures) = parse_signatures(raw_signatures) else {
         result.invalid.push(issue(pkg, integrity, resolved, Some(malformed_reason(pkg))));
         return;
-    }
-    let mut signatures = Vec::new();
-    if let Some(serde_json::Value::Array(elements)) = raw_signatures {
-        for element in elements {
-            let Ok(signature) = serde_json::from_value::<PackageSignature>(element.clone()) else {
-                result.invalid.push(issue(pkg, integrity, resolved, Some(malformed_reason(pkg))));
-                return;
-            };
-            signatures.push(signature);
-        }
-    }
+    };
 
     if version.is_none() {
         let reason = format!("Missing registry metadata for {}@{}", pkg.name, pkg.version);
@@ -265,6 +270,18 @@ fn process_version(
         Some(invalid) => result.invalid.push(invalid),
         None => result.verified += 1,
     }
+}
+
+/// The `dist.signatures` entries; `None` when the field is present but is
+/// not an array of well-formed signatures.
+fn parse_signatures(raw_signatures: Option<&serde_json::Value>) -> Option<Vec<PackageSignature>> {
+    let Some(value) = raw_signatures else {
+        return Some(Vec::new());
+    };
+    let serde_json::Value::Array(elements) = value else {
+        return None;
+    };
+    elements.iter().map(|element| serde_json::from_value(element.clone()).ok()).collect()
 }
 
 /// Returns `None` as soon as one signature validates against a trusted key.
@@ -430,20 +447,24 @@ async fn fetch_registry_keys(
         });
     }
 
+    parse_registry_keys(&body, &display_url)
+}
+
+/// The registry's signing keys. npm registry signing uses ECDSA P-256
+/// keys; provenance attestations are handled separately and intentionally
+/// ignored here.
+fn parse_registry_keys(body: &str, display_url: &str) -> Result<Vec<RegistryKey>, SignaturesError> {
     let value: serde_json::Value =
-        serde_json::from_str(&body).map_err(|err| SignaturesError::KeysInvalidJson {
-            url: display_url.clone(),
+        serde_json::from_str(body).map_err(|err| SignaturesError::KeysInvalidJson {
+            url: display_url.to_string(),
             reason: err.to_string(),
-            body: sanitize_response_body(&body),
+            body: sanitize_response_body(body),
         })?;
     let parsed: RegistryKeysResponse =
         serde_json::from_value(value.clone()).map_err(|_| SignaturesError::KeysUnexpectedBody {
-            url: display_url,
+            url: display_url.to_string(),
             body: sanitize_response_body(&value.to_string()),
         })?;
-
-    // npm registry signing uses ECDSA P-256 keys; provenance attestations are
-    // handled separately and intentionally ignored here.
     Ok(parsed
         .keys
         .into_iter()
@@ -492,19 +513,20 @@ async fn fetch_packument(
         });
     }
 
+    parse_packument(&body, &display_url).map(Some)
+}
+
+fn parse_packument(body: &str, display_url: &str) -> Result<Packument, SignaturesError> {
     let value: serde_json::Value =
-        serde_json::from_str(&body).map_err(|err| SignaturesError::PackumentInvalidJson {
-            url: display_url.clone(),
+        serde_json::from_str(body).map_err(|err| SignaturesError::PackumentInvalidJson {
+            url: display_url.to_string(),
             reason: err.to_string(),
-            body: sanitize_response_body(&body),
+            body: sanitize_response_body(body),
         })?;
-    let parsed: Packument = serde_json::from_value(value.clone()).map_err(|_| {
-        SignaturesError::PackumentUnexpectedBody {
-            url: display_url,
-            body: sanitize_response_body(&value.to_string()),
-        }
-    })?;
-    Ok(Some(parsed))
+    serde_json::from_value(value.clone()).map_err(|_| SignaturesError::PackumentUnexpectedBody {
+        url: display_url.to_string(),
+        body: sanitize_response_body(&value.to_string()),
+    })
 }
 
 fn with_trailing_slash(registry: &str) -> String {

--- a/pnpm/crates/cli/src/cli_args/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/cache.rs
@@ -170,29 +170,16 @@ impl CacheCommand {
         let mut meta_files_by_path = IndexMap::new();
         for (file_path, full_path) in meta_file_paths {
             let Some(meta_object) = load_meta(&full_path) else { continue };
-            let mtime = fs::metadata(&full_path).and_then(|meta| meta.modified()).ok();
             let (cached_versions, non_cached_versions) =
                 split_cached_versions(&meta_object, store_index.as_deref());
 
-            // The output groups versions per registry. The registry
-            // directory is the top-level component of the cache-relative
-            // path; for scoped packages the file lives one level deeper
-            // (`<registry>/@scope/name.jsonl`), so `parent()` would be
-            // wrong. Mirrors pnpm's cacheView walk to the top-most dir.
-            let registry_name = Path::new(&file_path).components().next().map_or_else(
-                || ".".to_string(),
-                |component| component.as_os_str().to_string_lossy().into_owned(),
-            );
-
+            // The output groups versions per registry.
             meta_files_by_path.insert(
-                decode_registry_name(&registry_name),
+                decode_registry_name(&cache_registry_name(&file_path)),
                 json!({
                     "cachedVersions": cached_versions,
                     "nonCachedVersions": non_cached_versions,
-                    "cachedAt": mtime.map(|time| {
-                        chrono::DateTime::<chrono::Utc>::from(time)
-                            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
-                    }),
+                    "cachedAt": cached_at(&full_path),
                     "distTags": meta_object.dist_tags,
                 }),
             );
@@ -226,6 +213,26 @@ impl CacheCommand {
         }
         Ok(())
     }
+}
+
+/// The registry directory of a cache-relative metadata path: its top-level
+/// component. For scoped packages the file lives one level deeper
+/// (`<registry>/@scope/name.jsonl`), so `parent()` would be wrong. Mirrors
+/// pnpm's cacheView walk to the top-most dir.
+fn cache_registry_name(file_path: &str) -> String {
+    Path::new(file_path).components().next().map_or_else(
+        || ".".to_string(),
+        |component| component.as_os_str().to_string_lossy().into_owned(),
+    )
+}
+
+/// The metadata file's modification time as an RFC 3339 timestamp.
+fn cached_at(full_path: &Path) -> Option<String> {
+    let mtime = fs::metadata(full_path).and_then(|meta| meta.modified()).ok()?;
+    Some(
+        chrono::DateTime::<chrono::Utc>::from(mtime)
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+    )
 }
 
 /// Every cache file matching `pattern`, as `(cache-relative path with

--- a/pnpm/crates/cli/src/cli_args/cat_index.rs
+++ b/pnpm/crates/cli/src/cli_args/cat_index.rs
@@ -60,20 +60,24 @@ impl CatIndexArgs {
             ));
         };
 
-        let mut value = serde_json::to_value(&pkg_files_index)
-            .into_diagnostic()
-            .wrap_err("serialize package index")?;
-        sort_deep_keys(&mut value, 0)?;
-
-        let json = serde_json::to_string_pretty(&value)
-            .into_diagnostic()
-            .wrap_err("render package index JSON")?;
-        let mut stdout = std::io::stdout();
-        let _ = writeln!(stdout, "{json}");
-        let _ = stdout.flush();
-
-        Ok(())
+        print_sorted_index(&pkg_files_index)
     }
+}
+
+fn print_sorted_index(pkg_files_index: &PackageFilesIndex) -> Result<()> {
+    let mut value = serde_json::to_value(pkg_files_index)
+        .into_diagnostic()
+        .wrap_err("serialize package index")?;
+    sort_deep_keys(&mut value, 0)?;
+
+    let json = serde_json::to_string_pretty(&value)
+        .into_diagnostic()
+        .wrap_err("render package index JSON")?;
+    let mut stdout = std::io::stdout();
+    let _ = writeln!(stdout, "{json}");
+    let _ = stdout.flush();
+
+    Ok(())
 }
 
 fn lockfile_dir(config: &Config, dir: &Path) -> PathBuf {

--- a/pnpm/crates/cli/src/cli_args/change.rs
+++ b/pnpm/crates/cli/src/cli_args/change.rs
@@ -89,12 +89,7 @@ impl ChangeArgs {
         if releasable.is_empty() {
             return Err(ChangeError::NoPackages.into());
         }
-        let releasable_dirs: HashSet<&str> =
-            releasable.iter().map(|project| project.dir.as_str()).collect();
-        let refs = index_project_refs(&engine_projects, &workspace_dir);
-        for reference in &self.params {
-            check_reference_is_releasable(&refs, reference, &releasable_dirs)?;
-        }
+        self.check_params_releasable(&releasable, &engine_projects, &workspace_dir)?;
         let bump = self
             .bump
             .as_ref()
@@ -131,6 +126,22 @@ impl ChangeArgs {
         println!("Recorded change intent .changeset/{id}.md");
         Ok(())
     }
+    /// Every reference in `params` must name a releasable project.
+    fn check_params_releasable(
+        &self,
+        releasable: &[ReleasableProject],
+        engine_projects: &[WorkspaceProject],
+        workspace_dir: &Path,
+    ) -> miette::Result<()> {
+        let releasable_dirs: HashSet<&str> =
+            releasable.iter().map(|project| project.dir.as_str()).collect();
+        let refs = index_project_refs(engine_projects, workspace_dir);
+        for reference in &self.params {
+            check_reference_is_releasable(&refs, reference, &releasable_dirs)?;
+        }
+        Ok(())
+    }
+
     /// Handle the `status` and `check` forms, reporting whether one ran.
     /// Only the exact no-option invocations are diagnostic, so a package
     /// that happens to be named "status" or "check" stays recordable.

--- a/pnpm/crates/cli/src/cli_args/dedupe.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     io::Write,
     marker::PhantomData,
     path::{Path, PathBuf},
@@ -116,28 +116,7 @@ impl DedupeArgs {
             &state;
         let lockfile_packages =
             lockfile.get().into_diagnostic()?.and_then(|lockfile| lockfile.packages.as_ref());
-        let modules_manifest =
-            read_modules_manifest::<Host>(&config.modules_dir).into_diagnostic()?;
-        let mut installability_host =
-            InstallabilityHost::detect_with(config.engine_strict, config.node_version.clone());
-        installability_host.supported_architectures = config.supported_architectures.clone();
-        let reusable_skipped_package_ids = modules_manifest
-            .into_iter()
-            .flat_map(|modules| modules.skipped)
-            .filter_map(|package_id| {
-                let package_key = package_id.parse::<PkgNameVerPeer>().ok()?.without_peer();
-                let metadata = lockfile_packages?.get(&package_key)?;
-                Some(reusable_skipped_package_id(
-                    &package_key,
-                    metadata,
-                    &installability_host,
-                    config.ignored_optional_dependencies.as_deref(),
-                ))
-            })
-            .collect::<miette::Result<Vec<_>>>()?
-            .into_iter()
-            .flatten()
-            .collect();
+        let reusable_skipped_package_ids = reusable_skipped_package_ids(config, lockfile_packages)?;
 
         let install = Install {
             tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
@@ -234,6 +213,35 @@ enum DedupeError {
     #[display("Dedupe --check found changes to the lockfile")]
     #[diagnostic(code(ERR_PNPM_DEDUPE_CHECK_ISSUES))]
     CheckIssues,
+}
+
+/// The skipped optional packages `.modules.yaml` records that the lockfile
+/// still holds and this host still cannot install.
+fn reusable_skipped_package_ids(
+    config: &Config,
+    lockfile_packages: Option<&HashMap<pnpm_lockfile::PackageKey, pnpm_lockfile::PackageMetadata>>,
+) -> miette::Result<HashSet<String>> {
+    let modules_manifest = read_modules_manifest::<Host>(&config.modules_dir).into_diagnostic()?;
+    let mut installability_host =
+        InstallabilityHost::detect_with(config.engine_strict, config.node_version.clone());
+    installability_host.supported_architectures.clone_from(&config.supported_architectures);
+    Ok(modules_manifest
+        .into_iter()
+        .flat_map(|modules| modules.skipped)
+        .filter_map(|package_id| {
+            let package_key = package_id.parse::<PkgNameVerPeer>().ok()?.without_peer();
+            let metadata = lockfile_packages?.get(&package_key)?;
+            Some(reusable_skipped_package_id(
+                &package_key,
+                metadata,
+                &installability_host,
+                config.ignored_optional_dependencies.as_deref(),
+            ))
+        })
+        .collect::<miette::Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect())
 }
 
 struct DedupeResolutionReporter<Reporter> {

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -301,41 +301,20 @@ impl DeployArgs {
         frozen_lockfile: bool,
         source_hooks: Option<Arc<dyn pnpm_hooks::PnpmfileHooks>>,
     ) -> miette::Result<()> {
-        let node_linker = self
-            .install_args
-            .node_linker
-            .map_or(base_config.node_linker, NodeLinkerArg::into_config);
-        let mut deploy_config = create_deploy_install_config(base_config, deploy_dir, node_linker);
-        deploy_config.prefer_frozen_lockfile = frozen_lockfile;
-        // pnpm's deploy forwards `--force` into the install, where it
-        // bypasses the installability check so optional dependencies of
-        // every platform are materialized (see `Config::force`).
-        deploy_config.force = self.install_args.force;
-        // `source_hooks` is the whole of the pnpmfile this install runs.
-        // With none to run there is nothing left to discover either: the
-        // install must not fall back to looking next to the deployed
-        // manifest, where `copy_project` may have left the deployed
-        // project's own pnpmfile.
-        deploy_config.ignore_pnpmfile = source_hooks.is_none();
         let legacy = matches!(&mode, DeployInstallMode::Legacy);
-        apply_shared_deploy_config(&mut deploy_config, deploy_dir, mode);
-        // The lockfile a shared deploy generates records no
-        // `pnpmfileChecksum`, so the pnpmfile behind these hooks must not
-        // claim one either. The legacy path resolves the deployed project
-        // from scratch and writes its own lockfile, which records the
-        // checksum as any other install does.
-        let pnpmfile_hook = source_hooks.map(|hooks| -> Arc<dyn pnpm_hooks::PnpmfileHooks> {
-            if legacy { hooks } else { Arc::new(pnpm_hooks::ChecksumFreeHooks::from(hooks)) }
-        });
-        let deploy_config = Config::leak(deploy_config);
-        let mut state =
-            State::init(deploy_dir.join("package.json"), deploy_config, frozen_lockfile)
-                .wrap_err("initialize the deploy install state")?;
+        let config = self.deploy_install_config(
+            base_config,
+            deploy_dir,
+            mode,
+            frozen_lockfile,
+            source_hooks.is_none(),
+        );
+        let pnpmfile_hook = deploy_pnpmfile_hooks(source_hooks, legacy);
+        let mut state = State::init(deploy_dir.join("package.json"), config, frozen_lockfile)
+            .wrap_err("initialize the deploy install state")?;
         if legacy {
             state.lockfile = deployed_lockfile(&state, deploy_dir, frozen_lockfile);
         }
-        let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
-            &state;
         // Deploying the workspace root copies `pnpm-workspace.yaml` and
         // the projects it globs, none of which the generated frozen
         // lockfile describes. pnpm installs the deploy directory with no
@@ -344,7 +323,7 @@ impl DeployArgs {
         let workspace_projects_override = (!legacy).then(|| {
             vec![Project {
                 root_dir: deploy_dir.to_path_buf(),
-                manifest: manifest.clone(),
+                manifest: state.manifest.clone(),
                 dependency_manifest: None,
             }]
         });
@@ -368,13 +347,13 @@ impl DeployArgs {
             .collect::<Vec<_>>();
 
         let install = Install {
-            tarball_mem_cache: Arc::clone(tarball_mem_cache),
-            http_client,
-            http_client_arc: Arc::clone(http_client),
+            tarball_mem_cache: Arc::clone(&state.tarball_mem_cache),
+            http_client: &state.http_client,
+            http_client_arc: Arc::clone(&state.http_client),
             config,
-            manifest,
+            manifest: &state.manifest,
             emit_initial_manifest: true,
-            lockfile: MaybeLazyLockfile::Lazy(lockfile),
+            lockfile: MaybeLazyLockfile::Lazy(&state.lockfile),
             lockfile_path: lockfile_path.as_deref(),
             dependency_groups,
             frozen_lockfile,
@@ -385,9 +364,9 @@ impl DeployArgs {
             update_checksums: false,
             mutation: ProjectMutation::InstallWorkspace,
             installs_only: true,
-            resolved_packages,
+            resolved_packages: &state.resolved_packages,
             supported_architectures,
-            node_linker,
+            node_linker: config.node_linker,
             lockfile_only: false,
             dry_run: false,
             persist_policy_excludes: false,
@@ -409,6 +388,50 @@ impl DeployArgs {
         }
         .wrap_err("installing deployed dependencies")
     }
+
+    /// The deploy directory's own install config, with the install flags
+    /// the deploy forwards.
+    fn deploy_install_config(
+        &self,
+        base_config: &Config,
+        deploy_dir: &Path,
+        mode: DeployInstallMode,
+        frozen_lockfile: bool,
+        ignore_pnpmfile: bool,
+    ) -> &'static Config {
+        let node_linker = self
+            .install_args
+            .node_linker
+            .map_or(base_config.node_linker, NodeLinkerArg::into_config);
+        let mut deploy_config = create_deploy_install_config(base_config, deploy_dir, node_linker);
+        deploy_config.prefer_frozen_lockfile = frozen_lockfile;
+        // pnpm's deploy forwards `--force` into the install, where it
+        // bypasses the installability check so optional dependencies of
+        // every platform are materialized (see `Config::force`).
+        deploy_config.force = self.install_args.force;
+        // `source_hooks` is the whole of the pnpmfile this install runs.
+        // With none to run there is nothing left to discover either: the
+        // install must not fall back to looking next to the deployed
+        // manifest, where `copy_project` may have left the deployed
+        // project's own pnpmfile.
+        deploy_config.ignore_pnpmfile = ignore_pnpmfile;
+        apply_shared_deploy_config(&mut deploy_config, deploy_dir, mode);
+        Config::leak(deploy_config)
+    }
+}
+
+/// The lockfile a shared deploy generates records no
+/// `pnpmfileChecksum`, so the pnpmfile behind these hooks must not
+/// claim one either. The legacy path resolves the deployed project
+/// from scratch and writes its own lockfile, which records the
+/// checksum as any other install does.
+fn deploy_pnpmfile_hooks(
+    source_hooks: Option<Arc<dyn pnpm_hooks::PnpmfileHooks>>,
+    legacy: bool,
+) -> Option<Arc<dyn pnpm_hooks::PnpmfileHooks>> {
+    source_hooks.map(|hooks| -> Arc<dyn pnpm_hooks::PnpmfileHooks> {
+        if legacy { hooks } else { Arc::new(pnpm_hooks::ChecksumFreeHooks::from(hooks)) }
+    })
 }
 
 /// A shared deploy installs the deployed project as a workspace of its
@@ -831,82 +854,29 @@ fn create_deploy_files(
     target_snapshot.dependencies = Some(HashMap::new());
     target_snapshot.dev_dependencies = Some(HashMap::new());
     target_snapshot.optional_dependencies = Some(HashMap::new());
-    let declared_dependencies = selected
-        .project
-        .manifest
-        .available_dependency_names(None)
-        .into_iter()
-        .collect::<HashSet<_>>();
-    let peer_only_dependencies = selected
-        .project
-        .manifest
-        .dependencies([DependencyGroup::Peer])
-        .map(|(name, _)| name.to_string())
-        .filter(|name| !declared_dependencies.contains(name))
-        .collect::<HashSet<_>>();
-
-    let selected_root = lexical_normalize(&selected.project.root_dir);
-    let selected_bases = ResolveBases { file_base: lockfile_dir, link_base: &selected_root };
-    // An excluded group's direct dependencies are left out of both the
-    // deployed manifest and the deployed importer, because the graph prune
-    // below drops the packages they would point at.
-    let include_prod = dependency_groups.contains(&DependencyGroup::Prod);
-    fill_target_dependency_map(
-        &mut target_snapshot.dependencies,
-        input_snapshot
-            .dependencies
-            .iter()
-            .flatten()
-            .filter(|(name, _)| include_prod || peer_only_dependencies.contains(&name.to_string())),
-        &ctx,
-        &selected_bases,
+    let (declared_dependencies, peer_only_dependencies) =
+        dependency_name_sets(&selected.project.manifest);
+    fill_target_dependencies(
+        &mut target_snapshot,
+        &DeployedDependencies {
+            input_snapshot,
+            dependency_groups,
+            peer_only_dependencies: &peer_only_dependencies,
+            selected,
+            ctx: &ctx,
+        },
     )?;
-    let include_dev = dependency_groups.contains(&DependencyGroup::Dev);
-    fill_target_dependency_map(
-        &mut target_snapshot.dev_dependencies,
-        input_snapshot
-            .dev_dependencies
-            .iter()
-            .flatten()
-            .filter(|(name, _)| include_dev || peer_only_dependencies.contains(&name.to_string())),
-        &ctx,
-        &selected_bases,
-    )?;
-    let include_optional = dependency_groups.contains(&DependencyGroup::Optional);
-    fill_target_dependency_map(
-        &mut target_snapshot.optional_dependencies,
-        input_snapshot.optional_dependencies.iter().flatten().filter(|(name, _)| {
-            include_optional || peer_only_dependencies.contains(&name.to_string())
-        }),
-        &ctx,
-        &selected_bases,
-    )?;
-    drop_empty_dependency_map(&mut target_snapshot.dependencies);
-    drop_empty_dependency_map(&mut target_snapshot.dev_dependencies);
-    drop_empty_dependency_map(&mut target_snapshot.optional_dependencies);
 
     let packages =
         convert_deploy_packages(lockfile, project_id, lockfile_dir, deploy_dir, selected, &ctx)?;
-    let DeploySnapshots { snapshots, linked_workspace_projects } =
-        convert_deploy_snapshots(lockfile, project_id, lockfile_dir, selected, &ctx)?;
-
-    let mut deploy_lockfile = lockfile.clone();
-    // The deployed manifest contains concrete dependency versions, so catalog
-    // snapshots would refer to configuration that is not copied to the target.
-    deploy_lockfile.catalogs = None;
-    deploy_lockfile.patched_dependencies = None;
-    deploy_lockfile.overrides = None;
-    deploy_lockfile.package_extensions_checksum = None;
-    deploy_lockfile.pnpmfile_checksum = None;
-    if let Some(settings) = deploy_lockfile.settings.as_mut() {
-        settings.inject_workspace_packages = false;
-    }
-    deploy_lockfile.importers =
-        HashMap::from([(Lockfile::ROOT_IMPORTER_KEY.to_string(), target_snapshot.clone())]);
-    deploy_lockfile.packages = (!packages.is_empty()).then_some(packages);
-    deploy_lockfile.snapshots = (!snapshots.is_empty()).then_some(snapshots);
-    prune_deploy_lockfile_graph(&mut deploy_lockfile, dependency_groups);
-    bind_singleton_peers(&mut deploy_lockfile, &linked_workspace_projects)?;
+    let converted = convert_deploy_snapshots(lockfile, project_id, lockfile_dir, selected, &ctx)?;
+    let mut deploy_lockfile = converted_deploy_lockfile(
+        lockfile,
+        &target_snapshot,
+        packages,
+        converted,
+        dependency_groups,
+    )?;
 
     let mut manifest = selected.project.manifest.value().clone();
     set_manifest_dependencies(&mut manifest, "dependencies", target_snapshot.dependencies.as_ref());
@@ -937,6 +907,108 @@ fn create_deploy_files(
             .then_some(Value::Object(workspace_manifest)),
         workspace_config,
     })
+}
+
+/// The names the project declares as dependencies, and the peers it does
+/// not also depend on itself.
+fn dependency_name_sets(manifest: &PackageManifest) -> (HashSet<String>, HashSet<String>) {
+    let declared_dependencies =
+        manifest.available_dependency_names(None).into_iter().collect::<HashSet<_>>();
+    let peer_only_dependencies = manifest
+        .dependencies([DependencyGroup::Peer])
+        .map(|(name, _)| name.to_string())
+        .filter(|name| !declared_dependencies.contains(name))
+        .collect::<HashSet<_>>();
+    (declared_dependencies, peer_only_dependencies)
+}
+
+struct DeployedDependencies<'a> {
+    input_snapshot: &'a ProjectSnapshot,
+    dependency_groups: &'a [DependencyGroup],
+    peer_only_dependencies: &'a HashSet<String>,
+    selected: &'a SelectedProject,
+    ctx: &'a ConvertCtx<'a>,
+}
+
+/// Fill the deployed importer's dependency maps. An excluded group's direct
+/// dependencies are left out of both the deployed manifest and the deployed
+/// importer, because the graph prune drops the packages they would point at;
+/// a peer the project only declares stays in whichever group carries it.
+fn fill_target_dependencies(
+    target_snapshot: &mut ProjectSnapshot,
+    deployed: &DeployedDependencies<'_>,
+) -> miette::Result<()> {
+    let selected_root = lexical_normalize(&deployed.selected.project.root_dir);
+    let selected_bases =
+        ResolveBases { file_base: deployed.ctx.lockfile_dir, link_base: &selected_root };
+    let peer_only_dependencies = deployed.peer_only_dependencies;
+    let include_prod = deployed.dependency_groups.contains(&DependencyGroup::Prod);
+    fill_target_dependency_map(
+        &mut target_snapshot.dependencies,
+        deployed
+            .input_snapshot
+            .dependencies
+            .iter()
+            .flatten()
+            .filter(|(name, _)| include_prod || peer_only_dependencies.contains(&name.to_string())),
+        deployed.ctx,
+        &selected_bases,
+    )?;
+    let include_dev = deployed.dependency_groups.contains(&DependencyGroup::Dev);
+    fill_target_dependency_map(
+        &mut target_snapshot.dev_dependencies,
+        deployed
+            .input_snapshot
+            .dev_dependencies
+            .iter()
+            .flatten()
+            .filter(|(name, _)| include_dev || peer_only_dependencies.contains(&name.to_string())),
+        deployed.ctx,
+        &selected_bases,
+    )?;
+    let include_optional = deployed.dependency_groups.contains(&DependencyGroup::Optional);
+    fill_target_dependency_map(
+        &mut target_snapshot.optional_dependencies,
+        deployed.input_snapshot.optional_dependencies.iter().flatten().filter(|(name, _)| {
+            include_optional || peer_only_dependencies.contains(&name.to_string())
+        }),
+        deployed.ctx,
+        &selected_bases,
+    )?;
+    drop_empty_dependency_map(&mut target_snapshot.dependencies);
+    drop_empty_dependency_map(&mut target_snapshot.dev_dependencies);
+    drop_empty_dependency_map(&mut target_snapshot.optional_dependencies);
+    Ok(())
+}
+
+/// The deployed lockfile: the source lockfile with the deployed project as
+/// its only importer and the converted graph, without the workspace-level
+/// configuration the target does not carry. The deployed manifest holds
+/// concrete dependency versions, so catalog snapshots would refer to
+/// configuration that is not copied to the target.
+fn converted_deploy_lockfile(
+    lockfile: &Lockfile,
+    target_snapshot: &ProjectSnapshot,
+    packages: HashMap<PackageKey, PackageMetadata>,
+    converted: DeploySnapshots,
+    dependency_groups: &[DependencyGroup],
+) -> miette::Result<Lockfile> {
+    let mut deploy_lockfile = lockfile.clone();
+    deploy_lockfile.catalogs = None;
+    deploy_lockfile.patched_dependencies = None;
+    deploy_lockfile.overrides = None;
+    deploy_lockfile.package_extensions_checksum = None;
+    deploy_lockfile.pnpmfile_checksum = None;
+    if let Some(settings) = deploy_lockfile.settings.as_mut() {
+        settings.inject_workspace_packages = false;
+    }
+    deploy_lockfile.importers =
+        HashMap::from([(Lockfile::ROOT_IMPORTER_KEY.to_string(), target_snapshot.clone())]);
+    deploy_lockfile.packages = (!packages.is_empty()).then_some(packages);
+    deploy_lockfile.snapshots = (!converted.snapshots.is_empty()).then_some(converted.snapshots);
+    prune_deploy_lockfile_graph(&mut deploy_lockfile, dependency_groups);
+    bind_singleton_peers(&mut deploy_lockfile, &converted.linked_workspace_projects)?;
+    Ok(deploy_lockfile)
 }
 
 /// The deployed lockfile's `packages` map: every source package with its

--- a/pnpm/crates/cli/src/cli_args/deps_tree_finders.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree_finders.rs
@@ -179,25 +179,35 @@ pub(crate) async fn evaluate_finders(
             "version": source.version,
             "manifest": manifest,
         });
-        let mut messages: Vec<String> = Vec::new();
-        let mut found = false;
-        for finder in finders {
-            let verdict = finder
-                .hooks
-                .run_finder(&finder.name, ctx.clone())
-                .await
-                .map_err(|err| miette::miette!("running finder {}: {err}", finder.name))?;
-            if let serde_json::Value::String(message) = verdict {
-                found = true;
-                messages.push(message);
-            } else if truthy(&verdict) {
-                found = true;
-            }
-        }
+        let (messages, found) = finder_verdicts(finders, &ctx).await?;
         let Some(verdict) = search_verdict(&messages, found) else { continue };
         results.insert((alias, node_id), verdict);
     }
     Ok(results)
+}
+
+/// Run every finder over one candidate: the messages the finders returned,
+/// and whether any of them matched.
+async fn finder_verdicts(
+    finders: &[FinderHandle],
+    ctx: &serde_json::Value,
+) -> miette::Result<(Vec<String>, bool)> {
+    let mut messages: Vec<String> = Vec::new();
+    let mut found = false;
+    for finder in finders {
+        let verdict = finder
+            .hooks
+            .run_finder(&finder.name, ctx.clone())
+            .await
+            .map_err(|err| miette::miette!("running finder {}: {err}", finder.name))?;
+        if let serde_json::Value::String(message) = verdict {
+            found = true;
+            messages.push(message);
+        } else if truthy(&verdict) {
+            found = true;
+        }
+    }
+    Ok((messages, found))
 }
 
 /// What the finders collectively decided about one candidate. `None`

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -17,10 +17,14 @@ use crate::{
 };
 use miette::{Context, IntoDiagnostic};
 use pnpm_config::{ColorMode, Config, Host, default_pnpm_home_dir};
-use pnpm_default_reporter::DefaultReporter;
+use pnpm_default_reporter::{DefaultReporter, SummaryScope};
 use pnpm_network_web_auth::OtpNonInteractiveError;
 use pnpm_reporter::{ExecutionTimeLog, LogEvent, LogLevel, NdjsonReporter, SilentReporter};
-use std::{future::Future, path::Path, pin::Pin};
+use std::{
+    future::Future,
+    path::{Path, PathBuf},
+    pin::Pin,
+};
 
 pub(crate) type CommandFuture<'a, Output = ()> =
     Pin<Box<dyn Future<Output = miette::Result<Output>> + Send + 'a>>;
@@ -199,220 +203,101 @@ impl CliArgs {
         }
         self.configure_reporter();
 
-        let reporter = self.effective_reporter();
-        // `version` short-circuits in `main`, never reaching dispatch.
-        let CliArgs {
-            command,
-            dir,
-            dir_from_command_line,
-            store_dir,
-            state_dir,
-            npmrc_auth_file,
-            registry,
-            https_proxy,
-            http_proxy,
-            no_proxy,
-            recursive,
-            reporter: _,
-            loglevel: _,
-            filter,
-            filter_prod,
-            workspace_root,
-            fail_if_no_match,
+        let anchors = RunAnchors::resolve(&self)?;
+        let setup = RunSetup::of(&self);
 
-            include_workspace_root,
-            no_include_workspace_root,
-            test_pattern,
-            changed_files_ignore_pattern,
-            version: _,
-            color,
-            no_color,
-            yes: _,
-            sort,
-            no_sort,
-            reverse,
-            no_reverse,
-            workspace_concurrency,
-            parallel,
-            resume_from,
-            report_summary,
-            no_bail,
-            bail,
-            if_present,
-            stream,
-            aggregate_output,
-            use_stderr,
-            reporter_hide_prefix,
-            no_reporter_hide_prefix,
-            ignore_workspace,
-            workspace_packages,
-        } = self;
-
-        // Canonicalize `--dir` so the bunyan-envelope `prefix` emitted by
-        // the reporter is the same absolute, symlink-resolved path that
-        // `@pnpm/cli.default-reporter` derives via `process.cwd()`. Without
-        // this, a default `--dir=.` leaves `prefix` as `"."`, the reporter
-        // never matches it against its `cwd`, and every progress / stats
-        // line gets a redundant `.` path prefix prepended. The resolved
-        // path becomes `config.dir` (used as the install `lockfileDir`,
-        // threaded into every event's `prefix`).
-        let dir = dunce::canonicalize(&dir)
-            .into_diagnostic()
-            .wrap_err_with(|| format!("canonicalizing the `--dir` argument: {}", dir.display()))?;
-        let cli_dir = if dir_from_command_line {
-            dir.clone()
-        } else {
-            std::env::current_dir().and_then(dunce::canonicalize).unwrap_or_else(|_| dir.clone())
-        };
-        let started_at = now_millis();
-        let is_install_family = matches!(
-            &command,
-            CliCommand::Add(_)
-                | CliCommand::Update(_)
-                | CliCommand::Remove(_)
-                | CliCommand::Install(_)
-                | CliCommand::InstallTest(_)
-                | CliCommand::Ci(_)
-                | CliCommand::Dlx(_)
-                | CliCommand::Link(_)
-                | CliCommand::Import(_)
-                | CliCommand::Dedupe(_)
-                | CliCommand::Deploy(_)
-                | CliCommand::Prune(_)
-                | CliCommand::Fetch(_)
-                | CliCommand::Unlink(_)
-                | CliCommand::Create(_)
-                | CliCommand::Runtime(_)
-                // `rebuild` drives the frozen-install pipeline and emits
-                // the same progress events, so it shares the `Done in ...`
-                // footer.
-                | CliCommand::Rebuild(_)
-                | CliCommand::PatchCommit(_)
-                | CliCommand::PatchRemove(_),
-        );
-        let print_json_errors = prints_json_errors(&command);
-        let recursive_by_default_command = command.recursive_by_default();
-        let command_summary_scope = command.default_reporter_summary_scope();
-        let command_reports_scope = command.reports_scope(recursive);
-        let command_uses_stderr_reporter = command.uses_stderr_reporter();
-        let manifest_path = dir.join("package.json");
-        // Load config anchored at `anchor`, reading `.npmrc` /
-        // `pnpm-workspace.yaml` from there.
-        //
-        // Seed `npmrc_auth_file` from the CLI flag before `current()` reads
-        // `.npmrc`, so the override redirects the user-level read. Mirrors
-        // pnpm's `--npmrc-auth-file`. Production callers turbofish `Host`
-        // explicitly so the dependency-injection plumbing is visible at the
-        // call site. See
-        // [pnpm/pacquet#339](https://github.com/pnpm/pacquet/issues/339).
         // CLI flags are applied on top of whatever `Config::current*` loaded —
         // they are trusted input and finalize every config variant below,
         // including `self-update`'s.
         let finalize_config =
             |mut cfg: Config, anchor: &Path| -> miette::Result<&'static mut Config> {
                 config_overrides.apply(&mut cfg, anchor);
-                apply_color_override(&mut cfg, color, no_color);
+                apply_color_override(&mut cfg, self.color, self.no_color);
                 if cfg.ci {
                     pnpm_default_reporter::force_append_only();
                 }
                 cfg.apply_proxy_cli_overrides(
-                    https_proxy.as_deref(),
-                    http_proxy.as_deref(),
-                    no_proxy.as_deref(),
+                    self.https_proxy.as_deref(),
+                    self.http_proxy.as_deref(),
+                    self.no_proxy.as_deref(),
                 );
                 apply_location_overrides(
                     &mut cfg,
                     anchor,
-                    registry.as_deref(),
-                    store_dir.as_deref(),
-                    state_dir.as_deref(),
+                    self.registry.as_deref(),
+                    self.store_dir.as_deref(),
+                    self.state_dir.as_deref(),
                 )?;
                 apply_project_selectors(
                     &mut cfg,
                     &ProjectSelectors {
-                        recursive,
-                        recursive_by_default_command,
-                        filter: &filter,
-                        filter_prod: &filter_prod,
-                        workspace_root,
-                        fail_if_no_match,
+                        recursive: self.recursive,
+                        recursive_by_default_command: setup.recursive_by_default,
+                        filter: &self.filter,
+                        filter_prod: &self.filter_prod,
+                        workspace_root: self.workspace_root,
+                        fail_if_no_match: self.fail_if_no_match,
                     },
                 );
-                cfg.bail = resolve_bool_override(bail, no_bail, cfg.bail);
-                cfg.stream |= stream;
-                cfg.aggregate_output |= aggregate_output;
-                cfg.use_stderr |= use_stderr;
-                cfg.sort = resolve_bool_override(sort, no_sort, cfg.sort);
-                cfg.reverse = resolve_bool_override(reverse, no_reverse, cfg.reverse);
+                cfg.bail = resolve_bool_override(self.bail, self.no_bail, cfg.bail);
+                cfg.stream |= self.stream;
+                cfg.aggregate_output |= self.aggregate_output;
+                cfg.use_stderr |= self.use_stderr;
+                cfg.sort = resolve_bool_override(self.sort, self.no_sort, cfg.sort);
+                cfg.reverse = resolve_bool_override(self.reverse, self.no_reverse, cfg.reverse);
                 cfg.include_workspace_root = resolve_bool_override(
-                    include_workspace_root,
-                    no_include_workspace_root,
+                    self.include_workspace_root,
+                    self.no_include_workspace_root,
                     cfg.include_workspace_root,
                 );
                 apply_output_overrides(
                     &mut cfg,
                     &OutputOverrides {
-                        reporter_hide_prefix,
-                        no_reporter_hide_prefix,
-                        workspace_packages: &workspace_packages,
-                        test_pattern: &test_pattern,
-                        changed_files_ignore_pattern: &changed_files_ignore_pattern,
-                        workspace_concurrency,
+                        reporter_hide_prefix: self.reporter_hide_prefix,
+                        no_reporter_hide_prefix: self.no_reporter_hide_prefix,
+                        workspace_packages: &self.workspace_packages,
+                        test_pattern: &self.test_pattern,
+                        changed_files_ignore_pattern: &self.changed_files_ignore_pattern,
+                        workspace_concurrency: self.workspace_concurrency,
                     },
                 );
                 // The command line already seeded the reporter; a value
                 // that came from the configuration instead still has to
                 // reach it, and the setters ignore a repeat.
                 configure_default_reporter(&DefaultReporterSetup {
-                    reporter,
-                    dir: &dir,
-                    summary_scope: command_summary_scope,
-                    reports_scope: command_reports_scope,
+                    reporter: setup.reporter,
+                    dir: &anchors.dir,
+                    summary_scope: setup.summary_scope,
+                    reports_scope: setup.reports_scope,
                     hide_added_pkgs_progress: false,
-                    is_recursive: recursive,
-                    use_stderr: cfg.use_stderr || command_uses_stderr_reporter,
+                    is_recursive: self.recursive,
+                    use_stderr: cfg.use_stderr || setup.uses_stderr_reporter,
                     stream_lifecycle_output: cfg.stream,
                     aggregate_output: cfg.aggregate_output,
                     hide_lifecycle_prefix: cfg.reporter_hide_prefix.unwrap_or(false),
                 });
                 Ok(Config::leak(cfg))
             };
+        // Load config anchored at `anchor`, reading `.npmrc` /
+        // `pnpm-workspace.yaml` from there.
         let load_config = |anchor: &Path| -> miette::Result<&'static mut Config> {
-            Config {
-                npmrc_auth_file: npmrc_auth_file.clone(),
-                ignore_workspace,
-                ..Config::default()
-            }
-            .current::<Host>(anchor)
-            .map_err(miette::Report::new)
-            .wrap_err("load configuration")
-            .and_then(|cfg| finalize_config(cfg, anchor))
+            seed_config(self.npmrc_auth_file.as_deref(), self.ignore_workspace)
+                .current::<Host>(anchor)
+                .map_err(miette::Report::new)
+                .wrap_err("load configuration")
+                .and_then(|cfg| finalize_config(cfg, anchor))
         };
         // Resolve `.npmrc` / `pnpm-workspace.yaml` from the canonicalized
         // `--dir` rather than the process cwd, matching pnpm 11 (which
         // builds its `localPrefix` from `cliOptions.dir`, not `cwd`).
-        let config = || load_config(&dir);
-        // A `-g` install is isolated from the caller's project: pnpm runs it
-        // with `cwd` = the pnpm home dir, so a project `.npmrc` cannot
-        // influence the network / TLS / registry decisions of a *global*
-        // install. Mirror that by anchoring the global-install config at the
-        // pnpm home (resolved from `PNPM_HOME` / platform defaults, never the
-        // project). Falls back to the `--dir` anchor when the home can't be
-        // determined — the global command then fails at the missing-global-
-        // bin-dir check regardless.
-        let pnpm_home_dir = default_pnpm_home_dir::<Host>();
-        let global_config_anchor = pnpm_home_dir.as_deref().unwrap_or(&dir);
-        let global_config = || load_config(global_config_anchor);
+        let config = || load_config(&anchors.dir);
+        let global_config = || load_config(&anchors.global_config);
         let config_self_update = || -> miette::Result<&'static mut Config> {
-            Config {
-                npmrc_auth_file: npmrc_auth_file.clone(),
-                ignore_workspace,
-                ..Config::default()
-            }
-            .current_for_self_update::<Host>(&dir)
-            .map_err(miette::Report::new)
-            .wrap_err("load configuration")
-            .and_then(|cfg| finalize_config(cfg, &dir))
+            seed_config(self.npmrc_auth_file.as_deref(), self.ignore_workspace)
+                .current_for_self_update::<Host>(&anchors.dir)
+                .map_err(miette::Report::new)
+                .wrap_err("load configuration")
+                .and_then(|cfg| finalize_config(cfg, &anchors.dir))
         };
         // `require_lockfile` is the "this subcommand cannot run without a
         // lockfile loaded" signal, used by `State::init` to override
@@ -422,49 +307,161 @@ impl CliArgs {
         // must not be silently dropped because `lockfile=false` was set
         // (or defaulted) in config.
         let state = |require_lockfile: bool| -> miette::Result<State> {
-            State::init(manifest_path.clone(), config()?, require_lockfile)
+            State::init(anchors.manifest_path.clone(), config()?, require_lockfile)
                 .wrap_err("initialize the state")
         };
 
         let ctx = RunCtx {
-            dir: &dir,
-            cli_dir: &cli_dir,
-            manifest_path: &manifest_path,
-            reporter,
-            recursive,
-            recursive_resume_from: resume_from.as_deref(),
-            recursive_report_summary: report_summary,
-            recursive_parallel: parallel,
-            if_present,
+            dir: &anchors.dir,
+            cli_dir: &anchors.cli_dir,
+            manifest_path: &anchors.manifest_path,
+            reporter: setup.reporter,
+            recursive: self.recursive,
+            recursive_resume_from: self.resume_from.as_deref(),
+            recursive_report_summary: self.report_summary,
+            recursive_parallel: self.parallel,
+            if_present: self.if_present,
             builtin_command_forced,
             config: &config,
             global_config: &global_config,
             config_self_update: &config_self_update,
             state: &state,
         };
-        if let Err(error) = run_routed_command(command, &ctx).await {
-            // A JSON-mode command reports its own failure on stdout and
-            // exits, so the human-readable miette report never renders.
-            if print_json_errors {
-                print_json_error(&error);
-                std::process::exit(1);
-            }
-            return Err(error);
-        }
+        exit_on_json_error(run_routed_command(self.command, &ctx).await, setup.print_json_errors)?;
 
         // The `Done in ...` footer covers the whole command, mirroring pnpm's
         // `pnpm:execution-time` emit in `main.ts`. Only the install-family
         // commands drive the visual reporter, so the rest stay silent.
-        if is_install_family {
-            reporter_emit(reporter)(&LogEvent::ExecutionTime(ExecutionTimeLog {
+        if setup.is_install_family {
+            reporter_emit(setup.reporter)(&LogEvent::ExecutionTime(ExecutionTimeLog {
                 level: LogLevel::Debug,
-                started_at,
+                started_at: setup.started_at,
                 ended_at: now_millis(),
             }));
         }
 
         Ok(())
     }
+}
+
+/// The directories a run is anchored at.
+struct RunAnchors {
+    /// The canonicalized `--dir`.
+    dir: PathBuf,
+    cli_dir: PathBuf,
+    manifest_path: PathBuf,
+    /// Where a `-g` install loads its config from. A `-g` install is
+    /// isolated from the caller's project: pnpm runs it with `cwd` = the
+    /// pnpm home dir, so a project `.npmrc` cannot influence the network /
+    /// TLS / registry decisions of a *global* install. Mirror that by
+    /// anchoring the global-install config at the pnpm home (resolved from
+    /// `PNPM_HOME` / platform defaults, never the project). Falls back to
+    /// the `--dir` anchor when the home can't be determined — the global
+    /// command then fails at the missing-global-bin-dir check regardless.
+    global_config: PathBuf,
+}
+
+impl RunAnchors {
+    /// Canonicalize `--dir` so the bunyan-envelope `prefix` emitted by the
+    /// reporter is the same absolute, symlink-resolved path that
+    /// `@pnpm/cli.default-reporter` derives via `process.cwd()`. Without
+    /// this, a default `--dir=.` leaves `prefix` as `"."`, the reporter
+    /// never matches it against its `cwd`, and every progress / stats line
+    /// gets a redundant `.` path prefix prepended. The resolved path
+    /// becomes `config.dir` (used as the install `lockfileDir`, threaded
+    /// into every event's `prefix`).
+    fn resolve(args: &CliArgs) -> miette::Result<Self> {
+        let dir = dunce::canonicalize(&args.dir).into_diagnostic().wrap_err_with(|| {
+            format!("canonicalizing the `--dir` argument: {}", args.dir.display())
+        })?;
+        let cli_dir = if args.dir_from_command_line {
+            dir.clone()
+        } else {
+            std::env::current_dir().and_then(dunce::canonicalize).unwrap_or_else(|_| dir.clone())
+        };
+        let manifest_path = dir.join("package.json");
+        let global_config = default_pnpm_home_dir::<Host>().unwrap_or_else(|| dir.clone());
+        Ok(RunAnchors { dir, cli_dir, manifest_path, global_config })
+    }
+}
+
+/// What the command line settles before any config is loaded, and when
+/// the run began.
+struct RunSetup {
+    started_at: u128,
+    reporter: ReporterType,
+    is_install_family: bool,
+    print_json_errors: bool,
+    recursive_by_default: bool,
+    summary_scope: SummaryScope,
+    reports_scope: bool,
+    uses_stderr_reporter: bool,
+}
+
+impl RunSetup {
+    fn of(args: &CliArgs) -> Self {
+        RunSetup {
+            started_at: now_millis(),
+            reporter: args.effective_reporter(),
+            is_install_family: matches!(
+                &args.command,
+                CliCommand::Add(_)
+                    | CliCommand::Update(_)
+                    | CliCommand::Remove(_)
+                    | CliCommand::Install(_)
+                    | CliCommand::InstallTest(_)
+                    | CliCommand::Ci(_)
+                    | CliCommand::Dlx(_)
+                    | CliCommand::Link(_)
+                    | CliCommand::Import(_)
+                    | CliCommand::Dedupe(_)
+                    | CliCommand::Deploy(_)
+                    | CliCommand::Prune(_)
+                    | CliCommand::Fetch(_)
+                    | CliCommand::Unlink(_)
+                    | CliCommand::Create(_)
+                    | CliCommand::Runtime(_)
+                    // `rebuild` drives the frozen-install pipeline and emits
+                    // the same progress events, so it shares the `Done in ...`
+                    // footer.
+                    | CliCommand::Rebuild(_)
+                    | CliCommand::PatchCommit(_)
+                    | CliCommand::PatchRemove(_),
+            ),
+            print_json_errors: prints_json_errors(&args.command),
+            recursive_by_default: args.command.recursive_by_default(),
+            summary_scope: args.command.default_reporter_summary_scope(),
+            reports_scope: args.command.reports_scope(args.recursive),
+            uses_stderr_reporter: args.command.uses_stderr_reporter(),
+        }
+    }
+}
+
+/// The config every load starts from. `npmrc_auth_file` is seeded from the
+/// CLI flag before `current()` reads `.npmrc`, so the override redirects the
+/// user-level read. Mirrors pnpm's `--npmrc-auth-file`. Production callers
+/// turbofish `Host` explicitly so the dependency-injection plumbing is
+/// visible at the call site. See
+/// [pnpm/pacquet#339](https://github.com/pnpm/pacquet/issues/339).
+fn seed_config(npmrc_auth_file: Option<&Path>, ignore_workspace: bool) -> Config {
+    Config {
+        npmrc_auth_file: npmrc_auth_file.map(Path::to_path_buf),
+        ignore_workspace,
+        ..Config::default()
+    }
+}
+
+/// A JSON-mode command reports its own failure on stdout and exits, so the
+/// human-readable miette report never renders.
+fn exit_on_json_error(result: miette::Result<()>, print_json_errors: bool) -> miette::Result<()> {
+    if let Err(error) = &result
+        && print_json_errors
+    {
+        print_json_error(error);
+        #[expect(clippy::exit, reason = "a JSON-mode command exits non-zero after its own report")]
+        std::process::exit(1);
+    }
+    result
 }
 
 /// `--color` wins over `--no-color`, and both over the configured value.

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -43,23 +43,7 @@ pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<Command
     let package_specifier_plan = PackageSpecifierPlan::parse(&args.package_names)?;
     check_specifier_combination(&args, &package_specifier_plan)?;
     if args.global {
-        let config = (ctx.global_config)()?;
-        args.lockfile_dir.apply_to_global(config)?;
-        args.apply_cli_config(config);
-        let dir = ctx.dir;
-        let update_check = update_notifier::spawn(config, reporter_emit(ctx.reporter));
-        let install: CommandFuture<'a> = match ctx.reporter {
-            ReporterType::Default | ReporterType::AppendOnly => {
-                Box::pin(args.run_global::<DefaultReporter>(config, dir))
-            }
-            ReporterType::Ndjson => Box::pin(args.run_global::<NdjsonReporter>(config, dir)),
-            ReporterType::Silent => Box::pin(args.run_global::<SilentReporter>(config, dir)),
-        };
-        return Ok(Box::pin(async move {
-            let installed = install.await;
-            update_notifier::settle(update_check, &installed).await;
-            installed
-        }));
+        return add_global(ctx, args);
     }
     let config_dependencies = args.parse_config_dependencies()?;
     let dir = ctx.dir;
@@ -104,6 +88,26 @@ pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<Command
         };
         update_notifier::settle(update_check, &added).await;
         added
+    }))
+}
+
+fn add_global<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<CommandFuture<'a>> {
+    let config = (ctx.global_config)()?;
+    args.lockfile_dir.apply_to_global(config)?;
+    args.apply_cli_config(config);
+    let dir = ctx.dir;
+    let update_check = update_notifier::spawn(config, reporter_emit(ctx.reporter));
+    let install: CommandFuture<'a> = match ctx.reporter {
+        ReporterType::Default | ReporterType::AppendOnly => {
+            Box::pin(args.run_global::<DefaultReporter>(config, dir))
+        }
+        ReporterType::Ndjson => Box::pin(args.run_global::<NdjsonReporter>(config, dir)),
+        ReporterType::Silent => Box::pin(args.run_global::<SilentReporter>(config, dir)),
+    };
+    Ok(Box::pin(async move {
+        let installed = install.await;
+        update_notifier::settle(update_check, &installed).await;
+        installed
     }))
 }
 
@@ -386,41 +390,13 @@ pub(super) fn pipeline<'a>(
     args: PipelineArgs,
 ) -> miette::Result<CommandFuture<'a>> {
     if args.watch {
-        let PipelineArgs {
-            name, repo, branch, interval, once, no_cache, report, report_to, ..
-        } = args;
         let config = ctx.config;
         return Ok(Box::pin(async move {
             let cfg = config()?;
-            let invocation = WatchInvocation {
-                pipeline_name: name,
-                repo: repo.expect("clap requires --repo with --watch"),
-                branch,
-                interval: std::time::Duration::from_secs(interval),
-                once,
-                no_cache,
-                report: report || report_to.is_some(),
-                report_to,
-                npmrc_auth_file: cfg.npmrc_auth_file.clone(),
-            };
-            run_watch(&invocation, &cfg.state_dir)
+            run_watch(&watch_invocation(args, cfg), &cfg.state_dir)
         }));
     }
-    let PipelineArgs {
-        name, mut install_args, json, no_cache, full, base, report, report_to, ..
-    } = args;
-    let invocation = PipelineInvocation {
-        name,
-        // `--dry-run` prints the task graph and runs nothing, the
-        // install included.
-        dry_run: install_args.dry_run,
-        json,
-        no_cache,
-        full,
-        base,
-        report: report || report_to.is_some(),
-        report_to,
-    };
+    let (invocation, mut install_args) = pipeline_invocation(args);
     install_args.frozen_lockfile = true;
     install_args.dry_run = false;
 
@@ -450,6 +426,37 @@ pub(super) fn pipeline<'a>(
         }
         Ok(())
     }))
+}
+
+fn watch_invocation(args: PipelineArgs, cfg: &Config) -> WatchInvocation {
+    WatchInvocation {
+        pipeline_name: args.name,
+        repo: args.repo.expect("clap requires --repo with --watch"),
+        branch: args.branch,
+        interval: std::time::Duration::from_secs(args.interval),
+        once: args.once,
+        no_cache: args.no_cache,
+        report: args.report || args.report_to.is_some(),
+        report_to: args.report_to,
+        npmrc_auth_file: cfg.npmrc_auth_file.clone(),
+    }
+}
+
+/// The pipeline run the arguments ask for, and the install it runs first.
+fn pipeline_invocation(args: PipelineArgs) -> (PipelineInvocation, InstallArgs) {
+    let invocation = PipelineInvocation {
+        name: args.name,
+        // `--dry-run` prints the task graph and runs nothing, the
+        // install included.
+        dry_run: args.install_args.dry_run,
+        json: args.json,
+        no_cache: args.no_cache,
+        full: args.full,
+        base: args.base,
+        report: args.report || args.report_to.is_some(),
+        report_to: args.report_to,
+    };
+    (invocation, args.install_args)
 }
 
 /// Publish the run to the configured pnpr server. A run that could not be

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -37,7 +37,7 @@ use miette::Context;
 use pnpm_config::Config;
 use pnpm_default_reporter::DefaultReporter;
 use pnpm_reporter::{NdjsonReporter, SilentReporter};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<CommandFuture<'a>> {
     let package_specifier_plan = PackageSpecifierPlan::parse(&args.package_names)?;
@@ -52,22 +52,8 @@ pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<Command
     let config = ctx.config;
     Ok(Box::pin(async move {
         let cfg = config()?;
-        // Before `apply_allow_build` persists anything: a `--workspace` add
-        // that cannot run must leave `pnpm-workspace.yaml` untouched.
-        workspace_link_root(args.workspace, cfg.workspace_dir.as_deref())?;
-        let recursive_sort = cfg.sort;
-        if config_dependencies.is_none() {
-            args.check_workspace_root(cfg, dir)?;
-        }
-        args.lockfile_dir.apply_to(cfg, dir);
-        args.apply_cli_config(cfg);
-        let config_root = derive_config_root(cfg, dir, reporter)
-            .wrap_err("derive workspace root and package manager policy")?;
-        // `allowBuilds` is persisted to `pnpm-workspace.yaml`, which stays
-        // at the workspace root even when `lockfileDir` moved the config
-        // root elsewhere.
-        let allow_build_root = cfg.workspace_dir.clone().unwrap_or_else(|| config_root.clone());
-        apply_allow_build(cfg, &args.allow_build, &allow_build_root)?;
+        let (config_root, recursive_sort) =
+            prepare_add_config(&args, cfg, dir, reporter, config_dependencies.is_none())?;
         let update_check = update_notifier::spawn(cfg, reporter_emit(reporter));
         let pipeline = AddPipeline {
             args,
@@ -89,6 +75,35 @@ pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<Command
         update_notifier::settle(update_check, &added).await;
         added
     }))
+}
+
+/// Apply the add's settings to the config and derive its root. Returns the
+/// config root and the `sort` setting as it stood before the command-line
+/// settings applied.
+fn prepare_add_config(
+    args: &AddArgs,
+    cfg: &mut Config,
+    dir: &Path,
+    reporter: ReporterType,
+    plain_dependencies: bool,
+) -> miette::Result<(PathBuf, bool)> {
+    // Before `apply_allow_build` persists anything: a `--workspace` add
+    // that cannot run must leave `pnpm-workspace.yaml` untouched.
+    workspace_link_root(args.workspace, cfg.workspace_dir.as_deref())?;
+    let recursive_sort = cfg.sort;
+    if plain_dependencies {
+        args.check_workspace_root(cfg, dir)?;
+    }
+    args.lockfile_dir.apply_to(cfg, dir);
+    args.apply_cli_config(cfg);
+    let config_root = derive_config_root(cfg, dir, reporter)
+        .wrap_err("derive workspace root and package manager policy")?;
+    // `allowBuilds` is persisted to `pnpm-workspace.yaml`, which stays
+    // at the workspace root even when `lockfileDir` moved the config
+    // root elsewhere.
+    let allow_build_root = cfg.workspace_dir.clone().unwrap_or_else(|| config_root.clone());
+    apply_allow_build(cfg, &args.allow_build, &allow_build_root)?;
+    Ok((config_root, recursive_sort))
 }
 
 fn add_global<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<CommandFuture<'a>> {

--- a/pnpm/crates/cli/src/cli_args/dlx.rs
+++ b/pnpm/crates/cli/src/cli_args/dlx.rs
@@ -162,123 +162,69 @@ impl DlxArgs {
         dir: &Path,
         config: &'static mut Config,
     ) -> miette::Result<()> {
-        let DlxArgs { command, package, allow_build, shell_mode, cpu, os, libc } = self;
-        let supported_architectures = SupportedArchitecturesArgs { cpu, os, libc };
-        let Some((bin_command, args)) = command.split_first() else {
+        let supported_architectures =
+            SupportedArchitecturesArgs { cpu: self.cpu, os: self.os, libc: self.libc };
+        let Some((bin_command, args)) = self.command.split_first() else {
             return Err(DlxError::MissingCommand.into());
         };
 
-        // Read the config values every dlx spawn applies, before the
-        // install path below consumes `config` to anchor it at the cache
-        // directory.
-        let extra_bin_paths = config.extra_bin_paths.clone();
-        let mut extra_env = config.extra_env.clone();
-        // The GVS resolution env injected by `Config::current` points at
-        // the *invoking* project's node_modules; the dlx tool runs from
-        // its own self-contained cache (GVS forced off for the cache
-        // install), so inheriting it would let the tool resolve phantom
-        // deps from the caller's tree.
-        extra_env.remove("NODE_PATH");
-        extra_env.remove("NODE_OPTIONS");
-        let user_agent = config.user_agent.clone();
+        let env = SpawnEnv::from_config(config, dir);
+        let spawn = env.spawn(self.shell_mode);
 
-        // The dlx command runs in the process working directory
-        // (`cwd: process.cwd()`), independent of `--dir`.
-        let run_cwd = std::env::current_dir().unwrap_or_else(|_| dir.to_path_buf());
-        let spawn = DlxSpawn {
-            cwd: &run_cwd,
-            extra_bin_paths: &extra_bin_paths,
-            extra_env: &extra_env,
-            user_agent: &user_agent,
-            shell_mode,
-        };
-
-        match provisioned_tool(&package, bin_command) {
-            Some(ProvisionedTool::PackageManager { pm, version_spec, spec, bin }) => {
-                return run_package_manager::<Reporter>(
-                    config,
-                    pm,
-                    version_spec,
-                    spec,
-                    bin,
-                    args,
-                    &spawn,
-                )
-                .await;
-            }
-            Some(ProvisionedTool::Runtime { name, version_spec }) => {
-                return run_runtime(
-                    &config.state_dir,
-                    name,
-                    version_spec,
-                    bin_command,
-                    args,
-                    &spawn,
-                )
-                .await;
-            }
-            None => {}
+        if let Some(tool) = provisioned_tool(&self.package, bin_command) {
+            return run_provisioned::<Reporter>(tool, config, bin_command, args, &spawn).await;
         }
 
         // `pkgs = package ?? [command]`. With `--package`, the command
         // names the bin to run; otherwise the command is also the package.
         let pkgs: Vec<String> =
-            if package.is_empty() { vec![bin_command.clone()] } else { package.clone() };
+            if self.package.is_empty() { vec![bin_command.clone()] } else { self.package.clone() };
         // Resolved here rather than in the install below so the catalog's
         // version also feeds the cache key: two callers whose catalogs pin
         // different versions of the same package must not share a cache
         // entry.
         let pkgs = resolve_catalog_specs(&pkgs, config)?;
 
-        // Read the config values needed before (and after) the install,
-        // because the install path consumes `config` to anchor it at the
-        // cache directory.
-        let cache_dir = config.cache_dir.clone();
-        let max_age = config.dlx_cache_max_age;
-        let registries = build_registries_map(config);
         // The effective (post-`--cpu`/`--os`/`--libc`) architecture set
         // is part of the cache key: it changes which platform-tagged
         // optional dependencies get installed, so two invocations that
         // differ only by architecture must not share a cache entry.
-        // `supportedArchitectures` is fed into the cache key for this.
-        let effective_architectures =
-            supported_architectures.apply_to(config.supported_architectures.clone());
-        let cache_key =
-            create_cache_key(&pkgs, &registries, &allow_build, effective_architectures.as_ref());
-        let dlx_command_cache_dir = cache_dir.join("dlx").join(&cache_key);
-        fs::create_dir_all(&dlx_command_cache_dir).map_err(|source| DlxError::Cache {
-            dir: dlx_command_cache_dir.display().to_string(),
-            source,
-        })?;
-        // Canonicalize so the prepare dir carries no `..` segments. A
-        // relative `cacheDir` (e.g. `../pnpm-cache`) would otherwise
-        // let the install's workspace-root walk pass through the
-        // caller's project dir and mistake it for the dlx workspace.
-        let dlx_command_cache_dir = dunce::canonicalize(&dlx_command_cache_dir)
-            .into_diagnostic()
-            .wrap_err("canonicalizing the dlx cache directory")?;
+        let dlx_command_cache_dir = dlx_command_cache_dir(
+            config,
+            &create_cache_key(
+                &pkgs,
+                &build_registries_map(config),
+                &self.allow_build,
+                supported_architectures.apply_to(config.supported_architectures.clone()).as_ref(),
+            ),
+        )?;
         let cache_link = dlx_command_cache_dir.join("pkg");
 
-        let cached_dir = match get_valid_cache_dir(&cache_link, max_age, SystemTime::now()) {
-            Some(dir) => dir,
-            None => {
-                prepare_cache_dir::<Reporter>(
-                    &dlx_command_cache_dir,
-                    &cache_link,
-                    &pkgs,
-                    &allow_build,
-                    &supported_architectures,
-                    config,
-                )
-                .await?
-            }
-        };
+        let cached_dir =
+            match get_valid_cache_dir(&cache_link, config.dlx_cache_max_age, SystemTime::now()) {
+                Some(cached_dir) => cached_dir,
+                None => {
+                    prepare_cache_dir::<Reporter>(
+                        &dlx_command_cache_dir,
+                        &cache_link,
+                        &pkgs,
+                        &self.allow_build,
+                        &supported_architectures,
+                        config,
+                    )
+                    .await?
+                }
+            };
 
-        let bins_dir = cached_dir.join("node_modules").join(".bin");
         let bin_name =
-            if package.is_empty() { get_bin_name(&cached_dir)? } else { bin_command.clone() };
+            if self.package.is_empty() { get_bin_name(&cached_dir)? } else { bin_command.clone() };
 
-        run_bin(DlxProgram::Named(&bin_name), args, vec![bins_dir], &spawn)
+        run_bin(
+            DlxProgram::Named(&bin_name),
+            args,
+            vec![cached_dir.join("node_modules").join(".bin")],
+            &spawn,
+        )
     }
 }
 
@@ -481,6 +427,78 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
     Ok(())
 }
 
+/// The config values every dlx spawn applies, read before the install path
+/// consumes `config` to anchor it at the cache directory.
+struct SpawnEnv {
+    cwd: PathBuf,
+    extra_bin_paths: Vec<PathBuf>,
+    extra_env: HashMap<String, String>,
+    user_agent: String,
+}
+
+impl SpawnEnv {
+    fn from_config(config: &Config, dir: &Path) -> Self {
+        let mut extra_env = config.extra_env.clone();
+        // The GVS resolution env injected by `Config::current` points at
+        // the *invoking* project's node_modules; the dlx tool runs from
+        // its own self-contained cache (GVS forced off for the cache
+        // install), so inheriting it would let the tool resolve phantom
+        // deps from the caller's tree.
+        extra_env.remove("NODE_PATH");
+        extra_env.remove("NODE_OPTIONS");
+        SpawnEnv {
+            // The dlx command runs in the process working directory
+            // (`cwd: process.cwd()`), independent of `--dir`.
+            cwd: std::env::current_dir().unwrap_or_else(|_| dir.to_path_buf()),
+            extra_bin_paths: config.extra_bin_paths.clone(),
+            extra_env,
+            user_agent: config.user_agent.clone(),
+        }
+    }
+
+    fn spawn(&self, shell_mode: bool) -> DlxSpawn<'_> {
+        DlxSpawn {
+            cwd: &self.cwd,
+            extra_bin_paths: &self.extra_bin_paths,
+            extra_env: &self.extra_env,
+            user_agent: &self.user_agent,
+            shell_mode,
+        }
+    }
+}
+
+async fn run_provisioned<Reporter: self::Reporter + 'static>(
+    tool: ProvisionedTool<'_>,
+    config: &'static Config,
+    bin_command: &str,
+    args: &[String],
+    spawn: &DlxSpawn<'_>,
+) -> miette::Result<()> {
+    match tool {
+        ProvisionedTool::PackageManager { pm, version_spec, spec, bin } => {
+            run_package_manager::<Reporter>(config, pm, version_spec, spec, bin, args, spawn).await
+        }
+        ProvisionedTool::Runtime { name, version_spec } => {
+            run_runtime(&config.state_dir, name, version_spec, bin_command, args, spawn).await
+        }
+    }
+}
+
+/// The command's cache directory, created and canonicalized so the prepare
+/// dir carries no `..` segments. A relative `cacheDir` (e.g. `../pnpm-cache`)
+/// would otherwise let the install's workspace-root walk pass through the
+/// caller's project dir and mistake it for the dlx workspace.
+fn dlx_command_cache_dir(config: &Config, cache_key: &str) -> miette::Result<PathBuf> {
+    let dlx_command_cache_dir = config.cache_dir.join("dlx").join(cache_key);
+    fs::create_dir_all(&dlx_command_cache_dir).map_err(|source| DlxError::Cache {
+        dir: dlx_command_cache_dir.display().to_string(),
+        source,
+    })?;
+    dunce::canonicalize(&dlx_command_cache_dir)
+        .into_diagnostic()
+        .wrap_err("canonicalizing the dlx cache directory")
+}
+
 /// How dlx spawns whatever it ends up running: the working directory and
 /// shell mode the command was invoked with, plus the environment read off
 /// `Config` before the install path consumes it.
@@ -532,12 +550,11 @@ fn run_bin(
     bin_dirs: Vec<PathBuf>,
     spawn: &DlxSpawn<'_>,
 ) -> miette::Result<()> {
-    let DlxSpawn { cwd, extra_bin_paths, extra_env, user_agent, shell_mode } = *spawn;
     let mut prepend = bin_dirs;
-    prepend.extend(extra_bin_paths.iter().cloned());
+    prepend.extend(spawn.extra_bin_paths.iter().cloned());
     let path = prepend_dirs_to_path(&prepend).map_err(DlxError::from)?;
 
-    let mut cmd = if shell_mode {
+    let mut cmd = if spawn.shell_mode {
         let shell = pnpm_executor::select_shell(None, cfg!(windows))
             .expect("default shell selection never fails");
         let word = program
@@ -555,7 +572,7 @@ fn run_bin(
         cmd
     } else {
         let executable = match program {
-            DlxProgram::Named(name) => which::which_in(name, Some(&path), cwd)
+            DlxProgram::Named(name) => which::which_in(name, Some(&path), spawn.cwd)
                 .map_err(|_| DlxError::CommandNotFound { command: name.to_string() })?,
             DlxProgram::Provisioned { executable, .. } => executable.to_path_buf(),
         };
@@ -564,15 +581,15 @@ fn run_bin(
         cmd
     };
 
-    cmd.current_dir(cwd);
+    cmd.current_dir(spawn.cwd);
     // `updateConfig`-provided env, applied first so pnpm's own keys win
     // on conflict (matching `exec`'s spawn and TS `makeEnv`). dlx does
     // not run the `updateConfig` hook, so this is currently always
     // empty; wired for uniformity with the other spawn sites and so it
     // works if that changes.
-    cmd.envs(extra_env);
+    cmd.envs(spawn.extra_env);
     set_command_path(&mut cmd, &path);
-    cmd.env("npm_config_user_agent", user_agent);
+    cmd.env("npm_config_user_agent", spawn.user_agent);
 
     let status = pnpm_executor::spawn_child(&mut cmd, None)
         .and_then(|mut child| child.wait())

--- a/pnpm/crates/cli/src/cli_args/exec/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/exec/recursive.rs
@@ -80,10 +80,6 @@ pub async fn exec_recursive(
     emit: fn(&LogEvent),
 ) -> miette::Result<()> {
     let command = prepare_command(args.command.clone())?;
-    // Unlike `run`'s `--stream`, `exec` prefixes its output only when
-    // the user turned the hiding off explicitly — pnpm gates on
-    // `reporterHidePrefix === false`, not on its falsiness.
-    let show_prefix = config.reporter_hide_prefix == Some(false);
     let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
 
     let (projects, patterns) = discover_workspace_projects(workspace_root, config)?;
@@ -99,53 +95,28 @@ pub async fn exec_recursive(
         dir,
         AutoExcludeRoot::Enabled { workspace_patterns: patterns.as_deref() },
     )?;
-    let graph = &selection.selected;
     // An empty `--filter` selection is a no-op (exit 0).
-    if graph.is_empty() {
+    if selection.selected.is_empty() {
         return Ok(());
     }
 
-    let command_name = &args.command[0];
-    let task_graph = build_exec_task_graph(args, graph, &selection, command_name);
-    let full_task_graph = task_graph;
-    let mut state_params = args.command.clone();
-    state_params.push(format!("shell-mode={}", args.shell_mode));
-    let state_extra_env = config.extra_env_with_node_options();
-    let state_settings = task_run_execution_settings(&TaskRunExecutionSettings {
-        extra_bin_paths: &config.extra_bin_paths,
-        extra_env: &state_extra_env,
-        modules_dir: &config.modules_dir,
-        node_experimental_package_map: config.node_experimental_package_map,
-        node_options: config.node_options.as_deref(),
-        user_agent: &config.user_agent,
-    });
+    let full_task_graph =
+        build_exec_task_graph(args, &selection.selected, &selection, &args.command[0]);
+    let state_inputs = ExecStateInputs::new(args, config);
     let task_run_state_context = TaskRunStateContext::new(
         "exec",
-        &state_params,
-        &state_settings,
+        &state_inputs.params,
+        &state_inputs.settings,
         &full_task_graph,
         workspace_root,
         |_, _| Vec::new(),
     );
-    let resume_anchor = args
-        .resume_from
-        .as_ref()
-        .map(|resume_from| find_resume_root(resume_from, graph))
-        .transpose()?;
-    let completed_tasks = resume_anchor
-        .as_ref()
-        .map(|_| task_run_state_context.read_completed_tasks())
-        .transpose()?
-        .flatten();
-    let mut task_graph = match resume_anchor {
-        Some(anchor) => resume_task_graph_from(
-            full_task_graph.clone(),
-            &anchor,
-            command_name,
-            completed_tasks.as_ref(),
-        ),
-        None => full_task_graph.clone(),
-    };
+    let mut task_graph = resumed_exec_task_graph(
+        args,
+        &selection.selected,
+        &full_task_graph,
+        &task_run_state_context,
+    )?;
     // Also the cycle check: a cyclic graph cannot be scheduled, and
     // sequenced into an arbitrary order it would succeed or fail by luck.
     let sequenced_tasks = sequence_tasks(
@@ -157,67 +128,156 @@ pub async fn exec_recursive(
         },
     )?;
 
-    let initially_completed: HashSet<TaskKey> =
-        full_task_graph.keys().filter(|key| !task_graph.contains_key(*key)).cloned().collect();
-    let task_run_state = task_run_state_context.start(&initially_completed)?;
-
-    let bail = !args.no_bail;
-    let concurrency = exec_concurrency(args, config, task_graph.len());
-    let result: Mutex<IndexMap<String, ExecutionStatus>> = Mutex::new(
-        task_graph
-            .values()
-            .map(|node| (node.project.to_string_lossy().into_owned(), ExecutionStatus::queued()))
-            .collect(),
-    );
-    let first_failure: Mutex<Option<String>> = Mutex::new(None);
-    let abort: Mutex<Option<miette::Report>> = Mutex::new(None);
-    let runs_concurrently = concurrency > 1 && !is_serial_task_graph(&task_graph, &sequenced_tasks);
-    let process_tracker = exec_process_tracker(bail, runs_concurrently);
-    let task_context = ExecTaskContext {
+    let task_run_state =
+        task_run_state_context.start(&initially_completed(&full_task_graph, &task_graph))?;
+    let run = ExecRun {
         args,
         config,
         command: &command,
         dir,
         workspace_root,
-        show_prefix,
         emit,
-        result: &result,
-        first_failure: &first_failure,
-        abort: &abort,
-        process_tracker: process_tracker.as_ref(),
         task_run_state: &task_run_state,
     };
-    let run_task = |node: &TaskNode| run_exec_task(&task_context, node);
-    let on_task_skipped = |node: &TaskNode| {
-        result.lock().expect("summary lock is not poisoned")
-            [&node.project.to_string_lossy().into_owned()]
-            .status = Status::Skipped;
-    };
-    schedule_tasks(
-        &task_graph,
-        &ScheduleTasksOptions {
-            concurrency,
-            bail,
-            run_task: &run_task,
-            on_task_skipped: &on_task_skipped,
-        },
-    );
-
-    if let Some(error) = abort.into_inner().expect("abort slot lock is not poisoned") {
-        return Err(error);
-    }
-
-    let result = result.into_inner().expect("summary lock is not poisoned");
-    let first_failure =
-        first_failure.into_inner().expect("first-failure slot lock is not poisoned");
-    report_recursive_outcome(
-        args,
-        workspace_root,
-        &result,
-        bail.then_some(first_failure).flatten(),
-    )?;
+    run.execute(&task_graph, &sequenced_tasks)?;
     task_run_state.finish()?;
     Ok(())
+}
+
+/// What identifies an exec run in the task-run state: its command line and
+/// the execution settings it ran under.
+struct ExecStateInputs {
+    params: Vec<String>,
+    settings: Vec<String>,
+}
+
+impl ExecStateInputs {
+    fn new(args: &ExecArgs, config: &Config) -> Self {
+        let mut params = args.command.clone();
+        params.push(format!("shell-mode={}", args.shell_mode));
+        let extra_env = config.extra_env_with_node_options();
+        let settings = task_run_execution_settings(&TaskRunExecutionSettings {
+            extra_bin_paths: &config.extra_bin_paths,
+            extra_env: &extra_env,
+            modules_dir: &config.modules_dir,
+            node_experimental_package_map: config.node_experimental_package_map,
+            node_options: config.node_options.as_deref(),
+            user_agent: &config.user_agent,
+        });
+        Self { params, settings }
+    }
+}
+
+/// The task graph to run: the full graph, or the part after `--resume-from`
+/// with the tasks a previous run already completed taken out.
+fn resumed_exec_task_graph(
+    args: &ExecArgs,
+    graph: &pnpm_workspace_projects_filter::ProjectGraph<pnpm_workspace::GraphPkg<'_>>,
+    full_task_graph: &TaskGraph,
+    task_run_state_context: &TaskRunStateContext,
+) -> miette::Result<TaskGraph> {
+    let resume_anchor = args
+        .resume_from
+        .as_ref()
+        .map(|resume_from| find_resume_root(resume_from, graph))
+        .transpose()?;
+    let completed_tasks = resume_anchor
+        .as_ref()
+        .map(|_| task_run_state_context.read_completed_tasks())
+        .transpose()?
+        .flatten();
+    Ok(match resume_anchor {
+        Some(anchor) => resume_task_graph_from(
+            full_task_graph.clone(),
+            &anchor,
+            &args.command[0],
+            completed_tasks.as_ref(),
+        ),
+        None => full_task_graph.clone(),
+    })
+}
+
+/// The tasks a resumed run starts with already completed.
+fn initially_completed(full_task_graph: &TaskGraph, task_graph: &TaskGraph) -> HashSet<TaskKey> {
+    full_task_graph.keys().filter(|key| !task_graph.contains_key(*key)).cloned().collect()
+}
+
+/// One recursive exec, ready to be scheduled over its task graph.
+struct ExecRun<'a> {
+    args: &'a ExecArgs,
+    config: &'a Config,
+    command: &'a [String],
+    dir: &'a Path,
+    workspace_root: &'a Path,
+    emit: fn(&LogEvent),
+    task_run_state: &'a crate::cli_args::task_run_state::TaskRunState,
+}
+
+impl ExecRun<'_> {
+    /// Run every task, then report the outcome the way the flags ask for.
+    fn execute(&self, task_graph: &TaskGraph, sequenced_tasks: &[TaskKey]) -> miette::Result<()> {
+        let bail = !self.args.no_bail;
+        let concurrency = exec_concurrency(self.args, self.config, task_graph.len());
+        let result: Mutex<IndexMap<String, ExecutionStatus>> = Mutex::new(
+            task_graph
+                .values()
+                .map(|node| {
+                    (node.project.to_string_lossy().into_owned(), ExecutionStatus::queued())
+                })
+                .collect(),
+        );
+        let first_failure: Mutex<Option<String>> = Mutex::new(None);
+        let abort: Mutex<Option<miette::Report>> = Mutex::new(None);
+        let runs_concurrently =
+            concurrency > 1 && !is_serial_task_graph(task_graph, sequenced_tasks);
+        let process_tracker = exec_process_tracker(bail, runs_concurrently);
+        let task_context = ExecTaskContext {
+            args: self.args,
+            config: self.config,
+            command: self.command,
+            dir: self.dir,
+            workspace_root: self.workspace_root,
+            // Unlike `run`'s `--stream`, `exec` prefixes its output only when
+            // the user turned the hiding off explicitly — pnpm gates on
+            // `reporterHidePrefix === false`, not on its falsiness.
+            show_prefix: self.config.reporter_hide_prefix == Some(false),
+            emit: self.emit,
+            result: &result,
+            first_failure: &first_failure,
+            abort: &abort,
+            process_tracker: process_tracker.as_ref(),
+            task_run_state: self.task_run_state,
+        };
+        let run_task = |node: &TaskNode| run_exec_task(&task_context, node);
+        let on_task_skipped = |node: &TaskNode| {
+            result.lock().expect("summary lock is not poisoned")
+                [&node.project.to_string_lossy().into_owned()]
+                .status = Status::Skipped;
+        };
+        schedule_tasks(
+            task_graph,
+            &ScheduleTasksOptions {
+                concurrency,
+                bail,
+                run_task: &run_task,
+                on_task_skipped: &on_task_skipped,
+            },
+        );
+
+        if let Some(error) = abort.into_inner().expect("abort slot lock is not poisoned") {
+            return Err(error);
+        }
+
+        let result = result.into_inner().expect("summary lock is not poisoned");
+        let first_failure =
+            first_failure.into_inner().expect("first-failure slot lock is not poisoned");
+        report_recursive_outcome(
+            self.args,
+            self.workspace_root,
+            &result,
+            bail.then_some(first_failure).flatten(),
+        )
+    }
 }
 
 /// `--no-bail` runs every task whatever fails, so it needs no tracker at

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -202,15 +202,7 @@ pub async fn handle_global_add<Reporter: self::Reporter + 'static>(
     if selects_pnpm_cli(groups.iter().flatten()) {
         return Err(GlobalError::GlobalPnpmInstall.into());
     }
-    // A tool name becomes the selector that installs the tool itself,
-    // which the ordinary pipeline then handles — so the result stays a
-    // normal global install that `pnpm ls -g` and `pnpm remove -g` see.
-    let groups: Vec<Vec<String>> = groups
-        .into_iter()
-        .map(|group| {
-            group.into_iter().map(|token| tool_install_selector(&token).unwrap_or(token)).collect()
-        })
-        .collect();
+    let groups = tool_install_selectors(groups);
 
     let (global_pkg_dir, global_bin_dir) = global_dirs(base_config)?;
     check_bin_dir(&global_bin_dir)?;
@@ -219,101 +211,20 @@ pub async fn handle_global_add<Reporter: self::Reporter + 'static>(
         .wrap_err("create the global packages directory")?;
     clean_orphaned_install_dirs(&global_pkg_dir);
 
+    let target = GlobalInstallTarget {
+        base_config,
+        global_pkg_dir: &global_pkg_dir,
+        global_bin_dir: &global_bin_dir,
+    };
     for group in groups {
-        let install_dir = create_install_dir(&global_pkg_dir)
-            .into_diagnostic()
-            .wrap_err("create global install dir")?;
-        let config = Box::pin(run_group_install::<Reporter>(GroupInstall {
-            base_config,
-            global_pkg_dir: &global_pkg_dir,
-            install_dir: &install_dir,
-            selectors: &group,
-            range_spec_style,
-            supported_architectures: supported_architectures.clone(),
-            allow_build,
-            lockfile_only: false,
-        }))
-        .await?;
-
-        let pkgs = read_installed_packages(&install_dir);
-        let dependencies = read_direct_dependencies(&install_dir);
-        let aliases = dependencies.iter().map(|(alias, _)| alias.clone()).collect::<Vec<_>>();
-        let aliases_to_replace = replacement_aliases(&aliases);
-        let _global_bin_lock =
-            discard_install_dir_on_error(&install_dir, acquire_global_bin_lock(&global_bin_dir))?;
-
-        discard_install_dir_on_error(
-            &install_dir,
-            check_virtual_shim_conflicts(&pkgs, &global_bin_dir),
-        )?;
-
-        let bins_to_skip = discard_install_dir_on_error(
-            &install_dir,
-            check_global_bin_conflicts(
-                &global_pkg_dir,
-                &global_bin_dir,
-                &pkgs,
-                |existing: &GlobalPackageInfo| {
-                    should_replace_existing_package(existing, &aliases, &aliases_to_replace)
-                },
-            ),
-        )?;
-
-        let existing = discard_install_dir_on_error(
-            &install_dir,
-            collect_existing_global_installs(&global_pkg_dir, &aliases, &aliases_to_replace)
-                .wrap_err("scan existing global installs"),
-        )?;
-        let prospective_bins = get_actual_bin_names::<CmdShimHost>(&pkgs, &bins_to_skip);
-        let replacement_plan = discard_install_dir_on_error(
-            &install_dir,
-            plan_replaced_global_bins(
-                &existing.groups_to_replace,
-                &global_bin_dir,
-                &prospective_bins,
-                &existing.protected_bins,
-                &crate::shim_dispatch::global_shims_setting(),
-            ),
-        )?;
-        let cache_hash = create_global_cache_key(&aliases, &registries_with_default(config));
-        let hash_link = get_hash_link(&global_pkg_dir, &cache_hash);
-        let linked_pkgs = hash_linked_packages(&pkgs, &install_dir, &hash_link);
-        let activation = activate_global_install_with_extra_bin_names::<CmdShimHost>(
-            &install_dir,
-            &hash_link,
-            &global_bin_dir,
-            &pkgs,
-            &bins_to_skip,
-            &replacement_plan.affected_bin_names,
-            || {
-                link_global_bins(
-                    base_config,
-                    &linked_pkgs,
-                    &dependencies,
-                    &global_bin_dir,
-                    &bins_to_skip,
-                )?;
-                restore_virtual_shims(&replacement_plan.shims_to_restore, &global_bin_dir)
-            },
-        )
-        .wrap_err("activate global install")?;
-        if let Some(leftover) = &activation.leftover_backup {
-            warn_global::<Reporter>(&leftover.to_string());
-        }
-        let activated_bins = activation.activated_bins;
-        if let Some(leftover) = cleanup_replaced_global_installs(
-            &global_pkg_dir,
-            &global_bin_dir,
-            &existing.groups_to_replace,
-            &cache_hash,
-            &activated_bins,
-            &existing.protected_bins,
-            &replacement_plan.restored_bin_names(),
-        )
-        .wrap_err("remove existing global installs")?
-        {
-            warn_global::<Reporter>(&leftover.to_string());
-        }
+        target
+            .add_group::<Reporter>(
+                &group,
+                range_spec_style,
+                supported_architectures.clone(),
+                allow_build,
+            )
+            .await?;
     }
     Ok(())
 }
@@ -399,13 +310,138 @@ pub async fn handle_global_update<Reporter: self::Reporter + 'static>(
         to_update.retain(|pkg| selected_hashes.contains(&pkg.hash));
     }
 
+    let target = GlobalInstallTarget {
+        base_config,
+        global_pkg_dir: &global_pkg_dir,
+        global_bin_dir: &global_bin_dir,
+    };
     for pkg in &to_update {
-        let install_dir = create_install_dir(&global_pkg_dir)
+        target
+            .update_group::<Reporter>(
+                pkg,
+                latest,
+                range_spec_style,
+                supported_architectures.clone(),
+            )
+            .await?;
+    }
+    Ok(())
+}
+
+/// A tool name becomes the selector that installs the tool itself, which
+/// the ordinary pipeline then handles — so the result stays a normal global
+/// install that `pnpm ls -g` and `pnpm remove -g` see.
+fn tool_install_selectors(groups: Vec<Vec<String>>) -> Vec<Vec<String>> {
+    groups
+        .into_iter()
+        .map(|group| {
+            group.into_iter().map(|token| tool_install_selector(&token).unwrap_or(token)).collect()
+        })
+        .collect()
+}
+
+/// The pnpm home a global group installs into.
+struct GlobalInstallTarget<'a> {
+    base_config: &'static Config,
+    global_pkg_dir: &'a Path,
+    global_bin_dir: &'a Path,
+}
+
+/// A freshly installed group, ready to take over the global bins of the
+/// groups it replaces.
+struct GroupActivation<'a> {
+    install_dir: &'a Path,
+    pkgs: &'a [PackageBinSource],
+    dependencies: &'a [(String, String)],
+    bins_to_skip: &'a HashSet<String>,
+    groups_to_replace: &'a [GlobalPackageBinSnapshot],
+    protected_bins: &'a HashSet<String>,
+    hash: &'a str,
+}
+
+impl GlobalInstallTarget<'_> {
+    /// Install one `add -g` group and activate it over the groups it
+    /// replaces.
+    async fn add_group<Reporter: self::Reporter + 'static>(
+        &self,
+        group: &[String],
+        range_spec_style: RangeSpecStyle,
+        supported_architectures: Option<SupportedArchitectures>,
+        allow_build: &[String],
+    ) -> miette::Result<()> {
+        let install_dir = create_install_dir(self.global_pkg_dir)
+            .into_diagnostic()
+            .wrap_err("create global install dir")?;
+        let config = Box::pin(run_group_install::<Reporter>(GroupInstall {
+            base_config: self.base_config,
+            global_pkg_dir: self.global_pkg_dir,
+            install_dir: &install_dir,
+            selectors: group,
+            range_spec_style,
+            supported_architectures,
+            allow_build,
+            lockfile_only: false,
+        }))
+        .await?;
+
+        let pkgs = read_installed_packages(&install_dir);
+        let dependencies = read_direct_dependencies(&install_dir);
+        let aliases = dependencies.iter().map(|(alias, _)| alias.clone()).collect::<Vec<_>>();
+        let aliases_to_replace = replacement_aliases(&aliases);
+        let _global_bin_lock = discard_install_dir_on_error(
+            &install_dir,
+            acquire_global_bin_lock(self.global_bin_dir),
+        )?;
+
+        discard_install_dir_on_error(
+            &install_dir,
+            check_virtual_shim_conflicts(&pkgs, self.global_bin_dir),
+        )?;
+
+        let bins_to_skip = discard_install_dir_on_error(
+            &install_dir,
+            check_global_bin_conflicts(
+                self.global_pkg_dir,
+                self.global_bin_dir,
+                &pkgs,
+                |existing: &GlobalPackageInfo| {
+                    should_replace_existing_package(existing, &aliases, &aliases_to_replace)
+                },
+            ),
+        )?;
+
+        let existing = discard_install_dir_on_error(
+            &install_dir,
+            collect_existing_global_installs(self.global_pkg_dir, &aliases, &aliases_to_replace)
+                .wrap_err("scan existing global installs"),
+        )?;
+        let cache_hash = create_global_cache_key(&aliases, &registries_with_default(config));
+        self.activate_group::<Reporter>(&GroupActivation {
+            install_dir: &install_dir,
+            pkgs: &pkgs,
+            dependencies: &dependencies,
+            bins_to_skip: &bins_to_skip,
+            groups_to_replace: &existing.groups_to_replace,
+            protected_bins: &existing.protected_bins,
+            hash: &cache_hash,
+        })
+    }
+
+    /// Reinstall one group for `update -g` and activate it over its own
+    /// previous install.
+    async fn update_group<Reporter: self::Reporter + 'static>(
+        &self,
+        pkg: &GlobalPackageInfo,
+        latest: bool,
+        range_spec_style: RangeSpecStyle,
+        supported_architectures: Option<SupportedArchitectures>,
+    ) -> miette::Result<()> {
+        let install_dir = create_install_dir(self.global_pkg_dir)
             .into_diagnostic()
             .wrap_err("create global install dir")?;
         let pins = Box::pin(pins_for_downgrades::<Reporter>(
-            base_config,
-            &global_pkg_dir,
+            self.base_config,
+            self.global_pkg_dir,
             &install_dir,
             pkg,
             latest,
@@ -414,12 +450,12 @@ pub async fn handle_global_update<Reporter: self::Reporter + 'static>(
         ))
         .await?;
         Box::pin(run_group_install::<Reporter>(GroupInstall {
-            base_config,
-            global_pkg_dir: &global_pkg_dir,
+            base_config: self.base_config,
+            global_pkg_dir: self.global_pkg_dir,
             install_dir: &install_dir,
             selectors: &update_selectors(&pkg.dependencies, latest, &pins),
             range_spec_style,
-            supported_architectures: supported_architectures.clone(),
+            supported_architectures,
             // `update -g` takes no `--allow-build`; the build policy comes
             // from the global `allowBuilds` loaded in `run_group_install`.
             allow_build: &[],
@@ -429,17 +465,19 @@ pub async fn handle_global_update<Reporter: self::Reporter + 'static>(
 
         let pkgs = read_installed_packages(&install_dir);
         let dependencies = read_direct_dependencies(&install_dir);
-        let _global_bin_lock =
-            discard_install_dir_on_error(&install_dir, acquire_global_bin_lock(&global_bin_dir))?;
+        let _global_bin_lock = discard_install_dir_on_error(
+            &install_dir,
+            acquire_global_bin_lock(self.global_bin_dir),
+        )?;
         discard_install_dir_on_error(
             &install_dir,
-            check_virtual_shim_conflicts(&pkgs, &global_bin_dir),
+            check_virtual_shim_conflicts(&pkgs, self.global_bin_dir),
         )?;
         let bins_to_skip = discard_install_dir_on_error(
             &install_dir,
             check_global_bin_conflicts(
-                &global_pkg_dir,
-                &global_bin_dir,
+                self.global_pkg_dir,
+                self.global_bin_dir,
                 &pkgs,
                 |existing: &GlobalPackageInfo| existing.hash == pkg.hash,
             ),
@@ -449,63 +487,82 @@ pub async fn handle_global_update<Reporter: self::Reporter + 'static>(
             &install_dir,
             (|| {
                 let group_to_replace = snapshot_global_package(pkg.clone())?;
-                let protected =
-                    bin_names_of_other_groups(&global_pkg_dir, &HashSet::from([pkg.hash.clone()]))?;
+                let protected = bin_names_of_other_groups(
+                    self.global_pkg_dir,
+                    &HashSet::from([pkg.hash.clone()]),
+                )?;
                 Ok::<_, miette::Report>((group_to_replace, protected))
             })()
             .wrap_err("scan global package bin ownership"),
         )?;
-        let prospective_bins = get_actual_bin_names::<CmdShimHost>(&pkgs, &bins_to_skip);
+        self.activate_group::<Reporter>(&GroupActivation {
+            install_dir: &install_dir,
+            pkgs: &pkgs,
+            dependencies: &dependencies,
+            bins_to_skip: &bins_to_skip,
+            groups_to_replace: std::slice::from_ref(&group_to_replace),
+            protected_bins: &protected,
+            hash: &pkg.hash,
+        })
+    }
+
+    /// Link the group's bins into the global bin directory over the groups
+    /// it replaces, then remove those groups.
+    fn activate_group<Reporter: self::Reporter>(
+        &self,
+        activation: &GroupActivation<'_>,
+    ) -> miette::Result<()> {
+        let prospective_bins =
+            get_actual_bin_names::<CmdShimHost>(activation.pkgs, activation.bins_to_skip);
         let replacement_plan = discard_install_dir_on_error(
-            &install_dir,
+            activation.install_dir,
             plan_replaced_global_bins(
-                std::slice::from_ref(&group_to_replace),
-                &global_bin_dir,
+                activation.groups_to_replace,
+                self.global_bin_dir,
                 &prospective_bins,
-                &protected,
+                activation.protected_bins,
                 &crate::shim_dispatch::global_shims_setting(),
             ),
         )?;
-        let hash_link = get_hash_link(&global_pkg_dir, &pkg.hash);
-        let linked_pkgs = hash_linked_packages(&pkgs, &install_dir, &hash_link);
-        let activation = activate_global_install_with_extra_bin_names::<CmdShimHost>(
-            &install_dir,
+        let hash_link = get_hash_link(self.global_pkg_dir, activation.hash);
+        let linked_pkgs = hash_linked_packages(activation.pkgs, activation.install_dir, &hash_link);
+        let activated = activate_global_install_with_extra_bin_names::<CmdShimHost>(
+            activation.install_dir,
             &hash_link,
-            &global_bin_dir,
-            &pkgs,
-            &bins_to_skip,
+            self.global_bin_dir,
+            activation.pkgs,
+            activation.bins_to_skip,
             &replacement_plan.affected_bin_names,
             || {
                 link_global_bins(
-                    base_config,
+                    self.base_config,
                     &linked_pkgs,
-                    &dependencies,
-                    &global_bin_dir,
-                    &bins_to_skip,
+                    activation.dependencies,
+                    self.global_bin_dir,
+                    activation.bins_to_skip,
                 )?;
-                restore_virtual_shims(&replacement_plan.shims_to_restore, &global_bin_dir)
+                restore_virtual_shims(&replacement_plan.shims_to_restore, self.global_bin_dir)
             },
         )
         .wrap_err("activate global install")?;
-        if let Some(leftover) = &activation.leftover_backup {
+        if let Some(leftover) = &activated.leftover_backup {
             warn_global::<Reporter>(&leftover.to_string());
         }
-        let activated_bins = activation.activated_bins;
         if let Some(leftover) = cleanup_replaced_global_installs(
-            &global_pkg_dir,
-            &global_bin_dir,
-            std::slice::from_ref(&group_to_replace),
-            &pkg.hash,
-            &activated_bins,
-            &protected,
+            self.global_pkg_dir,
+            self.global_bin_dir,
+            activation.groups_to_replace,
+            activation.hash,
+            &activated.activated_bins,
+            activation.protected_bins,
             &replacement_plan.restored_bin_names(),
         )
         .wrap_err("remove existing global installs")?
         {
             warn_global::<Reporter>(&leftover.to_string());
         }
+        Ok(())
     }
-    Ok(())
 }
 
 /// The installed groups the update targets. `None` when the command
@@ -657,44 +714,21 @@ pub fn handle_global_remove<Reporter: self::Reporter>(
     check_bin_dir(&global_bin_dir)?;
     let _global_bin_lock = acquire_global_bin_lock(&global_bin_dir)?;
 
-    let mut groups: Vec<GlobalPackageInfo> = Vec::new();
-    let mut seen = HashSet::new();
-    for param in params {
-        let Some(pkg) = find_global_package(&global_pkg_dir, param)
-            .into_diagnostic()
-            .wrap_err("scan global packages")?
-        else {
-            return Err(GlobalError::PkgNotFound { param: param.clone() }.into());
-        };
-        if seen.insert(pkg.hash.clone()) {
-            groups.push(pkg);
-        }
-    }
-
-    // Bins shared with (and owned by) groups that survive this removal must
-    // not be unlinked, or we'd delete another global package's bin.
-    let groups = groups
-        .into_iter()
-        .map(snapshot_global_package)
-        .collect::<miette::Result<Vec<_>>>()
-        .wrap_err("read global package bin ownership")?;
-    let exclude: HashSet<String> = groups.iter().map(|pkg| pkg.info.hash.clone()).collect();
-    let protected = bin_names_of_other_groups(&global_pkg_dir, &exclude)
-        .wrap_err("scan global package bin ownership")?;
+    let groups = requested_global_groups(&global_pkg_dir, params)?;
+    let protected = bin_names_of_other_groups(
+        &global_pkg_dir,
+        &groups.iter().map(|pkg| pkg.info.hash.clone()).collect::<HashSet<_>>(),
+    )
+    .wrap_err("scan global package bin ownership")?;
     let shims_to_restore = virtual_shims_to_restore(
         &groups,
         &global_bin_dir,
         &protected,
         &crate::shim_dispatch::global_shims_setting(),
     )?;
-    let restored_bin_names = shims_to_restore.values().flatten().cloned().collect::<HashSet<_>>();
-    let affected_bin_names = groups
-        .iter()
-        .flat_map(|group| group.bin_names.iter().cloned())
-        .filter(|bin| !protected.contains(bin))
-        .collect::<HashSet<_>>();
+    let affected_bin_names = unprotected_bin_names(&groups, &protected);
     let mut bins_to_keep = protected;
-    bins_to_keep.extend(restored_bin_names);
+    bins_to_keep.extend(shims_to_restore.values().flatten().cloned());
     let cleanup = GlobalInstallCleanup {
         global_pkg_dir: &global_pkg_dir,
         global_bin_dir: &global_bin_dir,
@@ -707,13 +741,50 @@ pub fn handle_global_remove<Reporter: self::Reporter>(
         cleanup: &cleanup,
         affected_bin_names: &affected_bin_names,
     };
-    let leftover_backup = commit_global_removal::<CmdShimHost>(&transaction, || {
+    if let Some(leftover) = commit_global_removal::<CmdShimHost>(&transaction, || {
         restore_virtual_shims(&shims_to_restore, &global_bin_dir)
-    })?;
-    if let Some(leftover) = leftover_backup {
+    })? {
         warn_global::<Reporter>(&leftover.to_string());
     }
     removed_global_install_result(cleanup_removed_global_install_dirs(&groups, &cleanup))
+}
+
+/// The groups holding the requested packages, each with the bins it owns.
+/// Bins shared with (and owned by) groups that survive the removal must not
+/// be unlinked, or another global package's bin would be deleted.
+fn requested_global_groups(
+    global_pkg_dir: &Path,
+    params: &[String],
+) -> miette::Result<Vec<GlobalPackageBinSnapshot>> {
+    let mut groups: Vec<GlobalPackageInfo> = Vec::new();
+    let mut seen = HashSet::new();
+    for param in params {
+        let Some(pkg) = find_global_package(global_pkg_dir, param)
+            .into_diagnostic()
+            .wrap_err("scan global packages")?
+        else {
+            return Err(GlobalError::PkgNotFound { param: param.clone() }.into());
+        };
+        if seen.insert(pkg.hash.clone()) {
+            groups.push(pkg);
+        }
+    }
+    groups
+        .into_iter()
+        .map(snapshot_global_package)
+        .collect::<miette::Result<Vec<_>>>()
+        .wrap_err("read global package bin ownership")
+}
+
+fn unprotected_bin_names(
+    groups: &[GlobalPackageBinSnapshot],
+    protected: &HashSet<String>,
+) -> HashSet<String> {
+    groups
+        .iter()
+        .flat_map(|group| group.bin_names.iter().cloned())
+        .filter(|bin| !protected.contains(bin))
+        .collect()
 }
 
 fn check_virtual_shim_conflicts(
@@ -866,42 +937,41 @@ struct GroupInstall<'a> {
 async fn run_group_install<Reporter: self::Reporter + 'static>(
     install: GroupInstall<'_>,
 ) -> miette::Result<&'static Config> {
-    let GroupInstall {
-        base_config,
-        global_pkg_dir,
-        install_dir,
-        selectors,
-        range_spec_style,
-        supported_architectures,
-        allow_build,
-        lockfile_only,
-    } = install;
-    let mut cfg =
-        global_group_config(base_config, install_dir, global_pkg_dir, supported_architectures)?;
-    apply_allow_build(&mut cfg, allow_build, global_pkg_dir)?;
+    let mut cfg = global_group_config(
+        install.base_config,
+        install.install_dir,
+        install.global_pkg_dir,
+        install.supported_architectures,
+    )?;
+    apply_allow_build(&mut cfg, install.allow_build, install.global_pkg_dir)?;
 
     let config: &'static Config = Config::leak(cfg);
 
-    let manifest_path = install_dir.join("package.json");
-    let selectors = selectors
+    let selectors = install
+        .selectors
         .iter()
         .map(|selector| infer_local_package_alias(selector))
         .collect::<miette::Result<Vec<_>>>()?;
-    let state = State::init(manifest_path, config, false)
+    let state = State::init(install.install_dir.join("package.json"), config, false)
         .wrap_err("initialize the global install state")?;
     add_packages::<Reporter, _>(
         state,
         &selectors,
-        range_spec_style,
+        install.range_spec_style,
         None,
-        lockfile_only,
+        install.lockfile_only,
         config.supported_architectures.clone(),
         Some([DependencyGroup::Prod]),
     )
     .await?;
 
-    if !lockfile_only {
-        prompt_approve_global_builds::<Reporter>(config, install_dir, global_pkg_dir).await?;
+    if !install.lockfile_only {
+        prompt_approve_global_builds::<Reporter>(
+            config,
+            install.install_dir,
+            install.global_pkg_dir,
+        )
+        .await?;
     }
     Ok(config)
 }
@@ -991,31 +1061,7 @@ pub async fn approve_global_builds<Reporter: self::Reporter + 'static>(
 ) -> miette::Result<()> {
     args.validate()?;
     let global_pkg_dir = base_config.global_pkg_dir.as_ref().ok_or(GlobalError::NoGlobalBinDir)?;
-    let packages =
-        scan_global_packages(global_pkg_dir).into_diagnostic().wrap_err("scan global packages")?;
-    let mut groups: Vec<(PathBuf, IgnoredBuildsScan)> = Vec::new();
-    let mut pending = BTreeSet::new();
-    let canonical_global_pkg_dir = (!packages.is_empty())
-        .then(|| dunce::canonicalize(global_pkg_dir))
-        .transpose()
-        .into_diagnostic()
-        .wrap_err("resolve the global packages directory")?;
-    // A group whose install dir resolves outside the global packages
-    // directory is not this pnpm home's to approve builds for.
-    let contained = packages.into_iter().filter(|package| {
-        canonical_global_pkg_dir.as_ref().is_none_or(|root| is_subdir(root, &package.install_dir))
-    });
-    for package in contained {
-        let config = global_group_config(
-            base_config,
-            &package.install_dir,
-            global_pkg_dir,
-            base_config.supported_architectures.clone(),
-        )?;
-        let scan = get_automatically_ignored_builds(&config)?;
-        pending.extend(scan.names.iter().flatten().cloned());
-        groups.push((package.install_dir, scan));
-    }
+    let (groups, pending) = scan_global_ignored_builds(base_config, global_pkg_dir)?;
     if pending.is_empty() && args.packages.is_empty() {
         println!("There are no packages awaiting approval");
         return Ok(());
@@ -1039,6 +1085,50 @@ pub async fn approve_global_builds<Reporter: self::Reporter + 'static>(
             rebuild_groups.push((install_dir, build_packages));
         }
     }
+    rebuild_approved_groups::<Reporter>(base_config, global_pkg_dir, rebuild_groups).await
+}
+
+/// Each global group's install dir with its ignored builds.
+type IgnoredBuildGroups = Vec<(PathBuf, IgnoredBuildsScan)>;
+
+/// Each global group's ignored builds, with the union of their names. A
+/// group whose install dir resolves outside the global packages directory is
+/// not this pnpm home's to approve builds for.
+fn scan_global_ignored_builds(
+    base_config: &Config,
+    global_pkg_dir: &Path,
+) -> miette::Result<(IgnoredBuildGroups, BTreeSet<String>)> {
+    let packages =
+        scan_global_packages(global_pkg_dir).into_diagnostic().wrap_err("scan global packages")?;
+    let mut groups: IgnoredBuildGroups = Vec::new();
+    let mut pending = BTreeSet::new();
+    let canonical_global_pkg_dir = (!packages.is_empty())
+        .then(|| dunce::canonicalize(global_pkg_dir))
+        .transpose()
+        .into_diagnostic()
+        .wrap_err("resolve the global packages directory")?;
+    let contained = packages.into_iter().filter(|package| {
+        canonical_global_pkg_dir.as_ref().is_none_or(|root| is_subdir(root, &package.install_dir))
+    });
+    for package in contained {
+        let config = global_group_config(
+            base_config,
+            &package.install_dir,
+            global_pkg_dir,
+            base_config.supported_architectures.clone(),
+        )?;
+        let scan = get_automatically_ignored_builds(&config)?;
+        pending.extend(scan.names.iter().flatten().cloned());
+        groups.push((package.install_dir, scan));
+    }
+    Ok((groups, pending))
+}
+
+async fn rebuild_approved_groups<Reporter: self::Reporter + 'static>(
+    base_config: &'static Config,
+    global_pkg_dir: &Path,
+    rebuild_groups: Vec<(PathBuf, Vec<String>)>,
+) -> miette::Result<()> {
     for (install_dir, build_packages) in rebuild_groups {
         let config = Config::leak(global_group_config(
             base_config,

--- a/pnpm/crates/cli/src/cli_args/import.rs
+++ b/pnpm/crates/cli/src/cli_args/import.rs
@@ -21,12 +21,10 @@ pub struct ImportArgs {
 
 impl ImportArgs {
     pub async fn run<Reporter: self::Reporter + 'static>(self, state: State) -> miette::Result<()> {
-        let State { tarball_mem_cache, http_client, config, manifest, resolved_packages, .. } =
-            &state;
-        let dir = manifest.path().parent().expect("manifest path always has a parent dir");
+        let dir = state.manifest.path().parent().expect("manifest path always has a parent dir");
         let lockfile_dir = state.lockfile_dir();
         let lockfile_path = state.lockfile_path();
-        let env_lockfile = if config.wanted_lockfile_name() == Lockfile::FILE_NAME {
+        let env_lockfile = if state.config.wanted_lockfile_name() == Lockfile::FILE_NAME {
             EnvLockfile::read(lockfile_dir)
                 .into_diagnostic()
                 .wrap_err("reading the env lockfile before import")?
@@ -34,7 +32,9 @@ impl ImportArgs {
             None
         };
 
-        if let Some(pnpr_server) = self.pnpr_server.as_deref().or(config.pnpr_server.as_deref()) {
+        if let Some(pnpr_server) =
+            self.pnpr_server.as_deref().or(state.config.pnpr_server.as_deref())
+        {
             let pnpr_server = redact_url_for_display(pnpr_server);
             pnpm_reporter::emit_global_warning::<Reporter>(&format!(
                 r#""pnpm import" resolves dependencies locally, so the pnpr server at {pnpr_server} is not used"#,
@@ -56,11 +56,11 @@ impl ImportArgs {
         let import_lockfile = pnpm_lockfile::LazyLockfile::preloaded(None);
 
         let install_result = Install {
-            tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
-            http_client,
-            http_client_arc: std::sync::Arc::clone(http_client),
-            config,
-            manifest,
+            tarball_mem_cache: std::sync::Arc::clone(&state.tarball_mem_cache),
+            http_client: &state.http_client,
+            http_client_arc: std::sync::Arc::clone(&state.http_client),
+            config: state.config,
+            manifest: &state.manifest,
             emit_initial_manifest: true,
             lockfile: pnpm_lockfile::MaybeLazyLockfile::Lazy(&import_lockfile),
             lockfile_path: Some(lockfile_path.as_path()),
@@ -73,14 +73,14 @@ impl ImportArgs {
             frozen_lockfile: false,
             prefer_frozen_lockfile: Some(false),
             ignore_manifest_check: false,
-            skip_runtimes: config.skip_runtimes,
+            skip_runtimes: state.config.skip_runtimes,
             trust_lockfile: false,
             update_checksums: false,
             mutation: ProjectMutation::NoInstall,
             installs_only: true,
-            resolved_packages,
-            supported_architectures: config.supported_architectures.clone(),
-            node_linker: config.node_linker,
+            resolved_packages: &state.resolved_packages,
+            supported_architectures: state.config.supported_architectures.clone(),
+            node_linker: state.config.node_linker,
             lockfile_only: true,
             dry_run: false,
             persist_policy_excludes: false,

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -32,6 +32,7 @@ use pnpm_pnpr_client::{
     PnprClient, PnprClientError, ResolveProject, ResolveProjectsOptions, VerifyLockfileOptions,
 };
 use pnpm_reporter::Reporter;
+use std::path::PathBuf;
 
 const BENCHMARK_PNPR_SERVER_REGISTRY_ENV: &str = "PACQUET_BENCHMARK_PNPR_SERVER_REGISTRY";
 const BENCHMARK_PNPR_TARBALL_REWRITE_FROM_ENV: &str = "PACQUET_BENCHMARK_PNPR_TARBALL_REWRITE_FROM";
@@ -507,60 +508,13 @@ impl InstallArgs {
     ) -> miette::Result<()> {
         state.http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
         let frozen_lockfile = self.resolve_frozen_lockfile(&state)?;
-        let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
-            &state;
-        let InstallArgs {
-            dependency_options,
-            supported_architectures,
-            // Layered over the `frozenLockfile` setting above.
-            frozen_lockfile: _,
-            no_frozen_lockfile: _,
-            lockfile_only,
-            fix_lockfile,
-            // Pinned onto `config` in the dispatch (`dispatch_install.rs`)
-            // before the state is built, so the install reads it from
-            // `config`, not from here.
-            lockfile_dir: _,
-            // Resolved against `config.merge_git_branch_lockfiles` by
-            // `apply_install_cli_config` in the dispatch.
-            merge_git_branch_lockfiles: _,
-            merge_git_branch_lockfiles_branch_pattern: _,
-            dry_run,
-            // Resolved against config by `apply_install_cli_config` in
-            // the dispatch, like `ignore_scripts` below.
-            force: _,
-            prefer_frozen_lockfile,
-            no_prefer_frozen_lockfile,
-            verify_deps_before_run_install,
-            ignore_manifest_check,
-            no_runtime,
-            // The `ignore_scripts` / `ignore_pnpmfile` / `offline` /
-            // `frozen_store` / `prefer_offline` flags and their `--no-`
-            // inverses are resolved against config by
-            // `apply_install_cli_config` in the dispatch (`cli_args.rs`),
-            // so the install reads them from `config`, not from here.
-            ignore_scripts: _,
-            no_ignore_scripts: _,
-            ignore_pnpmfile: _,
-            node_linker,
-            offline: _,
-            no_offline: _,
-            frozen_store: _,
-            no_frozen_store: _,
-            prefer_offline: _,
-            no_prefer_offline: _,
-            trust_lockfile,
-            no_trust_lockfile,
-            update_checksums,
-            network_concurrency: _,
-            fetch_timeout: _,
-            fetch_warn_timeout_ms: _,
-            fetch_min_speed_ki_bps: _,
-            user_agent: _,
-            // Read from `config.pnpr_server` (the CLI flag was already
-            // merged in by the dispatch in `cli_args.rs`), not from here.
-            pnpr_server: _,
-        } = self;
+        // The flags read here are the ones the dispatch has not already
+        // folded into `config`: `lockfileDir` is pinned onto it before the
+        // state is built, and `apply_install_cli_config` resolves
+        // `mergeGitBranchLockfiles`, `force`, `ignoreScripts`,
+        // `ignorePnpmfile`, `offline`, `frozenStore`, `preferOffline`, the
+        // network settings and `pnprServer` against it.
+        let config = state.config;
 
         // `--prefer-frozen-lockfile` / `--no-prefer-frozen-lockfile`
         // map to `Option<bool>`: `Some(true)` / `Some(false)` when
@@ -569,9 +523,9 @@ impl InstallArgs {
         // last-specified, so at most one is set and the precedence here
         // is straightforward.
         let prefer_frozen_lockfile = prefer_frozen_lockfile_override(
-            fix_lockfile,
-            prefer_frozen_lockfile,
-            no_prefer_frozen_lockfile,
+            self.fix_lockfile,
+            self.prefer_frozen_lockfile,
+            self.no_prefer_frozen_lockfile,
         );
 
         // Merge CLI overrides with the yaml-derived value before
@@ -581,13 +535,13 @@ impl InstallArgs {
         // in place; the install path takes the merged value as an
         // explicit parameter.
         let supported_architectures =
-            supported_architectures.apply_to(config.supported_architectures.clone());
+            self.supported_architectures.apply_to(config.supported_architectures.clone());
 
         // Either the npmrc/yaml-derived setting or the CLI flag
         // turns runtime-skipping on; pacquet doesn't expose a way
         // to override yaml's `true` back to `false` from the CLI,
         // matching pnpm's stance on the same flag.
-        let skip_runtimes = config.skip_runtimes || no_runtime;
+        let skip_runtimes = config.skip_runtimes || self.no_runtime;
 
         // `--trust-lockfile` / `--no-trust-lockfile` override the yaml
         // `trustLockfile` in either direction; an unset pair falls
@@ -595,13 +549,16 @@ impl InstallArgs {
         // CLI matters for security: a repo-controlled
         // `pnpm-workspace.yaml` can't pin `trustLockfile: true` past a
         // user's explicit `--no-trust-lockfile`.
-        let trust_lockfile =
-            resolve_bool_override(trust_lockfile, no_trust_lockfile, config.trust_lockfile);
+        let trust_lockfile = resolve_bool_override(
+            self.trust_lockfile,
+            self.no_trust_lockfile,
+            config.trust_lockfile,
+        );
 
         // `--node-linker` flag (if passed) overrides the
         // yaml/npmrc value for this invocation. Mirrors pnpm's
         // override-on-explicit-flag semantics.
-        let node_linker = node_linker.map_or(config.node_linker, NodeLinkerArg::into_config);
+        let node_linker = self.node_linker.map_or(config.node_linker, NodeLinkerArg::into_config);
         let lockfile_path = state.lockfile_path();
 
         // pnpr fast path: when a `pnprServer` URL is configured, offload
@@ -611,7 +568,7 @@ impl InstallArgs {
             // The pnpr path resolves and links through the server, so it
             // can't honor `--dry-run`'s no-write contract. Reject up front,
             // mirroring pnpm's CONFIG_CONFLICT_DRY_RUN_WITH_PNPR_SERVER.
-            if dry_run {
+            if self.dry_run {
                 return Err(DryRunIncompatibleWithPnpr.into());
             }
             return Box::pin(install_via_pnpr_inner::<Reporter>(
@@ -619,7 +576,8 @@ impl InstallArgs {
                 pnpr_server,
                 selection.as_ref(),
                 PnprLink {
-                    dependency_groups: dependency_options
+                    dependency_groups: self
+                        .dependency_options
                         .dependency_groups(config.optional)
                         .collect(),
                     supported_architectures,
@@ -629,9 +587,9 @@ impl InstallArgs {
                     prefer_frozen_lockfile: prefer_frozen_lockfile
                         .unwrap_or(config.prefer_frozen_lockfile),
                     update_patches: false,
-                    fix_lockfile,
-                    lockfile_only,
-                    ignore_manifest_check,
+                    fix_lockfile: self.fix_lockfile,
+                    lockfile_only: self.lockfile_only,
+                    ignore_manifest_check: self.ignore_manifest_check,
                     trust_lockfile,
                     lockfile_path: Some(&lockfile_path),
                     use_state_lockfile: true,
@@ -640,36 +598,36 @@ impl InstallArgs {
             .await;
         }
 
-        let install_lockfile = if fix_lockfile {
-            MaybeLazyLockfile::Repair(lockfile)
+        let install_lockfile = if self.fix_lockfile {
+            MaybeLazyLockfile::Repair(&state.lockfile)
         } else {
-            MaybeLazyLockfile::Lazy(lockfile)
+            MaybeLazyLockfile::Lazy(&state.lockfile)
         };
         let install = Install {
-            tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
-            http_client,
-            http_client_arc: std::sync::Arc::clone(http_client),
+            tarball_mem_cache: std::sync::Arc::clone(&state.tarball_mem_cache),
+            http_client: &state.http_client,
+            http_client_arc: std::sync::Arc::clone(&state.http_client),
             config,
-            manifest,
+            manifest: &state.manifest,
             emit_initial_manifest: true,
             lockfile: install_lockfile,
             lockfile_path: Some(&lockfile_path),
-            dependency_groups: dependency_options.dependency_groups(config.optional),
+            dependency_groups: self.dependency_options.dependency_groups(config.optional),
             frozen_lockfile,
             prefer_frozen_lockfile,
-            ignore_manifest_check,
+            ignore_manifest_check: self.ignore_manifest_check,
             skip_runtimes,
             trust_lockfile,
-            update_checksums,
+            update_checksums: self.update_checksums,
             mutation: ProjectMutation::InstallWorkspace,
             installs_only: true,
-            resolved_packages,
+            resolved_packages: &state.resolved_packages,
             supported_architectures,
             node_linker,
-            lockfile_only,
-            dry_run,
+            lockfile_only: self.lockfile_only,
+            dry_run: self.dry_run,
             persist_policy_excludes: true,
-            update_seed_policy: if fix_lockfile {
+            update_seed_policy: if self.fix_lockfile {
                 UpdateSeedPolicy::FixLockfile
             } else {
                 UpdateSeedPolicy::KeepAll
@@ -680,7 +638,7 @@ impl InstallArgs {
             peer_issues_sink: None,
             deps_requiring_build_sink: None,
             catalogs_override: None,
-            disable_optimistic_repeat_install: verify_deps_before_run_install,
+            disable_optimistic_repeat_install: self.verify_deps_before_run_install,
             pnpmfile_hook_override: None,
             workspace_projects_override: None,
         };
@@ -697,9 +655,7 @@ impl InstallArgs {
         // The resolution channel map stays out: dropping it closes its
         // watch senders, a signal `background_drop`'s contract
         // excludes, so it drops inline here with the rest.
-        let State { tarball_mem_cache: _, http_client: _, config: _, manifest, lockfile, .. } =
-            state;
-        pnpm_fs::background_drop((lockfile, manifest, selection));
+        pnpm_fs::background_drop((state.lockfile, state.manifest, selection));
         Ok(())
     }
     /// Whether this install runs frozen.
@@ -925,9 +881,119 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
     let lockfile_dir = link.lockfile_path.and_then(|path| path.parent()).unwrap_or_else(|| {
         state.manifest.path().parent().expect("manifest path always has a parent dir")
     });
+    let mut session =
+        prepare_pnpr_session::<Reporter>(state, selection, &link, lockfile_dir).await?;
+    let mut inputs = pnpr_request_inputs(state, &link, lockfile_dir).await?;
 
-    let previous_wanted = load_previous_wanted::<Reporter>(state, &link, lockfile_dir)?;
-    let merge_wanted = merge_source(state, &link, previous_wanted)?;
+    if (session.satisfied_without_server
+        || (link.frozen_lockfile && (selection.is_some() || !link.lockfile_only)))
+        && let Some(lockfile) = session.previous_wanted
+    {
+        return install_from_local_lockfile::<Reporter>(
+            state,
+            pnpr_server,
+            selection,
+            &link,
+            &LocalLockfileInstall {
+                lockfile,
+                lockfile_dir,
+                lockfile_path: &inputs.lockfile_path,
+                selection_importer_ids: session.selection_importer_ids.as_ref(),
+                overrides: inputs.overrides.as_ref(),
+                resolve_registry: &inputs.resolve_registry,
+                prefetch_allowed: inputs.prefetch_allowed,
+                pnpmfile_hook: inputs.pnpmfile_hook,
+            },
+        )
+        .await;
+    }
+
+    let opts = resolve_projects_options(state, pnpr_server, &link, &mut session, &mut inputs);
+    let (mut outcome, prefetcher) = resolve_via_pnpr(
+        state,
+        pnpr_server,
+        opts,
+        inputs.benchmark_registry_override.as_ref(),
+        ResolveStreaming {
+            lockfile_dir,
+            lockfile_only: link.lockfile_only,
+            partial_selection: session.partial_selection,
+            prefetch_allowed: inputs.prefetch_allowed,
+        },
+    )
+    .await?;
+
+    if let Some(registry) = inputs.benchmark_registry_override.as_ref() {
+        registry.rewrite_lockfile(&mut outcome.lockfile);
+    }
+    outcome.lockfile = merge_selected_importers(
+        state,
+        selection,
+        session.selection_importer_ids.as_ref().or(session.full_workspace_importer_ids.as_ref()),
+        session.merge_wanted,
+        outcome.lockfile,
+    )?;
+    let merged_repair_verifiers = verify_merged_repair::<Reporter>(
+        state,
+        &link,
+        session.partial_selection,
+        &outcome.lockfile,
+    )
+    .await?;
+
+    save_pnpr_lockfile(
+        state,
+        &link,
+        &outcome.lockfile,
+        &inputs.lockfile_path,
+        merged_repair_verifiers.as_deref(),
+    )?;
+
+    // `--lockfile-only`: the server resolved and returned the lockfile
+    // but fetched nothing; pnpm links nothing in this mode, so stop after
+    // writing the lockfile rather than running the materialization pass.
+    // See [pnpm/pnpm#12146](https://github.com/pnpm/pnpm/issues/12146).
+    if link.lockfile_only {
+        return Ok(());
+    }
+
+    link_pnpr_lockfile::<Reporter>(state, selection, link, &outcome.lockfile, inputs.pnpmfile_hook)
+        .await?;
+
+    // The materialization install has awaited every tarball's mem-cache
+    // slot, so all prefetch downloads have finished and queued their
+    // store-index rows. Drain the writer so those rows are persisted for
+    // the next install before returning.
+    if let Some(prefetcher) = prefetcher {
+        prefetcher.shutdown().await;
+    }
+
+    Ok(())
+}
+
+/// What the pnpr path knows about the workspace before deciding whether the
+/// server has to resolve anything.
+struct PnprSession<'a> {
+    previous_wanted: Option<&'a Lockfile>,
+    merge_wanted: Option<&'a Lockfile>,
+    selection_importer_ids:
+        Option<(std::collections::HashSet<String>, std::collections::HashSet<String>)>,
+    partial_selection: bool,
+    projects: Vec<ResolveProject>,
+    full_workspace_importer_ids:
+        Option<(std::collections::HashSet<String>, std::collections::HashSet<String>)>,
+    catalogs: Option<Catalogs>,
+    satisfied_without_server: bool,
+}
+
+async fn prepare_pnpr_session<'a, Reporter: self::Reporter + 'static>(
+    state: &'a State,
+    selection: Option<&InstallFamilySelection>,
+    link: &PnprLink<'_>,
+    lockfile_dir: &std::path::Path,
+) -> miette::Result<PnprSession<'a>> {
+    let previous_wanted = load_previous_wanted::<Reporter>(state, link, lockfile_dir)?;
+    let merge_wanted = merge_source(state, link, previous_wanted)?;
 
     let selection_importer_ids = selection_importer_ids(state, selection);
     let partial_selection = selection_importer_ids.as_ref().is_some_and(
@@ -935,19 +1001,48 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
     );
     let projects = resolve_projects_for_pnpr(state, selection, link.use_state_lockfile)?;
     let full_workspace_importer_ids =
-        full_workspace_importer_ids(state, selection, &link, &projects);
+        full_workspace_importer_ids(state, selection, link, &projects);
 
     let catalogs = pnpr_catalogs(state)?;
 
     let satisfied_without_server = satisfied_without_server(
         state,
-        &link,
+        link,
         previous_wanted,
         catalogs.as_ref(),
         partial_selection,
     )
     .await;
+    Ok(PnprSession {
+        previous_wanted,
+        merge_wanted,
+        selection_importer_ids,
+        partial_selection,
+        projects,
+        full_workspace_importer_ids,
+        catalogs,
+        satisfied_without_server,
+    })
+}
 
+/// The request-side inputs both pnpr paths need: the client policy the
+/// server resolves under, and the lockfile path and pnpmfile the local link
+/// runs with.
+struct PnprRequestInputs {
+    overrides: Option<serde_json::Value>,
+    patched_dependencies: Option<indexmap::IndexMap<String, String>>,
+    benchmark_registry_override: Option<PnprBenchmarkRegistryOverride>,
+    resolve_registry: String,
+    pnpmfile_hook: Option<std::sync::Arc<dyn pnpm_hooks::PnpmfileHooks>>,
+    prefetch_allowed: bool,
+    lockfile_path: PathBuf,
+}
+
+async fn pnpr_request_inputs(
+    state: &State,
+    link: &PnprLink<'_>,
+    lockfile_dir: &std::path::Path,
+) -> miette::Result<PnprRequestInputs> {
     let overrides = state
         .config
         .overrides
@@ -970,55 +1065,49 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
         || lockfile_dir.join(state.config.wanted_lockfile_name()),
         std::path::Path::to_path_buf,
     );
+    Ok(PnprRequestInputs {
+        overrides,
+        patched_dependencies,
+        benchmark_registry_override,
+        resolve_registry,
+        pnpmfile_hook,
+        prefetch_allowed,
+        lockfile_path,
+    })
+}
 
-    if (satisfied_without_server
-        || (link.frozen_lockfile && (selection.is_some() || !link.lockfile_only)))
-        && let Some(lockfile) = previous_wanted
-    {
-        return install_from_local_lockfile::<Reporter>(
-            state,
-            pnpr_server,
-            selection,
-            &link,
-            &LocalLockfileInstall {
-                lockfile,
-                lockfile_dir,
-                lockfile_path: &lockfile_path,
-                selection_importer_ids: selection_importer_ids.as_ref(),
-                overrides: overrides.as_ref(),
-                resolve_registry: &resolve_registry,
-                prefetch_allowed,
-                pnpmfile_hook,
-            },
-        )
-        .await;
-    }
-
-    // Send the on-disk lockfile + the full client policy so the server
-    // verifies the input lockfile under *our* policy before resolving;
-    // the client never runs `verify_lockfile_resolutions` on the pnpr
-    // path ([pnpm/pnpm#12139](https://github.com/pnpm/pnpm/issues/12139)).
-    // `trustPolicy: no-downgrade` is enforced
-    // server-side — both for reused entries (the input-lockfile
-    // verifier) and freshly-resolved ones (the resolver's pick-time
-    // gate, since the policy is wired into the server's config).
-    let opts = ResolveProjectsOptions {
-        projects,
-        registry: resolve_registry,
+/// Send the on-disk lockfile + the full client policy so the server
+/// verifies the input lockfile under *our* policy before resolving;
+/// the client never runs `verify_lockfile_resolutions` on the pnpr
+/// path ([pnpm/pnpm#12139](https://github.com/pnpm/pnpm/issues/12139)).
+/// `trustPolicy: no-downgrade` is enforced
+/// server-side — both for reused entries (the input-lockfile
+/// verifier) and freshly-resolved ones (the resolver's pick-time
+/// gate, since the policy is wired into the server's config).
+fn resolve_projects_options(
+    state: &State,
+    pnpr_server: &str,
+    link: &PnprLink<'_>,
+    session: &mut PnprSession<'_>,
+    inputs: &mut PnprRequestInputs,
+) -> ResolveProjectsOptions {
+    ResolveProjectsOptions {
+        projects: std::mem::take(&mut session.projects),
+        registry: std::mem::take(&mut inputs.resolve_registry),
         registries: state.config.registry_declarations(),
         // Only the caller's identity to pnpr is sent. Upstream registry
         // credentials are never forwarded: pnpr selects them from its own
         // route policy, so they stay out of the request body.
         authorization: state.config.auth_headers.for_url(pnpr_server),
-        overrides,
-        patched_dependencies,
+        overrides: inputs.overrides.take(),
+        patched_dependencies: inputs.patched_dependencies.take(),
         package_extensions: state.config.package_extensions.clone(),
         allow_unused_patches: state.config.allow_unused_patches,
-        catalogs,
+        catalogs: session.catalogs.take(),
         auto_install_peers: Some(state.config.auto_install_peers),
         dedupe_peers: Some(state.config.dedupe_peers),
         exclude_links_from_lockfile: Some(state.config.exclude_links_from_lockfile),
-        lockfile: previous_wanted.cloned(),
+        lockfile: session.previous_wanted.cloned(),
         frozen_lockfile: link.frozen_lockfile,
         prefer_frozen_lockfile: Some(link.prefer_frozen_lockfile),
         update_patches: link.update_patches,
@@ -1034,51 +1123,18 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
         trust_policy: state.config.trust_policy,
         trust_policy_exclude: state.config.trust_policy_exclude.clone(),
         trust_policy_ignore_after: state.config.trust_policy_ignore_after,
-    };
-    let (mut outcome, prefetcher) = resolve_via_pnpr(
-        state,
-        pnpr_server,
-        opts,
-        benchmark_registry_override.as_ref(),
-        ResolveStreaming {
-            lockfile_dir,
-            lockfile_only: link.lockfile_only,
-            partial_selection,
-            prefetch_allowed,
-        },
-    )
-    .await?;
-
-    if let Some(registry) = benchmark_registry_override.as_ref() {
-        registry.rewrite_lockfile(&mut outcome.lockfile);
     }
-    outcome.lockfile = merge_selected_importers(
-        state,
-        selection,
-        selection_importer_ids.as_ref().or(full_workspace_importer_ids.as_ref()),
-        merge_wanted,
-        outcome.lockfile,
-    )?;
-    let merged_repair_verifiers =
-        verify_merged_repair::<Reporter>(state, &link, partial_selection, &outcome.lockfile)
-            .await?;
+}
 
-    save_pnpr_lockfile(
-        state,
-        &link,
-        &outcome.lockfile,
-        &lockfile_path,
-        merged_repair_verifiers.as_deref(),
-    )?;
-
-    // `--lockfile-only`: the server resolved and returned the lockfile
-    // but fetched nothing; pnpm links nothing in this mode, so stop after
-    // writing the lockfile rather than running the materialization pass.
-    // See [pnpm/pnpm#12146](https://github.com/pnpm/pnpm/issues/12146).
-    if link.lockfile_only {
-        return Ok(());
-    }
-
+/// Link `node_modules` from the server-produced lockfile through the normal
+/// frozen install.
+async fn link_pnpr_lockfile<Reporter: self::Reporter + 'static>(
+    state: &State,
+    selection: Option<&InstallFamilySelection>,
+    link: PnprLink<'_>,
+    lockfile: &Lockfile,
+    pnpmfile_hook: Option<std::sync::Arc<dyn pnpm_hooks::PnpmfileHooks>>,
+) -> miette::Result<()> {
     let install = Install {
         tarball_mem_cache: std::sync::Arc::clone(&state.tarball_mem_cache),
         http_client: &state.http_client,
@@ -1086,7 +1142,7 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
         config: state.config,
         manifest: &state.manifest,
         emit_initial_manifest: true,
-        lockfile: MaybeLazyLockfile::Loaded(Some(&outcome.lockfile)),
+        lockfile: MaybeLazyLockfile::Loaded(Some(lockfile)),
         lockfile_path: link.lockfile_path,
         dependency_groups: link.dependency_groups,
         frozen_lockfile: true,
@@ -1126,17 +1182,7 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
         }
         None => install.run::<Reporter>().await,
     }
-    .wrap_err("linking dependencies resolved via the pnpr server")?;
-
-    // The materialization install has awaited every tarball's mem-cache
-    // slot, so all prefetch downloads have finished and queued their
-    // store-index rows. Drain the writer so those rows are persisted for
-    // the next install before returning.
-    if let Some(prefetcher) = prefetcher {
-        prefetcher.shutdown().await;
-    }
-
-    Ok(())
+    .wrap_err("linking dependencies resolved via the pnpr server")
 }
 
 /// Fold the server's answer for the selected importers back into the

--- a/pnpm/crates/cli/src/cli_args/lane.rs
+++ b/pnpm/crates/cli/src/cli_args/lane.rs
@@ -80,18 +80,8 @@ impl LaneArgs {
         let (projects, _) = discover_workspace_projects(&workspace_dir, config)?;
         let engine_projects = to_engine_projects(&projects);
         let refs = pnpm_versioning::index_project_refs(&engine_projects, &workspace_dir);
-        let releasable_dirs: HashSet<String> =
-            releasable_projects(&engine_projects, &workspace_dir, &config.versioning)
-                .into_iter()
-                .map(|project| project.dir)
-                .collect();
-        // (name, dir) of every selected releasable project, with the
-        // reference an intent or lanes entry should use for it.
-        let selected: Vec<(String, String, String)> =
-            selected_projects(&projects, config, &workspace_dir)?
-                .into_iter()
-                .filter_map(|(name, dir)| selected_entry(&refs, &releasable_dirs, name, dir))
-                .collect();
+        let selected =
+            selected_lane_entries(&projects, &engine_projects, config, &workspace_dir, &refs)?;
         if selected.is_empty() {
             return Err(LaneError::NoPackagesSelected.into());
         }
@@ -99,12 +89,7 @@ impl LaneArgs {
         let lane_by_dir = lanes_by_dir(&config.versioning, &refs);
 
         let mut settings: VersioningSettings = config.versioning.clone();
-        let selected_lines: String =
-            selected.iter().fold(String::new(), |mut lines, (_, _, reference)| {
-                use std::fmt::Write as _;
-                writeln!(lines, "  {reference}").expect("write to string");
-                lines
-            });
+        let selected_lines = selected_reference_lines(&selected);
         let output = if lane_name == MAIN_LANE {
             clear_lanes(&mut settings, &selected, &lane_by_dir);
             format!(
@@ -117,15 +102,51 @@ impl LaneArgs {
             format!("Moved to the \"{lane_name}\" lane:\n{selected_lines}")
         };
 
-        let value = if settings.is_empty() {
-            serde_json::Value::Null
-        } else {
-            serde_json::to_value(&settings).expect("versioning settings serialize to JSON")
-        };
-        update_manifest_field(&workspace_dir.join("pnpm-workspace.yaml"), "versioning", &value)
-            .map_err(miette::Report::new)?;
+        update_manifest_field(
+            &workspace_dir.join("pnpm-workspace.yaml"),
+            "versioning",
+            &versioning_value(&settings),
+        )
+        .map_err(miette::Report::new)?;
         println!("{output}");
         Ok(())
+    }
+}
+
+/// (name, dir) of every selected releasable project, with the reference an
+/// intent or lanes entry should use for it.
+fn selected_lane_entries(
+    projects: &[pnpm_workspace::Project],
+    engine_projects: &[pnpm_versioning::WorkspaceProject],
+    config: &Config,
+    workspace_dir: &std::path::Path,
+    refs: &pnpm_versioning::ProjectRefIndex,
+) -> miette::Result<Vec<(String, String, String)>> {
+    let releasable_dirs: HashSet<String> =
+        releasable_projects(engine_projects, workspace_dir, &config.versioning)
+            .into_iter()
+            .map(|project| project.dir)
+            .collect();
+    Ok(selected_projects(projects, config, workspace_dir)?
+        .into_iter()
+        .filter_map(|(name, dir)| selected_entry(refs, &releasable_dirs, name, dir))
+        .collect())
+}
+
+fn selected_reference_lines(selected: &[(String, String, String)]) -> String {
+    selected.iter().fold(String::new(), |mut lines, (_, _, reference)| {
+        use std::fmt::Write as _;
+        writeln!(lines, "  {reference}").expect("write to string");
+        lines
+    })
+}
+
+/// The `versioning` setting to write back: absent once nothing is set.
+fn versioning_value(settings: &VersioningSettings) -> serde_json::Value {
+    if settings.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::to_value(settings).expect("versioning settings serialize to JSON")
     }
 }
 

--- a/pnpm/crates/cli/src/cli_args/licenses.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses.rs
@@ -166,22 +166,7 @@ impl LicensesArgs {
                 ..Default::default()
             },
         );
-        let allow_build_policy = AllowBuildPolicy::from_config(config).into_diagnostic()?;
-        let project_manifest = safe_read_package_json_from_dir(dir).into_diagnostic()?;
-        let manifest_node_version =
-            project_manifest.as_ref().and_then(node_version_from_engines_runtime);
-        let effective_node_version =
-            config.node_version.as_deref().or(manifest_node_version.as_deref());
-        let layout = virtual_store_layout_for_lockfile(
-            config,
-            effective_node_version,
-            lockfile.snapshots.as_ref(),
-            lockfile.packages.as_ref(),
-            Some(&allow_build_policy),
-            Some(lockfile_dir),
-        );
-        validate_virtual_store_slot_containment(lockfile.snapshots.as_ref(), &layout)
-            .into_diagnostic()?;
+        let layout = lockfile_layout(config, dir, lockfile_dir, &lockfile)?;
 
         let dependencies = sorted_licensed_dependencies(&lockfile, belongs_to);
 
@@ -196,28 +181,60 @@ impl LicensesArgs {
             return Ok(());
         }
 
-        let mut header: Vec<String> = vec!["Package".to_string(), "License".to_string()];
-        if self.long {
-            header.push("Details".to_string());
-        }
-
-        let mut builder = Builder::default();
-        builder.push_record(header);
-        for info in sorted_license_infos(&results_by_license) {
-            let mut row =
-                vec![render_package_name(info), sanitize_inline(&info.license).into_owned()];
-            if self.long {
-                row.push(render_license_details(info));
-            }
-            builder.push_record(row);
-        }
-
-        let mut table = builder.build();
-        table.with(Style::modern());
-        println!("{table}");
-
+        print_license_table(&results_by_license, self.long);
         Ok(())
     }
+}
+
+/// Where each locked package's files live, checked to sit inside the
+/// virtual store.
+fn lockfile_layout(
+    config: &Config,
+    dir: &std::path::Path,
+    lockfile_dir: &std::path::Path,
+    lockfile: &Lockfile,
+) -> miette::Result<pnpm_deps_restorer::VirtualStoreLayout> {
+    let allow_build_policy = AllowBuildPolicy::from_config(config).into_diagnostic()?;
+    let project_manifest = safe_read_package_json_from_dir(dir).into_diagnostic()?;
+    let manifest_node_version =
+        project_manifest.as_ref().and_then(node_version_from_engines_runtime);
+    let effective_node_version =
+        config.node_version.as_deref().or(manifest_node_version.as_deref());
+    let layout = virtual_store_layout_for_lockfile(
+        config,
+        effective_node_version,
+        lockfile.snapshots.as_ref(),
+        lockfile.packages.as_ref(),
+        Some(&allow_build_policy),
+        Some(lockfile_dir),
+    );
+    validate_virtual_store_slot_containment(lockfile.snapshots.as_ref(), &layout)
+        .into_diagnostic()?;
+    Ok(layout)
+}
+
+fn print_license_table(
+    results_by_license: &IndexMap<String, BTreeMap<String, LicenseInfo>>,
+    long: bool,
+) {
+    let mut header: Vec<String> = vec!["Package".to_string(), "License".to_string()];
+    if long {
+        header.push("Details".to_string());
+    }
+
+    let mut builder = Builder::default();
+    builder.push_record(header);
+    for info in sorted_license_infos(results_by_license) {
+        let mut row = vec![render_package_name(info), sanitize_inline(&info.license).into_owned()];
+        if long {
+            row.push(render_license_details(info));
+        }
+        builder.push_record(row);
+    }
+
+    let mut table = builder.build();
+    table.with(Style::modern());
+    println!("{table}");
 }
 
 /// `pnpm licenses` takes exactly one subcommand, `list` (or `ls`).

--- a/pnpm/crates/cli/src/cli_args/link.rs
+++ b/pnpm/crates/cli/src/cli_args/link.rs
@@ -88,21 +88,7 @@ impl LinkArgs {
 
         let mut new_overrides = IndexMap::<String, String>::new();
         for path_str in &self.package_paths {
-            let target_path = PathBuf::from(path_str);
-            let target_dir = if target_path.is_absolute() {
-                target_path.clone()
-            } else {
-                manifest_dir.join(&target_path)
-            };
-
-            let target_manifest_path = target_dir.join("package.json");
-            let dir_display = target_dir.display();
-            let target_manifest = PackageManifest::from_path(target_manifest_path)
-                .map_err(|_| miette::miette!("No package.json found in {}", dir_display))?;
-            let package_name = target_manifest.value()["name"]
-                .as_str()
-                .ok_or_else(|| miette::miette!("Target package does not have a name field"))?
-                .to_string();
+            let (target_dir, package_name) = link_target(&manifest_dir, path_str)?;
 
             if !already_declared(&manifest, &package_name) {
                 manifest
@@ -118,61 +104,79 @@ impl LinkArgs {
 
         manifest.save().wrap_err("saving package.json with linked dependencies")?;
 
-        set_overrides(&root_dir, new_overrides.iter().map(|(k, v)| (k.as_str(), v.as_str())))
-            .wrap_err("recording linked dependencies in pnpm-workspace.yaml")?;
+        set_overrides(
+            &root_dir,
+            new_overrides
+                .iter()
+                .map(|(selector, specifier)| (selector.as_str(), specifier.as_str())),
+        )
+        .wrap_err("recording linked dependencies in pnpm-workspace.yaml")?;
 
-        let overrides = config.overrides.get_or_insert_with(IndexMap::new);
-        for (selector, specifier) in &new_overrides {
-            overrides.insert(selector.clone(), specifier.clone());
-        }
+        config.overrides.get_or_insert_with(IndexMap::new).extend(
+            new_overrides.iter().map(|(selector, specifier)| (selector.clone(), specifier.clone())),
+        );
 
         let state = State::init(manifest_path, config, false).wrap_err("initialize the state")?;
-        let lockfile_path = state.lockfile_path();
-        let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
-            &state;
-
-        Install {
-            tarball_mem_cache: Arc::clone(tarball_mem_cache),
-            http_client,
-            http_client_arc: Arc::clone(http_client),
-            config,
-            manifest,
-            emit_initial_manifest: true,
-            lockfile: pnpm_lockfile::MaybeLazyLockfile::Lazy(lockfile),
-            lockfile_path: Some(&lockfile_path),
-            dependency_groups: [
-                DependencyGroup::Prod,
-                DependencyGroup::Dev,
-                DependencyGroup::Optional,
-            ]
-            .into_iter(),
-            frozen_lockfile: false,
-            prefer_frozen_lockfile: Some(false),
-            ignore_manifest_check: false,
-            skip_runtimes: config.skip_runtimes,
-            trust_lockfile: config.trust_lockfile,
-            update_checksums: false,
-            mutation: ProjectMutation::NoInstall,
-            installs_only: false,
-            resolved_packages,
-            supported_architectures: config.supported_architectures.clone(),
-            node_linker: config.node_linker,
-            lockfile_only: false,
-            dry_run: false,
-            persist_policy_excludes: false,
-            disable_optimistic_repeat_install: false,
-            pnpmfile_hook_override: None,
-            workspace_projects_override: None,
-            update_seed_policy: UpdateSeedPolicy::KeepAll,
-            preferred_versions_override: None,
-            auth_override: None,
-            resolution_observer: None,
-            peer_issues_sink: None,
-            deps_requiring_build_sink: None,
-            catalogs_override: None,
-        }
-        .run::<Reporter>()
-        .await
-        .wrap_err("linking dependencies")
+        install_linked::<Reporter>(&state).await
     }
+}
+
+/// Install with the linked dependencies' overrides in place.
+async fn install_linked<Reporter: self::Reporter + 'static>(state: &State) -> miette::Result<()> {
+    let lockfile_path = state.lockfile_path();
+    Install {
+        tarball_mem_cache: Arc::clone(&state.tarball_mem_cache),
+        http_client: &state.http_client,
+        http_client_arc: Arc::clone(&state.http_client),
+        config: state.config,
+        manifest: &state.manifest,
+        emit_initial_manifest: true,
+        lockfile: pnpm_lockfile::MaybeLazyLockfile::Lazy(&state.lockfile),
+        lockfile_path: Some(&lockfile_path),
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional]
+            .into_iter(),
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: Some(false),
+        ignore_manifest_check: false,
+        skip_runtimes: state.config.skip_runtimes,
+        trust_lockfile: state.config.trust_lockfile,
+        update_checksums: false,
+        mutation: ProjectMutation::NoInstall,
+        installs_only: false,
+        resolved_packages: &state.resolved_packages,
+        supported_architectures: state.config.supported_architectures.clone(),
+        node_linker: state.config.node_linker,
+        lockfile_only: false,
+        dry_run: false,
+        persist_policy_excludes: false,
+        disable_optimistic_repeat_install: false,
+        pnpmfile_hook_override: None,
+        workspace_projects_override: None,
+        update_seed_policy: UpdateSeedPolicy::KeepAll,
+        preferred_versions_override: None,
+        auth_override: None,
+        resolution_observer: None,
+        peer_issues_sink: None,
+        deps_requiring_build_sink: None,
+        catalogs_override: None,
+    }
+    .run::<Reporter>()
+    .await
+    .wrap_err("linking dependencies")
+}
+
+/// The linked package's directory, and the name it is declared under.
+fn link_target(manifest_dir: &Path, path_str: &str) -> miette::Result<(PathBuf, String)> {
+    let target_path = PathBuf::from(path_str);
+    let target_dir =
+        if target_path.is_absolute() { target_path } else { manifest_dir.join(&target_path) };
+    let target_manifest_path = target_dir.join("package.json");
+    let dir_display = target_dir.display();
+    let target_manifest = PackageManifest::from_path(target_manifest_path)
+        .map_err(|_| miette::miette!("No package.json found in {}", dir_display))?;
+    let package_name = target_manifest.value()["name"]
+        .as_str()
+        .ok_or_else(|| miette::miette!("Target package does not have a name field"))?
+        .to_string();
+    Ok((target_dir, package_name))
 }

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -253,80 +253,98 @@ pub(crate) async fn collect_outdated_for_importer_in_run(
                     return None;
                 }
                 let current = current_versions.get(alias).cloned()?;
-                Some((alias, group, bare_specifier, current))
+                Some(OutdatedCandidate { alias, group, bare_specifier, current })
             })
         })
-        .map(|(alias, group, bare_specifier, current)| async move {
-            let bare_specifier = dereference_catalog(&run.catalogs, alias, bare_specifier)?;
-            let resolved_package_name =
-                PackageManifest::resolve_registry_dependency(alias, &bare_specifier).0.to_string();
-            let latest = run
-                .resolver
-                .resolve_latest(
-                    &LatestQuery {
-                        wanted_dependency: ResolverWantedDependency {
-                            alias: Some(alias.to_string()),
-                            bare_specifier: Some(bare_specifier.into_owned()),
-                            optional: Some(group == DependencyGroup::Optional),
-                            ..ResolverWantedDependency::default()
-                        },
-                        compatible: matches!(query.target_version, TargetVersion::WithinRange),
-                    },
-                    &run.resolve_options,
-                )
-                .await
-                .map_err(|error| {
-                    let reason = pnpm_network::redact_url_credentials(&error.to_string());
-                    miette::miette!(
-                        code = "ERR_PNPM_OUTDATED_REGISTRY_ERROR",
-                        r#"Failed to fetch metadata for "{resolved_package_name}": {reason}"#,
-                    )
-                })?;
-            let Some(target_manifest) = latest.and_then(|latest| latest.latest_manifest) else {
-                return Ok(None);
-            };
-            let Some(target) = target_manifest
-                .get("version")
-                .and_then(serde_json::Value::as_str)
-                .and_then(|version| version.parse::<Version>().ok())
-            else {
-                return Ok(None);
-            };
-            let deprecated = target_manifest
-                .get("deprecated")
-                .and_then(serde_json::Value::as_str)
-                .map(str::to_string);
-            let is_newer = target > current;
-            if !(is_newer || (query.include_deprecated && deprecated.is_some())) {
-                return Ok(None);
-            }
-            let package_name = target_manifest
-                .get("name")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or(&resolved_package_name)
-                .to_string();
-            Ok(Some(OutdatedPackage {
-                alias: alias.to_string(),
-                package_name,
-                belongs_to: group,
-                wanted: current.clone(),
-                current,
-                target,
-                github_action: false,
-                deprecated,
-                homepage: target_manifest
-                    .get("homepage")
-                    .and_then(serde_json::Value::as_str)
-                    .map(str::to_string),
-                workspace: Some(workspace.clone()),
-            }))
-        });
+        .map(|candidate| outdated_dependency(run, query, workspace, candidate));
 
     let fetched = futures_util::future::join_all(fetches)
         .await
         .into_iter()
         .collect::<miette::Result<Vec<_>>>()?;
     Ok(fetched.into_iter().flatten().collect())
+}
+
+/// One lockfile-pinned direct dependency to compare against the registry.
+struct OutdatedCandidate<'a> {
+    alias: &'a str,
+    group: DependencyGroup,
+    bare_specifier: &'a str,
+    current: Version,
+}
+
+/// The dependency's outdated entry: `None` when the registry names no
+/// target, or the target is neither newer nor (when asked) deprecated.
+async fn outdated_dependency(
+    run: &OutdatedRun,
+    query: &OutdatedQuery<'_>,
+    workspace: &str,
+    candidate: OutdatedCandidate<'_>,
+) -> miette::Result<Option<OutdatedPackage>> {
+    let bare_specifier =
+        dereference_catalog(&run.catalogs, candidate.alias, candidate.bare_specifier)?;
+    let resolved_package_name =
+        PackageManifest::resolve_registry_dependency(candidate.alias, &bare_specifier)
+            .0
+            .to_string();
+    let latest = run
+        .resolver
+        .resolve_latest(
+            &LatestQuery {
+                wanted_dependency: ResolverWantedDependency {
+                    alias: Some(candidate.alias.to_string()),
+                    bare_specifier: Some(bare_specifier.into_owned()),
+                    optional: Some(candidate.group == DependencyGroup::Optional),
+                    ..ResolverWantedDependency::default()
+                },
+                compatible: matches!(query.target_version, TargetVersion::WithinRange),
+            },
+            &run.resolve_options,
+        )
+        .await
+        .map_err(|error| {
+            let reason = pnpm_network::redact_url_credentials(&error.to_string());
+            miette::miette!(
+                code = "ERR_PNPM_OUTDATED_REGISTRY_ERROR",
+                r#"Failed to fetch metadata for "{resolved_package_name}": {reason}"#,
+            )
+        })?;
+    let Some(target_manifest) = latest.and_then(|latest| latest.latest_manifest) else {
+        return Ok(None);
+    };
+    let Some(target) = target_manifest
+        .get("version")
+        .and_then(serde_json::Value::as_str)
+        .and_then(|version| version.parse::<Version>().ok())
+    else {
+        return Ok(None);
+    };
+    let deprecated =
+        target_manifest.get("deprecated").and_then(serde_json::Value::as_str).map(str::to_string);
+    let is_newer = target > candidate.current;
+    if !(is_newer || (query.include_deprecated && deprecated.is_some())) {
+        return Ok(None);
+    }
+    let package_name = target_manifest
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or(&resolved_package_name)
+        .to_string();
+    Ok(Some(OutdatedPackage {
+        alias: candidate.alias.to_string(),
+        package_name,
+        belongs_to: candidate.group,
+        wanted: candidate.current.clone(),
+        current: candidate.current,
+        target,
+        github_action: false,
+        deprecated,
+        homepage: target_manifest
+            .get("homepage")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+        workspace: Some(workspace.to_string()),
+    }))
 }
 
 /// Replace a `catalog:` specifier with the specifier the catalog holds,
@@ -505,48 +523,25 @@ impl OutdatedArgs {
 
         let config = state.config;
         let manifest = &state.manifest;
-        let root = config
-            .workspace_dir
-            .as_deref()
-            .unwrap_or_else(|| manifest.path().parent().unwrap_or_else(|| manifest.path()));
+        let root = config.workspace_dir.as_deref().unwrap_or_else(|| project_dir(manifest));
         let importer_id = state.active_importer_id();
-        let lockfile = state
-            .lockfile
-            .get()
-            .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
-        let http_client = &state.http_client;
-        let package_patterns = self
-            .packages
-            .iter()
-            .filter(|selector| !github_actions::is_selector(selector))
-            .cloned()
-            .collect::<Vec<_>>();
+        let lockfile = loaded_lockfile(&state)?;
+        let package_patterns = self.package_patterns();
         let check_packages = self.checks_packages(manifest, &package_patterns);
         if check_packages && lockfile.is_none() {
-            let dir = manifest.path().parent().unwrap_or_else(|| manifest.path());
-            return Err(no_lockfile_error(dir));
+            return Err(no_lockfile_error(project_dir(manifest)));
         }
 
-        let include = self.dependency_options.include(config.optional);
-        let package_matcher =
-            (!package_patterns.is_empty()).then(|| create_matcher(&package_patterns));
+        let filters = OutdatedFilters::new(&self, config, &package_patterns);
         let action_matcher = github_actions::selector_matcher(&self.packages);
-
-        let ignored = ignored_dependencies_matcher(config);
-        let query = OutdatedQuery {
-            target_version: self.target_version(),
-            include_direct: &include,
-            match_names: package_matcher.as_ref(),
-            ignore_names: ignored.as_ref(),
-            include_deprecated: true,
-        };
+        let query = filters.query(self.target_version());
         let mut outdated = if check_packages {
             collect_outdated_for_importer(
                 manifest,
                 lockfile,
                 &importer_id,
                 config,
-                http_client,
+                &state.http_client,
                 &query,
             )
             .await?
@@ -554,23 +549,49 @@ impl OutdatedArgs {
             Vec::new()
         };
         outdated.extend(
-            self.outdated_actions::<Reporter>(config, root, &include, action_matcher.as_ref())
-                .await?
-                .into_iter()
-                .map(OutdatedPackage::from),
+            self.outdated_actions::<Reporter>(
+                config,
+                root,
+                &filters.include,
+                action_matcher.as_ref(),
+            )
+            .await?
+            .into_iter()
+            .map(OutdatedPackage::from),
         );
 
         sort_outdated(&mut outdated, self.sort_by);
-
-        let output = match self.resolve_format() {
-            OutdatedFormat::Table => render_table(&outdated, self.long),
-            OutdatedFormat::List => render_list(&outdated, self.long),
-            OutdatedFormat::Json => render_json(&outdated, self.long),
-        };
-
-        write_output(&output)?;
+        self.write_rendered(&outdated)?;
 
         Ok(if outdated.is_empty() { OutdatedOutcome::UpToDate } else { OutdatedOutcome::Outdated })
+    }
+
+    /// The `outdated <pattern>` arguments that select packages rather than
+    /// workflow actions.
+    fn package_patterns(&self) -> Vec<String> {
+        self.packages
+            .iter()
+            .filter(|selector| !github_actions::is_selector(selector))
+            .cloned()
+            .collect()
+    }
+
+    fn write_rendered(&self, outdated: &[OutdatedPackage]) -> miette::Result<()> {
+        let output = match self.resolve_format() {
+            OutdatedFormat::Table => render_table(outdated, self.long),
+            OutdatedFormat::List => render_list(outdated, self.long),
+            OutdatedFormat::Json => render_json(outdated, self.long),
+        };
+        write_output(&output)
+    }
+
+    fn write_recursive_rendered(&self, outdated: &[OutdatedInWorkspace]) -> miette::Result<()> {
+        let output = match self.resolve_format() {
+            OutdatedFormat::Table => render_recursive_table(outdated, self.long),
+            OutdatedFormat::List => render_recursive_list(outdated, self.long),
+            OutdatedFormat::Json => render_recursive_json(outdated, self.long),
+        };
+        write_output(&output)
     }
 
     /// `--compatible` reports the newest version the declared range
@@ -622,78 +643,54 @@ impl OutdatedArgs {
         let config = state.config;
         let workspace_root =
             config.workspace_dir.clone().unwrap_or_else(|| state.lockfile_dir().to_path_buf());
-        // The lockfile the importer ids name may sit somewhere else than
-        // the workspace the projects are discovered in — `lockfileDir`.
-        let lockfile_root = state.lockfile_dir().to_path_buf();
         let (projects, _) = discover_workspace_projects(&workspace_root, config)?;
-        let prefix = state.manifest.path().parent().unwrap_or_else(|| state.manifest.path());
-        let selection =
-            select_recursive_projects(&projects, config, prefix, AutoExcludeRoot::Disabled)?;
-        let include = self.dependency_options.include(config.optional);
-        let matcher = (!self.packages.is_empty()).then(|| create_matcher(&self.packages));
-        let ignored = ignored_dependencies_matcher(config);
-        let query = OutdatedQuery {
-            target_version: self.target_version(),
-            include_direct: &include,
-            match_names: matcher.as_ref(),
-            ignore_names: ignored.as_ref(),
-            include_deprecated: true,
-        };
+        let selection = select_recursive_projects(
+            &projects,
+            config,
+            project_dir(&state.manifest),
+            AutoExcludeRoot::Disabled,
+        )?;
+        let filters = OutdatedFilters::new(&self, config, &self.packages);
+        let query = filters.query(self.target_version());
 
         // Every project reads the one shared lockfile, or its own.
-        let shared_lockfile = if config.shares_one_lockfile() {
-            state
-                .lockfile
-                .get()
-                .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?
-        } else {
-            None
-        };
+        let shared_lockfile =
+            if config.shares_one_lockfile() { loaded_lockfile(&state)? } else { None };
         let project_inputs = recursive_project_inputs(config, &selection)?;
         let run = OutdatedRun::new(config, Arc::clone(&state.http_client))?;
-        let project_inputs_shared = ProjectOutdatedInputs {
-            config,
-            lockfile_root: &lockfile_root,
-            shared_lockfile,
-            query: &query,
-            run: &run,
-        };
-        let project_queries =
-            project_inputs.iter().map(|(project_dir, project, project_lockfile)| {
-                outdated_for_project(
-                    &project_inputs_shared,
-                    project_dir,
-                    project,
-                    project_lockfile.as_ref(),
-                )
-            });
-        let project_results = futures_util::future::join_all(project_queries).await;
-        let mut outdated = group_workspace_outdated(project_results)?;
+        let mut outdated = workspace_outdated(
+            &ProjectOutdatedInputs {
+                config,
+                lockfile_root: state.lockfile_dir(),
+                shared_lockfile,
+                query: &query,
+                run: &run,
+            },
+            &project_inputs,
+        )
+        .await?;
 
         let action_matcher = github_actions::selector_matcher(&self.packages);
-        let actions = self
-            .outdated_actions::<Reporter>(
+        outdated.extend(
+            self.outdated_actions::<Reporter>(
                 config,
                 &workspace_root,
-                &include,
+                &filters.include,
                 action_matcher.as_ref(),
             )
-            .await?;
-        outdated.extend(actions.into_iter().map(|action| OutdatedInWorkspace {
-            package: OutdatedPackage::from(action),
-            dependents: vec![DependentProject {
-                name: ".github".to_string(),
-                location: workspace_root.clone(),
-            }],
-        }));
+            .await?
+            .into_iter()
+            .map(|action| OutdatedInWorkspace {
+                package: OutdatedPackage::from(action),
+                dependents: vec![DependentProject {
+                    name: ".github".to_string(),
+                    location: workspace_root.clone(),
+                }],
+            }),
+        );
 
         sort_workspace_outdated(&mut outdated);
-        let output = match self.resolve_format() {
-            OutdatedFormat::Table => render_recursive_table(&outdated, self.long),
-            OutdatedFormat::List => render_recursive_list(&outdated, self.long),
-            OutdatedFormat::Json => render_recursive_json(&outdated, self.long),
-        };
-        write_output(&output)?;
+        self.write_recursive_rendered(&outdated)?;
 
         Ok(if outdated.is_empty() { OutdatedOutcome::UpToDate } else { OutdatedOutcome::Outdated })
     }
@@ -708,60 +705,30 @@ impl OutdatedArgs {
                 "Unable to find the global packages directory"
             )
         })?;
-        // The pnpm home may contain a workspace config, but each global
-        // install group owns its package.json and lockfile. Keep project
-        // lookup anchored to the scanned group while retaining the global
-        // registry and network settings.
-        let mut isolated_config = config.clone();
-        isolated_config.workspace_dir = None;
-        isolated_config.shared_workspace_lockfile = false;
-        isolated_config.lockfile_dir = None;
-        // A group's lockfile is written unconditionally (`run_group_install`
-        // forces it) because it is where the installed versions are recorded,
-        // so reading it back must not depend on the caller's `lockfile`
-        // setting.
-        isolated_config.lockfile = true;
-        let config = Config::leak(isolated_config);
-
-        let include = self.dependency_options.include(config.optional);
-        let target_version =
-            if self.compatible { TargetVersion::WithinRange } else { TargetVersion::Latest };
-        let matcher = (!self.packages.is_empty()).then(|| create_matcher(&self.packages));
-        let ignored = ignored_dependencies_matcher(config);
-        let query = OutdatedQuery {
-            target_version,
-            include_direct: &include,
-            match_names: matcher.as_ref(),
-            ignore_names: ignored.as_ref(),
-            include_deprecated: true,
-        };
+        let config = isolated_global_config(config);
+        let filters = OutdatedFilters::new(&self, config, &self.packages);
+        let query = filters.query(self.target_version());
 
         let mut outdated = Vec::new();
         let global_packages = pnpm_global::scan_global_packages(&global_pkg_dir)
             .map_err(|err| miette::miette!("failed to scan global packages: {err}"))?;
         for pkg in global_packages {
-            let manifest_path = pkg.install_dir.join("package.json");
-            let state = State::init(manifest_path, config, false)
+            let state = State::init(pkg.install_dir.join("package.json"), config, false)
                 .map_err(|err| miette::Report::new(err).wrap_err("initialize global state"))?;
-            let lockfile = state
-                .lockfile
-                .get()
-                .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
-            let result =
-                collect_outdated(&state.manifest, lockfile, config, &state.http_client, &query)
-                    .await?;
-            outdated.extend(result);
+            outdated.extend(
+                collect_outdated(
+                    &state.manifest,
+                    loaded_lockfile(&state)?,
+                    config,
+                    &state.http_client,
+                    &query,
+                )
+                .await?,
+            );
         }
 
         sort_outdated(&mut outdated, self.sort_by);
-
-        let output = match self.resolve_format() {
-            OutdatedFormat::Table => render_table(&outdated, self.long),
-            OutdatedFormat::List => render_list(&outdated, self.long),
-            OutdatedFormat::Json => render_json(&outdated, self.long),
-        };
-
-        write_output(&output)?;
+        self.write_rendered(&outdated)?;
 
         Ok(if outdated.is_empty() { OutdatedOutcome::UpToDate } else { OutdatedOutcome::Outdated })
     }
@@ -779,6 +746,69 @@ impl OutdatedArgs {
             self.format
         }
     }
+}
+
+/// The dependency groups and the name matchers one outdated query walks.
+struct OutdatedFilters {
+    include: Vec<DependencyGroup>,
+    match_names: Option<Matcher>,
+    ignore_names: Option<Matcher>,
+}
+
+impl OutdatedFilters {
+    fn new(args: &OutdatedArgs, config: &Config, package_patterns: &[String]) -> Self {
+        Self {
+            include: args.dependency_options.include(config.optional),
+            match_names: (!package_patterns.is_empty()).then(|| create_matcher(package_patterns)),
+            ignore_names: ignored_dependencies_matcher(config),
+        }
+    }
+
+    fn query(&self, target_version: TargetVersion) -> OutdatedQuery<'_> {
+        OutdatedQuery {
+            target_version,
+            include_direct: &self.include,
+            match_names: self.match_names.as_ref(),
+            ignore_names: self.ignore_names.as_ref(),
+            include_deprecated: true,
+        }
+    }
+}
+
+/// The directory the manifest sits in, or its path when it has no parent.
+fn project_dir(manifest: &PackageManifest) -> &std::path::Path {
+    manifest.path().parent().unwrap_or_else(|| manifest.path())
+}
+
+fn loaded_lockfile(state: &State) -> miette::Result<Option<&Lockfile>> {
+    state.lockfile.get().map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))
+}
+
+/// The pnpm home may contain a workspace config, but each global install
+/// group owns its package.json and lockfile. Keep project lookup anchored
+/// to the scanned group while retaining the global registry and network
+/// settings. A group's lockfile is written unconditionally
+/// (`run_group_install` forces it) because it is where the installed
+/// versions are recorded, so reading it back must not depend on the
+/// caller's `lockfile` setting.
+fn isolated_global_config(config: &Config) -> &'static Config {
+    let mut isolated_config = config.clone();
+    isolated_config.workspace_dir = None;
+    isolated_config.shared_workspace_lockfile = false;
+    isolated_config.lockfile_dir = None;
+    isolated_config.lockfile = true;
+    Config::leak(isolated_config)
+}
+
+/// Every selected project's outdated dependencies, grouped by package.
+async fn workspace_outdated(
+    inputs: &ProjectOutdatedInputs<'_>,
+    project_inputs: &[(&PathBuf, &pnpm_workspace::Project, Option<Lockfile>)],
+) -> miette::Result<Vec<OutdatedInWorkspace>> {
+    let project_queries = project_inputs.iter().map(|(project_dir, project, project_lockfile)| {
+        outdated_for_project(inputs, project_dir, project, project_lockfile.as_ref())
+    });
+    group_workspace_outdated(futures_util::future::join_all(project_queries).await)
 }
 
 fn no_lockfile_error(dir: &std::path::Path) -> miette::Report {

--- a/pnpm/crates/cli/src/cli_args/owner.rs
+++ b/pnpm/crates/cli/src/cli_args/owner.rs
@@ -170,18 +170,12 @@ impl OwnerArgs {
 
 async fn owner_ls(context: &OwnerContext<'_>, params: &[String]) -> miette::Result<String> {
     let package_name = params.first().ok_or(OwnerError::LsPackageRequired)?;
-
-    let registry_url = pick_registry_for_package(&context.registries, package_name, None);
-    let auth_header =
-        context.config.auth_headers.for_url_with_package(&registry_url, Some(package_name));
-
-    let escaped = encode_package_name(package_name);
-    let url = format!("{registry_url}-/package/{escaped}/owners");
+    let endpoint = owners_endpoint(context, package_name);
 
     let (_guard, response) =
-        send_with_retry(&context.http_client, &url, context.retry_opts, |client| {
-            let mut builder = client.get(&url);
-            if let Some(auth) = auth_header.as_deref() {
+        send_with_retry(&context.http_client, &endpoint.url, context.retry_opts, |client| {
+            let mut builder = client.get(&endpoint.url);
+            if let Some(auth) = endpoint.auth_header.as_deref() {
                 builder = builder.header("authorization", auth);
             }
             builder
@@ -203,9 +197,11 @@ async fn owner_ls(context: &OwnerContext<'_>, params: &[String]) -> miette::Resu
         .into_diagnostic()
         .map_err(|source| registry_operation_error("parsing owners response", source))?;
 
-    let lines: Vec<String> =
-        owners.iter().map(|o| format!("{} <{}>", o.username, o.email)).collect();
-    Ok(lines.join("\n"))
+    Ok(owners
+        .iter()
+        .map(|o| format!("{} <{}>", o.username, o.email))
+        .collect::<Vec<_>>()
+        .join("\n"))
 }
 
 async fn owner_add(context: &OwnerContext<'_>, params: &[String]) -> miette::Result<String> {
@@ -214,20 +210,16 @@ async fn owner_add(context: &OwnerContext<'_>, params: &[String]) -> miette::Res
     }
     let package_name = &params[0];
     let owner = &params[1];
-
-    let registry_url = pick_registry_for_package(&context.registries, package_name, None);
-    let auth_header =
-        context.config.auth_headers.for_url_with_package(&registry_url, Some(package_name));
-
-    let escaped = encode_package_name(package_name);
-    let url = format!("{registry_url}-/package/{escaped}/owners");
+    let endpoint = owners_endpoint(context, package_name);
     let body = serde_json::json!({ "user": owner }).to_string();
 
     let (_guard, response) =
-        send_with_retry(&context.http_client, &url, context.retry_opts, |client| {
-            let mut builder =
-                client.put(&url).header("content-type", "application/json").body(body.clone());
-            if let Some(auth) = auth_header.as_deref() {
+        send_with_retry(&context.http_client, &endpoint.url, context.retry_opts, |client| {
+            let mut builder = client
+                .put(&endpoint.url)
+                .header("content-type", "application/json")
+                .body(body.clone());
+            if let Some(auth) = endpoint.auth_header.as_deref() {
                 builder = builder.header("authorization", auth);
             }
             if let Some(otp) = &context.otp {
@@ -251,18 +243,13 @@ async fn owner_rm(context: &OwnerContext<'_>, params: &[String]) -> miette::Resu
     let package_name = &params[0];
     let owner = &params[1];
 
-    let registry_url = pick_registry_for_package(&context.registries, package_name, None);
-    let auth_header =
-        context.config.auth_headers.for_url_with_package(&registry_url, Some(package_name));
-
-    let escaped = encode_package_name(package_name);
-    let encoded_owner = encode_uri_component(owner);
-    let url = format!("{registry_url}-/package/{escaped}/owners/{encoded_owner}");
+    let endpoint = owners_endpoint(context, package_name);
+    let url = format!("{}/{}", endpoint.url, encode_uri_component(owner));
 
     let (_guard, response) =
         send_with_retry(&context.http_client, &url, context.retry_opts, |client| {
             let mut builder = client.delete(&url);
-            if let Some(auth) = auth_header.as_deref() {
+            if let Some(auth) = endpoint.auth_header.as_deref() {
                 builder = builder.header("authorization", auth);
             }
             if let Some(otp) = &context.otp {
@@ -277,6 +264,21 @@ async fn owner_rm(context: &OwnerContext<'_>, params: &[String]) -> miette::Resu
         return Ok(format!("-{owner}: {package_name}"));
     }
     Err(write_error_from_response(response, format!(r#"remove owner "{owner}" from"#)).await)
+}
+
+/// The package's `owners` route on its registry, with the credential
+/// configured for that registry.
+struct OwnersEndpoint {
+    url: String,
+    auth_header: Option<String>,
+}
+
+fn owners_endpoint(context: &OwnerContext<'_>, package_name: &str) -> OwnersEndpoint {
+    let registry_url = pick_registry_for_package(&context.registries, package_name, None);
+    let auth_header =
+        context.config.auth_headers.for_url_with_package(&registry_url, Some(package_name));
+    let escaped = encode_package_name(package_name);
+    OwnersEndpoint { url: format!("{registry_url}-/package/{escaped}/owners"), auth_header }
 }
 
 fn build_http_client(

--- a/pnpm/crates/cli/src/cli_args/pack.rs
+++ b/pnpm/crates/cli/src/cli_args/pack.rs
@@ -153,11 +153,11 @@ impl PackArgs {
         if self.out.is_some() && self.pack_destination.is_some() {
             return Err(miette::Report::new(PackError::OutAndPackDestination));
         }
-        let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
         // `pack` is not in pnpm's root-auto-exclusion command set, so the
         // workspace root stays in the selection (its own name/version
         // eligibility check still applies below).
-        let (projects, _patterns) = discover_workspace_projects(workspace_root, config)?;
+        let (projects, _) =
+            discover_workspace_projects(config.workspace_dir.as_deref().unwrap_or(dir), config)?;
         let selection =
             select_recursive_projects(&projects, config, dir, AutoExcludeRoot::Disabled)?;
         let graph = &selection.selected;
@@ -173,20 +173,10 @@ impl PackArgs {
         // to the CLI dir), so every tarball lands in one place regardless
         // of each project's own root.
         let (out, pack_destination) = self.resolve_recursive_destination(dir);
-        let catalogs = configured_catalogs(config)?;
-        let output_can_change_while_packing =
-            output_can_change_while_packing(config, graph, &before_packing_hooks);
-        let dependency_order = graph_sequencer(
-            &project_dependencies
-                .iter()
-                .map(|(project, dependencies)| (project.clone(), dependencies.clone()))
-                .collect::<HashMap<_, _>>(),
-            &project_dependencies.keys().cloned().collect::<Vec<_>>(),
-        )
-        .order;
-        let output_is_literal =
-            out.as_ref().is_some_and(|out| !out.contains("%s") && !out.contains("%v"));
-        if !output_can_change_while_packing || output_is_literal {
+        let dependency_order = dependency_order(&project_dependencies);
+        if !output_can_change_while_packing(config, graph, &before_packing_hooks)
+            || output_is_literal(out.as_deref())
+        {
             serialize_shared_outputs(
                 &mut project_dependencies,
                 graph,
@@ -195,72 +185,31 @@ impl PackArgs {
                 pack_destination.as_deref(),
             );
         }
-        let order_index: HashMap<PathBuf, usize> = dependency_order
-            .into_iter()
-            .enumerate()
-            .map(|(index, project)| (project, index))
-            .collect();
 
-        let packed: Mutex<Vec<(usize, PackResultJson)>> = Mutex::new(Vec::new());
-        let first_error: Mutex<Option<miette::Report>> = Mutex::new(None);
-        let output_locks = Arc::new(PackOutputLocks::default());
-        let run_node = |root: PathBuf| {
-            let project_order = order_index[&root];
-            let catalogs = catalogs.clone();
-            let out = out.clone();
-            let pack_destination = pack_destination.clone();
-            let before_packing_hooks = before_packing_hooks.clone();
-            let output_locks = Arc::clone(&output_locks);
-            let packed = &packed;
-            let first_error = &first_error;
-            async move {
-                let project = graph[&root].package.project;
-                let Some(mut options) = self.packable_options(
-                    project,
-                    config,
-                    catalogs,
-                    out,
-                    pack_destination,
-                    before_packing_hooks,
-                ) else {
-                    return TaskCompletion::Passed;
-                };
-                options.output_locks = Some(output_locks);
-                match self.pack_one::<Reporter>(config, project, options).await {
-                    Ok(result) => {
-                        packed
-                            .lock()
-                            .expect("packed results lock is not poisoned")
-                            .push((project_order, to_pack_result_json(&result)));
-                        TaskCompletion::Passed
-                    }
-                    Err(error) => {
-                        first_error
-                            .lock()
-                            .expect("pack error lock is not poisoned")
-                            .get_or_insert(error);
-                        TaskCompletion::Failed
-                    }
-                }
-            }
+        let pack = RecursivePack {
+            config,
+            graph,
+            catalogs: configured_catalogs(config)?,
+            out,
+            pack_destination,
+            before_packing_hooks,
+            output_locks: Arc::new(PackOutputLocks::default()),
+            order_index: order_index(dependency_order),
+            packed: Mutex::new(Vec::new()),
+            first_error: Mutex::new(None),
         };
-        let on_node_skipped: fn(&PathBuf) = |_| {};
+        let run_node = |root: PathBuf| pack.pack_node::<Reporter>(self, root);
         schedule_graph_async(
             &project_dependencies,
             &ScheduleGraphAsyncOptions::new(
                 usize::try_from(config.workspace_concurrency).unwrap_or(usize::MAX).max(1),
                 true,
                 &run_node,
-                &on_node_skipped,
+                &|_: &PathBuf| {},
             ),
         )
         .await;
-        if let Some(error) = first_error.into_inner().expect("pack error lock is not poisoned") {
-            return Err(error);
-        }
-        let mut packed = packed.into_inner().expect("packed results lock is not poisoned");
-        packed.sort_unstable_by_key(|(index, _)| *index);
-        let packed = packed.into_iter().map(|(_, result)| result).collect::<Vec<_>>();
+        let packed = pack.finish()?;
 
         if packed.is_empty() {
             tracing::info!(
@@ -373,6 +322,94 @@ impl PackArgs {
             output_locks: None,
         }
     }
+}
+
+/// The shared inputs of every project's pack in a recursive run, and the
+/// results the packs report into.
+struct RecursivePack<'a, 'graph> {
+    config: &'a Config,
+    graph: &'a pnpm_workspace_projects_filter::ProjectGraph<pnpm_workspace::GraphPkg<'graph>>,
+    catalogs: Catalogs,
+    out: Option<String>,
+    pack_destination: Option<String>,
+    before_packing_hooks: Vec<Arc<dyn PnpmfileHooks>>,
+    output_locks: Arc<PackOutputLocks>,
+    /// Each project's position in dependency order, which the results are
+    /// listed in.
+    order_index: HashMap<PathBuf, usize>,
+    packed: Mutex<Vec<(usize, PackResultJson)>>,
+    first_error: Mutex<Option<miette::Report>>,
+}
+
+impl RecursivePack<'_, '_> {
+    async fn pack_node<Reporter: self::Reporter>(
+        &self,
+        args: &PackArgs,
+        root: PathBuf,
+    ) -> TaskCompletion {
+        let project = self.graph[&root].package.project;
+        let Some(mut options) = args.packable_options(
+            project,
+            self.config,
+            self.catalogs.clone(),
+            self.out.clone(),
+            self.pack_destination.clone(),
+            self.before_packing_hooks.clone(),
+        ) else {
+            return TaskCompletion::Passed;
+        };
+        options.output_locks = Some(Arc::clone(&self.output_locks));
+        match args.pack_one::<Reporter>(self.config, project, options).await {
+            Ok(result) => {
+                self.packed
+                    .lock()
+                    .expect("packed results lock is not poisoned")
+                    .push((self.order_index[&root], to_pack_result_json(&result)));
+                TaskCompletion::Passed
+            }
+            Err(error) => {
+                self.first_error
+                    .lock()
+                    .expect("pack error lock is not poisoned")
+                    .get_or_insert(error);
+                TaskCompletion::Failed
+            }
+        }
+    }
+
+    /// The results in dependency order, or the first pack error.
+    fn finish(self) -> miette::Result<Vec<PackResultJson>> {
+        if let Some(error) = self.first_error.into_inner().expect("pack error lock is not poisoned")
+        {
+            return Err(error);
+        }
+        let mut packed = self.packed.into_inner().expect("packed results lock is not poisoned");
+        packed.sort_unstable_by_key(|(index, _)| *index);
+        Ok(packed.into_iter().map(|(_, result)| result).collect())
+    }
+}
+
+fn dependency_order(
+    project_dependencies: &indexmap::IndexMap<PathBuf, Vec<PathBuf>>,
+) -> Vec<PathBuf> {
+    graph_sequencer(
+        &project_dependencies
+            .iter()
+            .map(|(project, dependencies)| (project.clone(), dependencies.clone()))
+            .collect::<HashMap<_, _>>(),
+        &project_dependencies.keys().cloned().collect::<Vec<_>>(),
+    )
+    .order
+}
+
+/// Whether `--out` names one file for every project, with no `%s` / `%v`
+/// placeholders telling them apart.
+fn output_is_literal(out: Option<&str>) -> bool {
+    out.is_some_and(|out| !out.contains("%s") && !out.contains("%v"))
+}
+
+fn order_index(dependency_order: Vec<PathBuf>) -> HashMap<PathBuf, usize> {
+    dependency_order.into_iter().enumerate().map(|(index, project)| (project, index)).collect()
 }
 
 /// Order two projects that pack to the same output path against each

--- a/pnpm/crates/cli/src/cli_args/pack_app.rs
+++ b/pnpm/crates/cli/src/cli_args/pack_app.rs
@@ -276,48 +276,24 @@ impl PackAppArgs {
         // (additive merging would prevent narrowing from the CLI).
         let project = read_project_app_config(dir)?;
 
-        let entry_path = self.resolve_entry(&project, dir)?;
-        let resolved_entry = dir.join(&entry_path);
+        let resolved_entry = dir.join(self.resolve_entry(&project, dir)?);
 
         let targets = self.resolve_targets(&project)?;
 
         // Parse the runtime before output-name derivation and any network
         // work so a malformed --runtime fails fast with a clear error
         // instead of being masked by later problems.
-        let runtime_spec = self
-            .runtime
-            .clone()
-            .or_else(|| project.app.as_ref().and_then(|app| app.runtime.clone()))
-            .unwrap_or_else(|| format!("node@{}", default_runtime_version()));
-        let requested_node_spec = parse_runtime(&runtime_spec)?;
+        let requested_node_spec = parse_runtime(&self.runtime_spec(&project))?;
 
         // Derive and validate the output name before creating any
         // directory, so an invalid `--output-name` / `pnpm.app.outputName`
         // (or a missing package name) fails fast without leaving an empty
         // `dist-app` behind.
-        let configured_output_name = self
-            .output_name
-            .clone()
-            .or_else(|| project.app.as_ref().and_then(|app| app.output_name.clone()));
-        let output_name = match configured_output_name {
-            Some(name) => name,
-            None => derive_output_name_from_package(&project, dir)?,
-        };
-        let output_name = validate_output_name(&output_name)?;
+        let output_name = self.resolve_output_name(&project, dir)?;
 
         let output_dir = self.resolve_output_dir(&project, dir)?;
 
-        // Reject a pre-existing symlink (or any non-regular file) at any
-        // target's final output path before downloading anything: a repo
-        // could commit `dist-app/<target>/<name>` as a symlink pointing
-        // outside the project, and `node --build-sea` would follow it to
-        // overwrite an arbitrary file. The directory containment checks
-        // above do not cover the leaf file.
-        for target in &targets {
-            let output_file =
-                output_dir.join(&target.raw).join(output_file_name(&output_name, &target.platform));
-            reject_non_regular_output_file(&output_file)?;
-        }
+        reject_non_regular_outputs(&targets, &output_dir, &output_name)?;
 
         let build_root = pnpm_home_dir()?.join("pack-app");
 
@@ -326,88 +302,53 @@ impl PackAppArgs {
         // the serialized format has changed across Node.js minor releases,
         // so a blob produced by a builder of a different version than the
         // embedded runtime fails deserialization at startup.
-        let resolved_target_version = resolve_version(config, &requested_node_spec).await?;
-        let builder_bin = resolve_builder_binary(&build_root, &resolved_target_version)?;
-
-        let pacquet_bin = std::env::current_exe()
-            .into_diagnostic()
-            .wrap_err("resolving the pnpm executable path")?;
-
-        let mut results = Vec::with_capacity(targets.len());
-        for target in &targets {
-            let embedded_node_bin = ensure_node_runtime(
-                &pacquet_bin,
-                &build_root,
-                &resolved_target_version,
-                &target.platform,
-                &target.arch,
-                target.libc.as_deref(),
-            )?;
-
-            let target_output_dir = output_dir.join(&target.raw);
-            fs::create_dir_all(&target_output_dir).into_diagnostic().wrap_err_with(|| {
-                format!("creating target output directory {}", target_output_dir.display())
-            })?;
-            // A repo could symlink `dist-app/<target>` out of the project even
-            // when `dist-app` itself is contained; re-check the real path
-            // before any binary is written into it.
-            if !path_is_within(&target_output_dir, dir) {
-                return Err(PackAppError::OutputDirOutsideProject {
-                    path: target_output_dir.display().to_string(),
-                }
-                .into());
-            }
-
-            let output_file =
-                target_output_dir.join(output_file_name(&output_name, &target.platform));
-            // Re-check the leaf path right before the build in case it became
-            // a symlink after the upfront pass.
-            reject_non_regular_output_file(&output_file)?;
-
-            let sea_config = serde_json::json!({
-                "main": resolved_entry,
-                "output": output_file,
-                "executable": embedded_node_bin,
-                "disableExperimentalSEAWarning": true,
-                "useCodeCache": false,
-                "useSnapshot": false,
-            });
-            // Write the SEA config into a fresh, unpredictable temp
-            // directory (0700 by default) rather than a predictable path
-            // under the system temp dir. Avoids TOCTOU/symlink attacks on
-            // multi-user systems.
-            let tmp_config_dir = tempfile::Builder::new()
-                .prefix("pacquet-pack-app-")
-                .tempdir()
+        let target_version = resolve_version(config, &requested_node_spec).await?;
+        let build = SeaBuild {
+            builder_bin: resolve_builder_binary(&build_root, &target_version)?,
+            pacquet_bin: std::env::current_exe()
                 .into_diagnostic()
-                .wrap_err("creating a temp directory for the SEA config")?;
-            let config_path = tmp_config_dir.path().join("sea-config.json");
-            fs::write(
-                &config_path,
-                serde_json::to_vec_pretty(&sea_config).expect("serialize SEA config"),
-            )
-            .into_diagnostic()
-            .wrap_err("writing the SEA config")?;
+                .wrap_err("resolving the pnpm executable path")?,
+            build_root,
+            target_version,
+            dir,
+            output_dir,
+            output_name,
+            entry: resolved_entry,
+        };
 
-            run_command(
-                Command::new(&builder_bin).arg("--build-sea").arg(&config_path),
-                "node --build-sea",
-            )?;
-            drop(tmp_config_dir);
-
-            ad_hoc_sign_mac_binary(target, &output_file, dir)?;
-
-            results.push(format!(
-                "  {}: {} (Node.js {resolved_target_version})",
-                target.raw,
-                output_file.display(),
-            ));
-        }
-
-        let count = targets.len();
-        let plural = if count == 1 { "" } else { "s" };
-        println!("Built {count} executable{plural}:\n{}", results.join("\n"));
+        let results = targets
+            .iter()
+            .map(|target| build.build_target(target))
+            .collect::<miette::Result<Vec<_>>>()?;
+        print_built(&results);
         Ok(())
+    }
+
+    /// The runtime to embed: `--runtime`, else `pnpm.app.runtime`, else the
+    /// default Node.js version.
+    fn runtime_spec(&self, project: &ReadProjectAppConfigResult) -> String {
+        self.runtime
+            .clone()
+            .or_else(|| project.app.as_ref().and_then(|app| app.runtime.clone()))
+            .unwrap_or_else(|| format!("node@{}", default_runtime_version()))
+    }
+
+    /// The validated output name: `--output-name`, else
+    /// `pnpm.app.outputName`, else one derived from the package name.
+    fn resolve_output_name(
+        &self,
+        project: &ReadProjectAppConfigResult,
+        dir: &Path,
+    ) -> miette::Result<String> {
+        let configured = self
+            .output_name
+            .clone()
+            .or_else(|| project.app.as_ref().and_then(|app| app.output_name.clone()));
+        let output_name = match configured {
+            Some(name) => name,
+            None => derive_output_name_from_package(project, dir)?,
+        };
+        Ok(validate_output_name(&output_name)?)
     }
     /// The created output directory. `outputDir` is repo-controllable, so
     /// absolute paths and `..` traversal are rejected — build artifacts
@@ -494,6 +435,118 @@ impl PackAppArgs {
         }
         Ok(entry_path)
     }
+}
+
+/// Everything one target's SEA build reads besides the target itself.
+struct SeaBuild<'a> {
+    dir: &'a Path,
+    output_dir: PathBuf,
+    output_name: String,
+    entry: PathBuf,
+    build_root: PathBuf,
+    target_version: String,
+    builder_bin: PathBuf,
+    pacquet_bin: PathBuf,
+}
+
+impl SeaBuild<'_> {
+    /// Build one target's executable and describe it for the summary.
+    fn build_target(&self, target: &ParsedTarget) -> miette::Result<String> {
+        let embedded_node_bin = ensure_node_runtime(
+            &self.pacquet_bin,
+            &self.build_root,
+            &self.target_version,
+            &target.platform,
+            &target.arch,
+            target.libc.as_deref(),
+        )?;
+
+        let target_output_dir = self.output_dir.join(&target.raw);
+        fs::create_dir_all(&target_output_dir).into_diagnostic().wrap_err_with(|| {
+            format!("creating target output directory {}", target_output_dir.display())
+        })?;
+        // A repo could symlink `dist-app/<target>` out of the project even
+        // when `dist-app` itself is contained; re-check the real path
+        // before any binary is written into it.
+        if !path_is_within(&target_output_dir, self.dir) {
+            return Err(PackAppError::OutputDirOutsideProject {
+                path: target_output_dir.display().to_string(),
+            }
+            .into());
+        }
+
+        let output_file =
+            target_output_dir.join(output_file_name(&self.output_name, &target.platform));
+        // Re-check the leaf path right before the build in case it became
+        // a symlink after the upfront pass.
+        reject_non_regular_output_file(&output_file)?;
+
+        let sea_config = serde_json::json!({
+            "main": self.entry,
+            "output": output_file,
+            "executable": embedded_node_bin,
+            "disableExperimentalSEAWarning": true,
+            "useCodeCache": false,
+            "useSnapshot": false,
+        });
+        // Write the SEA config into a fresh, unpredictable temp
+        // directory (0700 by default) rather than a predictable path
+        // under the system temp dir. Avoids TOCTOU/symlink attacks on
+        // multi-user systems.
+        let tmp_config_dir = tempfile::Builder::new()
+            .prefix("pacquet-pack-app-")
+            .tempdir()
+            .into_diagnostic()
+            .wrap_err("creating a temp directory for the SEA config")?;
+        let config_path = tmp_config_dir.path().join("sea-config.json");
+        fs::write(
+            &config_path,
+            serde_json::to_vec_pretty(&sea_config).expect("serialize SEA config"),
+        )
+        .into_diagnostic()
+        .wrap_err("writing the SEA config")?;
+
+        run_command(
+            Command::new(&self.builder_bin).arg("--build-sea").arg(&config_path),
+            "node --build-sea",
+        )?;
+        drop(tmp_config_dir);
+
+        ad_hoc_sign_mac_binary(target, &output_file, self.dir)?;
+        Ok(
+            format!(
+                "  {}: {} (Node.js {})",
+                target.raw,
+                output_file.display(),
+                self.target_version,
+            ),
+        )
+    }
+}
+
+/// Reject a pre-existing symlink (or any non-regular file) at any
+/// target's final output path before downloading anything: a repo
+/// could commit `dist-app/<target>/<name>` as a symlink pointing
+/// outside the project, and `node --build-sea` would follow it to
+/// overwrite an arbitrary file. The directory containment checks
+/// do not cover the leaf file.
+fn reject_non_regular_outputs(
+    targets: &[ParsedTarget],
+    output_dir: &Path,
+    output_name: &str,
+) -> Result<(), PackAppError> {
+    for target in targets {
+        let output_file =
+            output_dir.join(&target.raw).join(output_file_name(output_name, &target.platform));
+        reject_non_regular_output_file(&output_file)?;
+    }
+    Ok(())
+}
+
+fn print_built(results: &[String]) {
+    let count = results.len();
+    let plural = if count == 1 { "" } else { "s" };
+    println!("Built {count} executable{plural}:\n{}", results.join("\n"));
 }
 
 /// The Node.js version pack-app embeds when neither `--runtime` nor

--- a/pnpm/crates/cli/src/cli_args/patch_commit.rs
+++ b/pnpm/crates/cli/src/cli_args/patch_commit.rs
@@ -124,13 +124,7 @@ impl PatchCommitArgs {
         state: State,
     ) -> Result<bool, PatchCommitError> {
         let patch_dir = resolve_path(dir, &self.patch_dir);
-        let manifest_path = patch_dir.join("package.json");
-        let patched_manifest =
-            PackageManifest::from_path(manifest_path.clone()).map_err(|source| {
-                PatchCommitError::ReadManifest { path: manifest_path.clone(), source }
-            })?;
-        let name = manifest_string(patched_manifest.value(), "name", &manifest_path)?;
-        let version = manifest_string(patched_manifest.value(), "version", &manifest_path)?;
+        let (name, version) = patched_identity(&patch_dir)?;
         let state_value = read_edit_dir_state(&state.config.modules_dir, &patch_dir)
             .map_err(PatchCommitError::StateFile)?
             .ok_or_else(|| PatchCommitError::InvalidPatchDir { patch_dir: patch_dir.clone() })?;
@@ -141,57 +135,29 @@ impl PatchCommitArgs {
                 .ok_or(PatchCommitError::PatchNoLockfile)?;
         let target = patch_target_from_state(&state_value, &name, &version, &current_lockfile)?;
 
-        let clean_dir = clean_source_dir(&state, &patch_dir);
-        remove_dir_if_exists(&clean_dir).map_err(|source| PatchCommitError::CleanupTempDir {
-            path: clean_dir.clone(),
-            source,
-        })?;
-        WritePackageForPatch {
-            tarball_mem_cache: &state.tarball_mem_cache,
-            http_client: &state.http_client,
-            config: state.config,
-            current_lockfile: &current_lockfile,
-            target: &target,
-            dest: &clean_dir,
-        }
-        .run::<Reporter>()
-        .await
-        .map_err(|source| match remove_dir_if_exists(&clean_dir) {
-            Ok(()) => PatchCommitError::WritePackage(source),
-            Err(cleanup_source) => {
-                PatchCommitError::CleanupTempDir { path: clean_dir.clone(), source: cleanup_source }
-            }
-        })?;
-
-        let filtered = match prepare_pkg_files_for_diff(&patch_dir) {
-            Ok(filtered) => filtered,
-            Err(source) => {
-                remove_dir_if_exists(&clean_dir).map_err(|cleanup_source| {
-                    PatchCommitError::CleanupTempDir {
-                        path: clean_dir.clone(),
-                        source: cleanup_source,
-                    }
-                })?;
-                return Err(PatchCommitError::PatchCommit(source));
-            }
-        };
-        let filtered_path = match &filtered {
-            PkgFilesForDiff::Original(path) | PkgFilesForDiff::Temporary(path) => path,
-        };
-        let patch_content = match diff_folders(&clean_dir, filtered_path) {
-            Ok(patch_content) => patch_content,
-            Err(source) => {
-                cleanup_after_diff(&clean_dir, &filtered)?;
-                return Err(PatchCommitError::PatchCommit(source));
-            }
-        };
-        cleanup_after_diff(&clean_dir, &filtered)?;
+        let patch_content =
+            diff_against_clean::<Reporter>(&state, &patch_dir, &target, &current_lockfile).await?;
 
         if patch_content.is_empty() {
             println!("No changes were found to the following directory: {}", patch_dir.display());
             return Ok(false);
         }
 
+        self.record_patch(&state, dir, &name, &version, state_value.apply_to_all, &patch_content)?;
+        Ok(true)
+    }
+
+    /// Write the patch under the patches directory and record it in the
+    /// workspace's `patchedDependencies`.
+    fn record_patch(
+        &self,
+        state: &State,
+        dir: &Path,
+        name: &str,
+        version: &str,
+        apply_to_all: bool,
+        patch_content: &str,
+    ) -> Result<(), PatchCommitError> {
         let workspace_dir = state.config.workspace_dir.clone().unwrap_or_else(|| dir.to_path_buf());
         let patches_dir_name = normalize_patches_dir_name(
             self.patches_dir
@@ -206,8 +172,7 @@ impl PatchCommitArgs {
         })?;
         let patch_file_context = PatchFileWriteContext::new(&workspace_dir, &patches_dir_name)?;
 
-        let patch_key =
-            if state_value.apply_to_all { name.clone() } else { format!("{name}@{version}") };
+        let patch_key = if apply_to_all { name.to_string() } else { format!("{name}@{version}") };
         let patch_file_name = format!("{}.patch", patch_key.replace('/', "__"));
         let patch_file_path = patch_file_context.patch_file_path(&patch_file_name)?;
         write_patch_file_atomically(&patch_file_path, patch_content.as_bytes()).map_err(
@@ -221,10 +186,71 @@ impl PatchCommitArgs {
             &workspace_dir,
             &patched_dependencies,
         )
-        .map_err(PatchCommitError::UpdateWorkspaceManifest)?;
-
-        Ok(true)
+        .map_err(PatchCommitError::UpdateWorkspaceManifest)
     }
+}
+
+/// The patched package's name and version, from the manifest `pnpm patch`
+/// left in the directory.
+fn patched_identity(patch_dir: &Path) -> Result<(String, String), PatchCommitError> {
+    let manifest_path = patch_dir.join("package.json");
+    let patched_manifest = PackageManifest::from_path(manifest_path.clone())
+        .map_err(|source| PatchCommitError::ReadManifest { path: manifest_path.clone(), source })?;
+    Ok((
+        manifest_string(patched_manifest.value(), "name", &manifest_path)?,
+        manifest_string(patched_manifest.value(), "version", &manifest_path)?,
+    ))
+}
+
+/// The diff between the package as installed and the edited copy, with
+/// the temporary clean copy removed either way.
+async fn diff_against_clean<Reporter: self::Reporter + 'static>(
+    state: &State,
+    patch_dir: &Path,
+    target: &PatchTarget,
+    current_lockfile: &Lockfile,
+) -> Result<String, PatchCommitError> {
+    let clean_dir = clean_source_dir(state, patch_dir);
+    remove_dir_if_exists(&clean_dir)
+        .map_err(|source| PatchCommitError::CleanupTempDir { path: clean_dir.clone(), source })?;
+    WritePackageForPatch {
+        tarball_mem_cache: &state.tarball_mem_cache,
+        http_client: &state.http_client,
+        config: state.config,
+        current_lockfile,
+        target,
+        dest: &clean_dir,
+    }
+    .run::<Reporter>()
+    .await
+    .map_err(|source| match remove_dir_if_exists(&clean_dir) {
+        Ok(()) => PatchCommitError::WritePackage(source),
+        Err(cleanup_source) => {
+            PatchCommitError::CleanupTempDir { path: clean_dir.clone(), source: cleanup_source }
+        }
+    })?;
+
+    let filtered = match prepare_pkg_files_for_diff(patch_dir) {
+        Ok(filtered) => filtered,
+        Err(source) => {
+            remove_dir_if_exists(&clean_dir).map_err(|cleanup_source| {
+                PatchCommitError::CleanupTempDir { path: clean_dir.clone(), source: cleanup_source }
+            })?;
+            return Err(PatchCommitError::PatchCommit(source));
+        }
+    };
+    let filtered_path = match &filtered {
+        PkgFilesForDiff::Original(path) | PkgFilesForDiff::Temporary(path) => path,
+    };
+    let patch_content = match diff_folders(&clean_dir, filtered_path) {
+        Ok(patch_content) => patch_content,
+        Err(source) => {
+            cleanup_after_diff(&clean_dir, &filtered)?;
+            return Err(PatchCommitError::PatchCommit(source));
+        }
+    };
+    cleanup_after_diff(&clean_dir, &filtered)?;
+    Ok(patch_content)
 }
 
 fn manifest_string(

--- a/pnpm/crates/cli/src/cli_args/pipeline.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline.rs
@@ -210,30 +210,17 @@ pub fn run_pipeline(
     dir: &Path,
     reporter: ReporterType,
 ) -> miette::Result<PipelineOutcome> {
-    let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
-    let emit = reporter_emit(reporter);
-    let silent = matches!(reporter, ReporterType::Ndjson | ReporterType::Silent);
-    let info = |message: String| {
-        emit(&LogEvent::Pnpm(PnpmLog {
-            level: LogLevel::Info,
-            message,
-            prefix: workspace_root.to_string_lossy().into_owned(),
-        }));
+    let run = PipelineRun {
+        invocation,
+        config,
+        dir,
+        workspace_root: config.workspace_dir.as_deref().unwrap_or(dir),
+        emit: reporter_emit(reporter),
+        silent: matches!(reporter, ReporterType::Ndjson | ReporterType::Silent),
     };
+    let (name, requested_tasks) = run.requested_tasks()?;
 
-    if config.pipelines.is_empty() {
-        return Err(PipelineError::NoPipelines.into());
-    }
-    let name = invocation.name.as_deref().unwrap_or(DEFAULT_PIPELINE_NAME);
-    let Some(requested_tasks) = config.pipelines.get(name) else {
-        return Err(PipelineError::UnknownPipeline {
-            name: name.to_string(),
-            available: config.pipelines.keys().cloned().collect::<Vec<_>>().join(", "),
-        }
-        .into());
-    };
-
-    let (projects, _patterns) = discover_workspace_projects(workspace_root, config)?;
+    let (projects, _) = discover_workspace_projects(run.workspace_root, config)?;
     let graph = build_full_graph(&projects, config);
 
     let base = invocation
@@ -243,148 +230,277 @@ pub fn run_pipeline(
         .unwrap_or_else(|| DEFAULT_PIPELINE_BASE.to_string());
     let selection = select_affected_projects(&SelectAffectedOptions {
         graph: &graph,
-        workspace_root,
+        workspace_root: run.workspace_root,
         base: &base,
         full: invocation.full,
         config,
-        emit,
+        emit: run.emit,
     })?;
 
-    let revision = git_stdout(workspace_root, &["rev-parse", "HEAD"]);
-    let report = RunReport::new(name, &base, &selection, revision)?;
-
-    if selection.requested.is_empty() {
-        info(format!("No projects are affected since {base} — nothing to run."));
-        let report_dir = report.write(&pipeline_data_dir(config, workspace_root))?;
-        info(format!("Report: {}", report_dir.display()));
-        return Ok(PipelineOutcome {
-            failed_tasks: 0,
-            upload: Some(report.to_upload(workspace_identity(workspace_root))),
-        });
-    }
-
-    let selected_graph: ProjectGraph<GraphPkg<'_>> = graph
-        .iter()
-        .filter(|(root, _)| selection.selected.contains(root.as_path()))
-        .map(|(root, node)| (root.clone(), node.clone()))
-        .collect();
-    let project_dependencies =
-        filtered_projects_dependencies(&selected_graph, &graph, None, &HashSet::new());
-
-    let select_scripts = |project: &Path, task_name: &str| -> Vec<String> {
-        let manifest = graph[project].package.project.manifest.value();
-        match ScriptSelector::new(task_name) {
-            Ok(selector) => selector.select(manifest),
-            Err(_) => Vec::new(),
-        }
-    };
-    let task_names: Vec<&str> = requested_tasks.iter().map(String::as_str).collect();
-    let mut task_graph = build_pipeline_task_graph(&BuildPipelineTaskGraphOptions {
-        project_dependencies: &project_dependencies,
-        select_scripts,
-        task_names: &task_names,
-        requested_projects: Some(&selection.requested),
-        tasks: (!config.tasks.is_empty()).then_some(&config.tasks),
-    });
-    let sequenced_tasks = sequence_tasks(
-        &mut task_graph,
-        &SequenceTasksOptions {
-            workspace_dir: workspace_root,
-            ignore_cycles: config.ignore_workspace_cycles,
-            emit,
-        },
+    let report = RunReport::new(
+        name,
+        &base,
+        &selection,
+        git_stdout(run.workspace_root, &["rev-parse", "HEAD"]),
     )?;
 
-    if invocation.dry_run {
-        print_dry_run(invocation, &task_graph, &sequenced_tasks, workspace_root)?;
-        return Ok(PipelineOutcome::without_upload());
+    if selection.requested.is_empty() {
+        run.info(format!("No projects are affected since {base} — nothing to run."));
+        return run.conclude(&report, None, 0);
+    }
+    run.execute(&PipelinePlan {
+        name,
+        requested_tasks,
+        graph: &graph,
+        selection: &selection,
+        report: &report,
+    })
+}
+
+/// What every phase of one pipeline run reads.
+struct PipelineRun<'a> {
+    invocation: &'a PipelineInvocation,
+    config: &'a Config,
+    dir: &'a Path,
+    workspace_root: &'a Path,
+    emit: fn(&LogEvent),
+    silent: bool,
+}
+
+/// What the selection pre-pass settled: the tasks to run, the projects to
+/// run them over, and the report recording the run.
+struct PipelinePlan<'a, 'graph> {
+    name: &'a str,
+    requested_tasks: &'a [String],
+    graph: &'a ProjectGraph<GraphPkg<'graph>>,
+    selection: &'a Selection,
+    report: &'a RunReport,
+}
+
+impl<'a> PipelineRun<'a> {
+    fn info(&self, message: String) {
+        (self.emit)(&LogEvent::Pnpm(PnpmLog {
+            level: LogLevel::Info,
+            message,
+            prefix: self.workspace_root.to_string_lossy().into_owned(),
+        }));
     }
 
-    let cache = TaskCache::open(&pipeline_data_dir(config, workspace_root), workspace_root)?;
-    // Keys are computed for every task before anything runs, walking the
-    // sequenced order so a task's dependency keys exist when its own is
-    // built. This is also what a distributed tier would need: the whole
-    // plan, priced, without executing. `--no-cache` skips the pricing
-    // altogether: nothing reads a key, and hashing every tracked file of
-    // every project is the bulk of what the flag exists to avoid.
-    let task_keys = if invocation.no_cache {
-        HashMap::new()
-    } else {
-        compute_task_keys(&task_graph, &sequenced_tasks, &graph, &cache, config)?
-    };
+    fn data_dir(&self) -> PathBuf {
+        pipeline_data_dir(self.config, self.workspace_root)
+    }
 
-    capture::install_forward(emit);
-    let concurrency = usize::try_from(config.workspace_concurrency).unwrap_or(usize::MAX).max(1);
-    let init_cwd = env::current_dir().unwrap_or_else(|_| dir.to_path_buf());
-    let base_extra_env: HashMap<String, String> = config.extra_env_with_node_options();
+    /// The named pipeline's tasks, or the default pipeline's without a name.
+    fn requested_tasks(&self) -> miette::Result<(&'a str, &'a [String])> {
+        if self.config.pipelines.is_empty() {
+            return Err(PipelineError::NoPipelines.into());
+        }
+        let name = self.invocation.name.as_deref().unwrap_or(DEFAULT_PIPELINE_NAME);
+        let Some(requested_tasks) = self.config.pipelines.get(name) else {
+            return Err(PipelineError::UnknownPipeline {
+                name: name.to_string(),
+                available: self.config.pipelines.keys().cloned().collect::<Vec<_>>().join(", "),
+            }
+            .into());
+        };
+        Ok((name, requested_tasks.as_slice()))
+    }
 
-    let statuses: Mutex<IndexMap<String, ExecutionStatus>> = Mutex::new(
-        task_graph
-            .keys()
-            .map(|key| (format_task(key, workspace_root), ExecutionStatus::queued()))
-            .collect(),
-    );
-    let abort: Mutex<Option<miette::Report>> = Mutex::new(None);
+    /// Run the plan's tasks, serving cached results where the keys match,
+    /// and report how the run went.
+    fn execute(&self, plan: &PipelinePlan<'_, '_>) -> miette::Result<PipelineOutcome> {
+        let mut task_graph = self.task_graph(plan);
+        let sequenced_tasks = sequence_tasks(
+            &mut task_graph,
+            &SequenceTasksOptions {
+                workspace_dir: self.workspace_root,
+                ignore_cycles: self.config.ignore_workspace_cycles,
+                emit: self.emit,
+            },
+        )?;
 
-    let run_task = |node: &TaskNode| -> TaskCompletion {
+        if self.invocation.dry_run {
+            print_dry_run(self.invocation, &task_graph, &sequenced_tasks, self.workspace_root)?;
+            return Ok(PipelineOutcome::without_upload());
+        }
+
+        let cache = TaskCache::open(&self.data_dir(), self.workspace_root)?;
+        // Keys are computed for every task before anything runs, walking the
+        // sequenced order so a task's dependency keys exist when its own is
+        // built. This is also what a distributed tier would need: the whole
+        // plan, priced, without executing. `--no-cache` skips the pricing
+        // altogether: nothing reads a key, and hashing every tracked file of
+        // every project is the bulk of what the flag exists to avoid.
+        let task_keys = if self.invocation.no_cache {
+            HashMap::new()
+        } else {
+            compute_task_keys(&task_graph, &sequenced_tasks, plan.graph, &cache, self.config)?
+        };
+
+        capture::install_forward(self.emit);
+        let runner = TaskRunner {
+            run: self,
+            graph: plan.graph,
+            cache: &cache,
+            task_keys: &task_keys,
+            report: plan.report,
+            init_cwd: env::current_dir().unwrap_or_else(|_| self.dir.to_path_buf()),
+            base_extra_env: self.config.extra_env_with_node_options(),
+            statuses: Mutex::new(
+                task_graph
+                    .keys()
+                    .map(|key| (format_task(key, self.workspace_root), ExecutionStatus::queued()))
+                    .collect(),
+            ),
+            abort: Mutex::new(None),
+        };
+        schedule_tasks(
+            &task_graph,
+            &ScheduleTasksOptions {
+                concurrency: usize::try_from(self.config.workspace_concurrency)
+                    .unwrap_or(usize::MAX)
+                    .max(1),
+                bail: false,
+                run_task: &|node: &TaskNode| runner.run_task(node),
+                on_task_skipped: &|node: &TaskNode| runner.skip_task(node),
+            },
+        );
+
+        let statuses = runner.finish()?;
+        let counts = StatusCounts::of(&statuses);
+        let hits = plan.report.cache_hits();
+
+        plan.report.finish(&statuses, &task_keys, self.workspace_root);
+        self.conclude(
+            plan.report,
+            Some(format!(
+                r#"Pipeline "{}": {} tasks — {} passed ({hits} from cache), {} failed, {} skipped."#,
+                plan.name,
+                statuses.len(),
+                counts.passed,
+                counts.failed,
+                counts.skipped,
+            )),
+            counts.failed,
+        )
+    }
+
+    /// The task graph over the selection: the requested projects' tasks
+    /// plus the `dependsOn` edges into the rest of the selected projects.
+    fn task_graph(&self, plan: &PipelinePlan<'_, '_>) -> TaskGraph {
+        let selected_graph: ProjectGraph<GraphPkg<'_>> = plan
+            .graph
+            .iter()
+            .filter(|(root, _)| plan.selection.selected.contains(root.as_path()))
+            .map(|(root, node)| (root.clone(), node.clone()))
+            .collect();
+        let project_dependencies =
+            filtered_projects_dependencies(&selected_graph, plan.graph, None, &HashSet::new());
+
+        let select_scripts = |project: &Path, task_name: &str| -> Vec<String> {
+            let manifest = plan.graph[project].package.project.manifest.value();
+            match ScriptSelector::new(task_name) {
+                Ok(selector) => selector.select(manifest),
+                Err(_) => Vec::new(),
+            }
+        };
+        let task_names: Vec<&str> = plan.requested_tasks.iter().map(String::as_str).collect();
+        build_pipeline_task_graph(&BuildPipelineTaskGraphOptions {
+            project_dependencies: &project_dependencies,
+            select_scripts,
+            task_names: &task_names,
+            requested_projects: Some(&plan.selection.requested),
+            tasks: (!self.config.tasks.is_empty()).then_some(&self.config.tasks),
+        })
+    }
+
+    /// Write the report and name it, after the summary line when there is
+    /// one.
+    fn conclude(
+        &self,
+        report: &RunReport,
+        summary: Option<String>,
+        failed_tasks: usize,
+    ) -> miette::Result<PipelineOutcome> {
+        let report_dir = report.write(&self.data_dir())?;
+        if let Some(summary) = summary {
+            self.info(summary);
+        }
+        self.info(format!("Report: {}", report_dir.display()));
+        Ok(PipelineOutcome {
+            failed_tasks,
+            upload: Some(report.to_upload(workspace_identity(self.workspace_root))),
+        })
+    }
+}
+
+/// The per-task state the scheduler's callbacks read and update.
+struct TaskRunner<'a, 'graph> {
+    run: &'a PipelineRun<'a>,
+    graph: &'a ProjectGraph<GraphPkg<'graph>>,
+    cache: &'a TaskCache,
+    task_keys: &'a HashMap<TaskKey, Option<String>>,
+    report: &'a RunReport,
+    init_cwd: PathBuf,
+    base_extra_env: HashMap<String, String>,
+    statuses: Mutex<IndexMap<String, ExecutionStatus>>,
+    abort: Mutex<Option<miette::Report>>,
+}
+
+impl TaskRunner<'_, '_> {
+    fn run_task(&self, node: &TaskNode) -> TaskCompletion {
         let key = TaskKey { project: node.project.clone(), task_name: node.task_name.clone() };
-        let summary_key = format_task(&key, workspace_root);
+        let summary_key = format_task(&key, self.run.workspace_root);
         let outcome = run_pipeline_task(&RunTaskOptions {
             node,
-            graph: &graph,
-            config,
-            invocation,
-            cache: &cache,
-            task_key: task_keys.get(&key).and_then(Option::as_deref),
-            init_cwd: &init_cwd,
-            base_extra_env: &base_extra_env,
-            emit,
-            silent,
-            report: &report,
+            graph: self.graph,
+            config: self.run.config,
+            invocation: self.run.invocation,
+            cache: self.cache,
+            task_key: self.task_keys.get(&key).and_then(Option::as_deref),
+            init_cwd: &self.init_cwd,
+            base_extra_env: &self.base_extra_env,
+            emit: self.run.emit,
+            silent: self.run.silent,
+            report: self.report,
             summary_key: &summary_key,
         });
-        record_task_outcome(&statuses, &abort, &summary_key, outcome)
-    };
-    let on_task_skipped = |node: &TaskNode| {
-        let key = TaskKey { project: node.project.clone(), task_name: node.task_name.clone() };
-        let summary_key = format_task(&key, workspace_root);
-        statuses.lock().expect("status lock is not poisoned")[&summary_key].status =
-            Status::Skipped;
-        report.task_skipped(&summary_key);
-    };
-    schedule_tasks(
-        &task_graph,
-        &ScheduleTasksOptions {
-            concurrency,
-            bail: false,
-            run_task: &run_task,
-            on_task_skipped: &on_task_skipped,
-        },
-    );
-
-    if let Some(error) = abort.into_inner().expect("abort slot lock is not poisoned") {
-        return Err(error);
+        record_task_outcome(&self.statuses, &self.abort, &summary_key, outcome)
     }
 
-    let statuses = statuses.into_inner().expect("status lock is not poisoned");
-    let failed = statuses.values().filter(|status| status.status == Status::Failure).count();
-    let passed = statuses.values().filter(|status| status.status == Status::Passed).count();
-    let skipped = statuses.values().filter(|status| status.status == Status::Skipped).count();
-    let hits = report.cache_hits();
+    fn skip_task(&self, node: &TaskNode) {
+        let key = TaskKey { project: node.project.clone(), task_name: node.task_name.clone() };
+        let summary_key = format_task(&key, self.run.workspace_root);
+        self.statuses.lock().expect("status lock is not poisoned")[&summary_key].status =
+            Status::Skipped;
+        self.report.task_skipped(&summary_key);
+    }
 
-    report.finish(&statuses, &task_keys, workspace_root);
-    let report_dir = report.write(&pipeline_data_dir(config, workspace_root))?;
+    /// The settled statuses, unless a task could not run at all.
+    fn finish(self) -> miette::Result<IndexMap<String, ExecutionStatus>> {
+        if let Some(error) = self.abort.into_inner().expect("abort slot lock is not poisoned") {
+            return Err(error);
+        }
+        Ok(self.statuses.into_inner().expect("status lock is not poisoned"))
+    }
+}
 
-    info(format!(
-        r#"Pipeline "{name}": {total} tasks — {passed} passed ({hits} from cache), {failed} failed, {skipped} skipped."#,
-        total = statuses.len(),
-    ));
-    info(format!("Report: {}", report_dir.display()));
+struct StatusCounts {
+    failed: usize,
+    passed: usize,
+    skipped: usize,
+}
 
-    Ok(PipelineOutcome {
-        failed_tasks: failed,
-        upload: Some(report.to_upload(workspace_identity(workspace_root))),
-    })
+impl StatusCounts {
+    fn of(statuses: &IndexMap<String, ExecutionStatus>) -> Self {
+        let count =
+            |wanted: Status| statuses.values().filter(|status| status.status == wanted).count();
+        StatusCounts {
+            failed: count(Status::Failure),
+            passed: count(Status::Passed),
+            skipped: count(Status::Skipped),
+        }
+    }
 }
 
 /// Where the pipeline keeps its task cache, restore records, and run
@@ -491,10 +607,12 @@ fn record_task_outcome(
 }
 
 fn select_affected_projects(options: &SelectAffectedOptions<'_>) -> miette::Result<Selection> {
-    let SelectAffectedOptions { graph, workspace_root, base, full, config, emit } = *options;
-    let all_dirs: Vec<PathBuf> = graph
+    let all_dirs: Vec<PathBuf> = options
+        .graph
         .keys()
-        .filter(|dir| config.include_workspace_root || dir.as_path() != workspace_root)
+        .filter(|dir| {
+            options.config.include_workspace_root || dir.as_path() != options.workspace_root
+        })
         .cloned()
         .collect();
     let full_selection = |merge_base: Option<String>, changed_count: usize| Selection {
@@ -505,27 +623,28 @@ fn select_affected_projects(options: &SelectAffectedOptions<'_>) -> miette::Resu
         changed_count,
     };
 
-    if full {
+    if options.full {
         return Ok(full_selection(None, 0));
     }
-    let Some(merge_base) = resolve_merge_base(workspace_root, base) else {
-        emit(&LogEvent::Pnpm(PnpmLog {
+    let Some(merge_base) = resolve_merge_base(options.workspace_root, options.base) else {
+        (options.emit)(&LogEvent::Pnpm(PnpmLog {
             level: LogLevel::Warn,
             message: format!(
-                "Cannot resolve the merge base of HEAD and {base}; running the pipeline over every project.",
+                "Cannot resolve the merge base of HEAD and {}; running the pipeline over every project.",
+                options.base,
             ),
-            prefix: workspace_root.to_string_lossy().into_owned(),
+            prefix: options.workspace_root.to_string_lossy().into_owned(),
         }));
         return Ok(full_selection(None, 0));
     };
 
     let changed = get_changed_projects(
-        graph.keys().cloned().collect(),
+        options.graph.keys().cloned().collect(),
         &merge_base,
         &GetChangedProjectsOptions {
-            workspace_dir: workspace_root,
-            test_pattern: &config.test_pattern,
-            changed_files_ignore_pattern: &config.changed_files_ignore_pattern,
+            workspace_dir: options.workspace_root,
+            test_pattern: &options.config.test_pattern,
+            changed_files_ignore_pattern: &options.config.changed_files_ignore_pattern,
         },
     )
     .map_err(miette::Report::new)?;
@@ -540,31 +659,36 @@ fn select_affected_projects(options: &SelectAffectedOptions<'_>) -> miette::Resu
         .changed_projects
         .iter()
         .chain(&changed.ignore_dependent_for_projects)
-        .any(|dir| dir == workspace_root)
+        .any(|dir| dir == options.workspace_root)
     {
-        emit(&LogEvent::Pnpm(PnpmLog {
+        (options.emit)(&LogEvent::Pnpm(PnpmLog {
             level: LogLevel::Warn,
             message:
                 "The diff touches workspace-root files; running the pipeline over every project."
                     .to_string(),
-            prefix: workspace_root.to_string_lossy().into_owned(),
+            prefix: options.workspace_root.to_string_lossy().into_owned(),
         }));
         return Ok(full_selection(Some(merge_base), changed_count));
     }
 
-    let mut affected = projects_with_dependents(graph, &changed.changed_projects);
+    let mut affected = projects_with_dependents(options.graph, &changed.changed_projects);
     // A project whose only changes match `testPattern` is selected itself
     // without pulling in its dependents.
     affected.extend(changed.ignore_dependent_for_projects.iter().cloned());
-    if !config.include_workspace_root {
-        affected.remove(workspace_root);
+    if !options.config.include_workspace_root {
+        affected.remove(options.workspace_root);
     }
-    let selected = with_transitive_dependencies(graph, &affected, workspace_root, config);
+    let selected = with_transitive_dependencies(
+        options.graph,
+        &affected,
+        options.workspace_root,
+        options.config,
+    );
 
     // In the workspace graph's deterministic order, which is the
     // dispatch tie-break order.
     let requested: Vec<PathBuf> =
-        graph.keys().filter(|dir| affected.contains(dir.as_path())).cloned().collect();
+        options.graph.keys().filter(|dir| affected.contains(dir.as_path())).cloned().collect();
     Ok(Selection {
         requested,
         selected,
@@ -734,56 +858,17 @@ struct RunTaskOptions<'a, 'graph> {
 
 /// Script failures are returned as statuses. Infrastructure errors abort the run.
 fn run_pipeline_task(options: &RunTaskOptions<'_, '_>) -> miette::Result<ExecutionStatus> {
-    let RunTaskOptions {
-        node,
-        graph,
-        config,
-        invocation,
-        cache,
-        task_key,
-        emit,
-        report,
-        summary_key,
-        ..
-    } = *options;
-    let root = node.project.as_path();
-    let settings = config.tasks.get(&node.task_name);
-    let cache_key = task_key.filter(|_| task_cacheable(invocation, settings));
+    let root = options.node.project.as_path();
+    let summary_key = options.summary_key;
+    let settings = options.config.tasks.get(&options.node.task_name);
+    let cache_key = options.task_key.filter(|_| task_cacheable(options.invocation, settings));
     let start = Instant::now();
-    report.task_started(summary_key, task_key);
+    options.report.task_started(summary_key, options.task_key);
 
     if let Some(cache_key) = cache_key
-        && let Some(stored) = cache.lookup(cache_key)
+        && let Some(restored) = try_restore(options, cache_key, start)?
     {
-        match cache.restore(&stored, root, summary_key) {
-            Ok(()) => {
-                capture::replay(&stored.scripts, root, emit);
-                sync_injected_deps_if_configured(config, node, graph)?;
-                let duration = start.elapsed().as_secs_f64() * 1e3;
-                report.task_finished(summary_key, Status::Passed, CacheDisposition::Hit, duration);
-                emit(&LogEvent::Pnpm(PnpmLog {
-                    level: LogLevel::Info,
-                    message: format!("{summary_key}: restored from cache"),
-                    prefix: root.to_string_lossy().into_owned(),
-                }));
-                return Ok(ExecutionStatus {
-                    status: Status::Passed,
-                    duration: Some(duration),
-                    prefix: None,
-                    message: None,
-                });
-            }
-            Err(reason) => {
-                // A file the restore cannot account for is the user's;
-                // overwriting it silently is how caches lose trust. The
-                // task runs normally instead.
-                emit(&LogEvent::Pnpm(PnpmLog {
-                    level: LogLevel::Warn,
-                    message: format!("{summary_key}: not restoring from cache: {reason}"),
-                    prefix: root.to_string_lossy().into_owned(),
-                }));
-            }
-        }
+        return Ok(restored);
     }
 
     let execution = execute_task_with_cargo_cache(options, settings)?;
@@ -793,8 +878,8 @@ fn run_pipeline_task(options: &RunTaskOptions<'_, '_>) -> miette::Result<Executi
         && let Some(captured) = execution.captured
     {
         let outputs = settings.and_then(|settings| settings.outputs.as_deref()).unwrap_or_default();
-        if let Err(error) = cache.store(cache_key, root, summary_key, outputs, captured) {
-            emit(&LogEvent::Pnpm(PnpmLog {
+        if let Err(error) = options.cache.store(cache_key, root, summary_key, outputs, captured) {
+            (options.emit)(&LogEvent::Pnpm(PnpmLog {
                 level: LogLevel::Warn,
                 message: format!("{summary_key}: failed to store the task in the cache: {error}"),
                 prefix: root.to_string_lossy().into_owned(),
@@ -803,7 +888,7 @@ fn run_pipeline_task(options: &RunTaskOptions<'_, '_>) -> miette::Result<Executi
     }
     let disposition =
         if cache_key.is_some() { CacheDisposition::Miss } else { CacheDisposition::Bypass };
-    report.task_finished(summary_key, execution.status, disposition, duration);
+    options.report.task_finished(summary_key, execution.status, disposition, duration);
     Ok(ExecutionStatus {
         status: execution.status,
         duration: Some(duration),
@@ -812,12 +897,60 @@ fn run_pipeline_task(options: &RunTaskOptions<'_, '_>) -> miette::Result<Executi
     })
 }
 
+/// The status of a task served from the cache, or `None` when nothing is
+/// stored under `cache_key` or the restore refused.
+fn try_restore(
+    options: &RunTaskOptions<'_, '_>,
+    cache_key: &str,
+    start: Instant,
+) -> miette::Result<Option<ExecutionStatus>> {
+    let root = options.node.project.as_path();
+    let summary_key = options.summary_key;
+    let Some(stored) = options.cache.lookup(cache_key) else {
+        return Ok(None);
+    };
+    match options.cache.restore(&stored, root, summary_key) {
+        Ok(()) => {
+            capture::replay(&stored.scripts, root, options.emit);
+            sync_injected_deps_if_configured(options.config, options.node, options.graph)?;
+            let duration = start.elapsed().as_secs_f64() * 1e3;
+            options.report.task_finished(
+                summary_key,
+                Status::Passed,
+                CacheDisposition::Hit,
+                duration,
+            );
+            (options.emit)(&LogEvent::Pnpm(PnpmLog {
+                level: LogLevel::Info,
+                message: format!("{summary_key}: restored from cache"),
+                prefix: root.to_string_lossy().into_owned(),
+            }));
+            Ok(Some(ExecutionStatus {
+                status: Status::Passed,
+                duration: Some(duration),
+                prefix: None,
+                message: None,
+            }))
+        }
+        Err(reason) => {
+            // A file the restore cannot account for is the user's;
+            // overwriting it silently is how caches lose trust. The
+            // task runs normally instead.
+            (options.emit)(&LogEvent::Pnpm(PnpmLog {
+                level: LogLevel::Warn,
+                message: format!("{summary_key}: not restoring from cache: {reason}"),
+                prefix: root.to_string_lossy().into_owned(),
+            }));
+            Ok(None)
+        }
+    }
+}
+
 fn execute_task_with_cargo_cache(
     options: &RunTaskOptions<'_, '_>,
     settings: Option<&pnpm_config::TaskSettings>,
 ) -> miette::Result<TaskExecution> {
-    let RunTaskOptions { node, config, invocation, task_key, emit, summary_key, .. } = *options;
-    let root = node.project.as_path();
+    let root = options.node.project.as_path();
     let Some(directory) = settings.and_then(|settings| settings.cargo_target_dir.as_deref()) else {
         return execute_task_scripts(options);
     };
@@ -826,40 +959,59 @@ fn execute_task_with_cargo_cache(
         options.base_extra_env,
         settings.and_then(|settings| settings.env.as_deref()).unwrap_or_default(),
     );
-    let cargo_cacheable =
-        !invocation.no_cache && settings.is_some_and(|settings| settings.cache != Some(false));
-    let snapshot = cargo_cacheable.then_some(task_key).flatten().and_then(|task_key| {
-        cargo_cache::snapshot_entry(&config.cache_dir, root, task_key, &environment)
+    let cargo_cacheable = !options.invocation.no_cache
+        && settings.is_some_and(|settings| settings.cache != Some(false));
+    let snapshot = cargo_cacheable.then_some(options.task_key).flatten().and_then(|task_key| {
+        cargo_cache::snapshot_entry(&options.config.cache_dir, root, task_key, &environment)
             .inspect_err(|error| cargo_cache_warning(options, &error.to_string()))
             .ok()
     });
-    if let Some((entry, key, _)) = &snapshot {
-        match cargo.restore(entry, key) {
-            Ok(true) => emit(&LogEvent::Pnpm(PnpmLog {
-                level: LogLevel::Info,
-                message: format!("{summary_key}: restored Cargo build state"),
-                prefix: root.to_string_lossy().into_owned(),
-            })),
-            // A snapshot that is not there yet is the ordinary first run.
-            Ok(false) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => cargo_cache_warning(options, &error.to_string()),
-        }
-        cargo.prepare(key).into_diagnostic()?;
+    if let Some(snapshot) = &snapshot {
+        restore_cargo_snapshot(options, &cargo, snapshot)?;
     }
-    let mut extra_env = options.base_extra_env.clone();
-    for name in ["CARGO_TARGET_DIR", "CARGO_BUILD_BUILD_DIR"] {
-        extra_env.insert(name.to_string(), cargo.target.to_string_lossy().into_owned());
-    }
+    let extra_env = cargo_build_env(options.base_extra_env, &cargo);
     let execution =
         execute_task_scripts(&RunTaskOptions { base_extra_env: &extra_env, ..*options })?;
     if execution.status == Status::Passed
-        && let Some(task_key) = task_key
+        && let Some(task_key) = options.task_key
         && let Some(snapshot) = &snapshot
     {
         publish_cargo_snapshot(options, &cargo, snapshot, task_key, &environment);
     }
     Ok(execution)
+}
+
+/// Restore the key's snapshot into the build directory, then ready the
+/// directory for this key's run.
+fn restore_cargo_snapshot(
+    options: &RunTaskOptions<'_, '_>,
+    cargo: &cargo_cache::CargoCache,
+    (entry, key, _): &(PathBuf, String, Vec<String>),
+) -> miette::Result<()> {
+    match cargo.restore(entry, key) {
+        Ok(true) => (options.emit)(&LogEvent::Pnpm(PnpmLog {
+            level: LogLevel::Info,
+            message: format!("{}: restored Cargo build state", options.summary_key),
+            prefix: options.node.project.to_string_lossy().into_owned(),
+        })),
+        // A snapshot that is not there yet is the ordinary first run.
+        Ok(false) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => cargo_cache_warning(options, &error.to_string()),
+    }
+    cargo.prepare(key).into_diagnostic()
+}
+
+/// The task's environment with Cargo pointed at the cached build directory.
+fn cargo_build_env(
+    base_extra_env: &HashMap<String, String>,
+    cargo: &cargo_cache::CargoCache,
+) -> HashMap<String, String> {
+    let mut extra_env = base_extra_env.clone();
+    for name in ["CARGO_TARGET_DIR", "CARGO_BUILD_BUILD_DIR"] {
+        extra_env.insert(name.to_string(), cargo.target.to_string_lossy().into_owned());
+    }
+    extra_env
 }
 
 /// Save the build directory as this task key's snapshot — but only when
@@ -903,42 +1055,33 @@ struct TaskExecution {
 /// Run the task's scripts for real, capturing their output stream for
 /// the cache alongside the live reporter rendering.
 fn execute_task_scripts(options: &RunTaskOptions<'_, '_>) -> miette::Result<TaskExecution> {
-    let RunTaskOptions {
-        node,
-        graph,
-        config,
-        invocation,
-        init_cwd,
-        base_extra_env,
-        silent,
-        emit,
-        ..
-    } = *options;
-    let root = node.project.as_path();
-    let manifest = &graph[root].package.project.manifest;
+    let root = options.node.project.as_path();
+    let manifest = &options.graph[root].package.project.manifest;
 
-    let extra_env = task_environment(config, root, base_extra_env);
-    let capture_output =
-        options.task_key.is_some() && task_cacheable(invocation, config.tasks.get(&node.task_name));
+    let extra_env = task_environment(options.config, root, options.base_extra_env);
+    let capture_output = options.task_key.is_some()
+        && task_cacheable(options.invocation, options.config.tasks.get(&options.node.task_name));
     let root_str = root.to_string_lossy().into_owned();
-    let mut status = Status::Passed;
-    let mut message = None;
-    let mut captured = capture_output.then(Vec::new);
+    let mut execution = TaskExecution {
+        status: Status::Passed,
+        message: None,
+        captured: capture_output.then(Vec::new),
+    };
     let mut captured_bytes = 0usize;
-    for selected in &node.scripts {
+    for selected in &options.node.scripts {
         let Some(script) = runnable_script(manifest, selected, root)? else {
             continue;
         };
         let ctx = RunContext {
             manifest,
             dir: root,
-            init_cwd,
-            config,
+            init_cwd: options.init_cwd,
+            config: options.config,
             extra_env: &extra_env,
-            silent,
+            silent: options.silent,
             output: ScriptOutput::Streamed {
                 dep_path: &root_str,
-                emit: if capture_output { capture::capturing_emit } else { emit },
+                emit: if capture_output { capture::capturing_emit } else { options.emit },
             },
             // The pipeline never bails, so there is no cancellation to
             // propagate into running children.
@@ -947,21 +1090,22 @@ fn execute_task_scripts(options: &RunTaskOptions<'_, '_>) -> miette::Result<Task
         let exit = run_stages(&ctx, selected, &script, &[]);
         if capture_output {
             drain_captured_output(
-                &mut captured,
+                &mut execution.captured,
                 &mut captured_bytes,
                 &root_str,
                 selected,
-                config.enable_pre_post_scripts,
+                options.config.enable_pre_post_scripts,
             );
         }
         let exit = exit?;
         if !exit.success() {
-            status = Status::Failure;
-            message = Some(format!("command failed with exit code {}", exit.code().unwrap_or(1)));
+            execution.status = Status::Failure;
+            execution.message =
+                Some(format!("command failed with exit code {}", exit.code().unwrap_or(1)));
             break;
         }
     }
-    Ok(TaskExecution { status, message, captured })
+    Ok(execution)
 }
 
 /// Take the output one script produced into the capture buffer. A task

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
@@ -130,29 +130,28 @@ impl TaskCache {
     /// The task's cache key: `pnpm-pipeline-task:v0` over the components
     /// the RFC names, NUL-separated and hashed.
     pub fn compute_task_key(&self, inputs: &TaskKeyInputs<'_>) -> miette::Result<Option<String>> {
-        let TaskKeyInputs { node, settings, dependency_keys, script_bodies, environment } = *inputs;
-        let project_rel = self.project_rel(&node.project);
         let mut components: Vec<String> = vec![
             "pnpm-pipeline-task:v1".to_string(),
             format!("platform:{}:{}", env::consts::OS, env::consts::ARCH),
-            format!("outputs:{:?}", settings.and_then(|settings| settings.outputs.as_ref())),
-            project_rel,
-            node.task_name.clone(),
+            format!("outputs:{:?}", inputs.settings.and_then(|settings| settings.outputs.as_ref())),
+            self.project_rel(&inputs.node.project),
+            inputs.node.task_name.clone(),
             format!("lockfile:{}", self.lockfile_hash),
             format!("runtime:{}", self.runtime_fingerprint),
         ];
-        for (stage, body) in script_bodies {
+        for (stage, body) in inputs.script_bodies {
             components.push(format!("script:{stage}={body}"));
         }
-        for name in settings.and_then(|settings| settings.env.as_deref()).unwrap_or_default() {
-            let value = environment.get(name).cloned().or_else(|| env::var(name).ok());
+        for name in inputs.settings.and_then(|settings| settings.env.as_deref()).unwrap_or_default()
+        {
+            let value = inputs.environment.get(name).cloned().or_else(|| env::var(name).ok());
             components.push(format!("env:{name}={value:?}"));
         }
-        let Some(files) = self.input_files(node, settings)? else { return Ok(None) };
+        let Some(files) = self.input_files(inputs.node, inputs.settings)? else { return Ok(None) };
         for file in files.iter() {
             components.push(format!("file:{}={}", file.rel_path, file.hash));
         }
-        for dependency_key in dependency_keys {
+        for dependency_key in inputs.dependency_keys {
             components.push(format!("dep:{dependency_key}"));
         }
         Ok(Some(create_hex_hash(&components.join("\0"))))
@@ -313,22 +312,11 @@ impl TaskCache {
         settings: Option<&TaskSettings>,
     ) -> miette::Result<ProjectInputHashes> {
         let Some(all) = self.hashed_project_files(&node.project)? else { return Ok(None) };
-        let outputs = settings.and_then(|settings| settings.outputs.as_deref()).unwrap_or_default();
-        let inputs = settings.and_then(|settings| settings.inputs.as_deref());
-        let output_globs = compile_globs(outputs)?;
-        let (replace_globs, add_globs) = match inputs {
-            None => (Vec::new(), Vec::new()),
-            Some(patterns) => {
-                let (add, replace): (Vec<&String>, Vec<&String>) =
-                    patterns.iter().partition(|pattern| pattern.starts_with('+'));
-                (
-                    compile_globs_ref(&replace)?,
-                    compile_globs_owned(
-                        &add.iter().map(|pattern| pattern[1..].to_string()).collect::<Vec<_>>(),
-                    )?,
-                )
-            }
-        };
+        let output_globs = compile_globs(
+            settings.and_then(|settings| settings.outputs.as_deref()).unwrap_or_default(),
+        )?;
+        let (replace_globs, add_globs) =
+            input_globs(settings.and_then(|settings| settings.inputs.as_deref()))?;
         let filtered: Vec<HashedFile> = all
             .iter()
             .filter(|file| !output_globs.iter().any(|glob| glob.is_match(file.rel_path.as_str())))
@@ -397,6 +385,22 @@ impl TaskCache {
             .insert(project.to_path_buf(), Some(Arc::clone(&files)));
         Ok(Some(files))
     }
+}
+
+/// The globs a task's `inputs` declaration replaces the default set with,
+/// and the `+`-prefixed ones that add to it.
+fn input_globs(inputs: Option<&[String]>) -> miette::Result<(Vec<Glob<'_>>, Vec<Glob<'static>>)> {
+    let Some(patterns) = inputs else {
+        return Ok((Vec::new(), Vec::new()));
+    };
+    let (add, replace): (Vec<&String>, Vec<&String>) =
+        patterns.iter().partition(|pattern| pattern.starts_with('+'));
+    Ok((
+        compile_globs_ref(&replace)?,
+        compile_globs_owned(
+            &add.iter().map(|pattern| pattern[1..].to_string()).collect::<Vec<_>>(),
+        )?,
+    ))
 }
 
 /// A tracked input's contribution to the key, or `None` when the file is

--- a/pnpm/crates/cli/src/cli_args/pipeline/cargo_cache.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cargo_cache.rs
@@ -235,9 +235,22 @@ pub(super) fn snapshot_entry(
     for path in paths {
         add_tracked_file_input(&repo, path, &mut inputs)?;
     }
+    add_config_inputs(project, environment, &mut inputs)?;
+    let key = create_hex_hash(&serde_json::to_string(&inputs)?);
+    let scope = create_hex_hash(&common.to_string_lossy());
+    Ok((cache_dir.join("cargo-build/v1").join(scope).join(&key), key, local_packages))
+}
+
+/// Every Cargo config file the build reads: `.cargo/config[.toml]` in each
+/// ancestor of the project, then the Cargo home's.
+fn add_config_inputs(
+    project: &Path,
+    environment: &BTreeMap<String, String>,
+    inputs: &mut Vec<String>,
+) -> io::Result<()> {
     for ancestor in project.ancestors() {
         for name in ["config", "config.toml"] {
-            add_config(&ancestor.join(".cargo").join(name), project, &mut inputs)?;
+            add_config(&ancestor.join(".cargo").join(name), project, inputs)?;
         }
     }
     let cargo_home = environment
@@ -246,12 +259,10 @@ pub(super) fn snapshot_entry(
         .or_else(|| home::home_dir().map(|home| home.join(".cargo")));
     if let Some(cargo_home) = cargo_home {
         for name in ["config", "config.toml"] {
-            add_config(&cargo_home.join(name), project, &mut inputs)?;
+            add_config(&cargo_home.join(name), project, inputs)?;
         }
     }
-    let key = create_hex_hash(&serde_json::to_string(&inputs)?);
-    let scope = create_hex_hash(&common.to_string_lossy());
-    Ok((cache_dir.join("cargo-build/v1").join(scope).join(&key), key, local_packages))
+    Ok(())
 }
 
 /// The workspace's own packages, and the guarantee that each one's

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -281,46 +281,15 @@ fn select_workspace_projects_with_cycles(
                 pnpm_package_manager::workspace_cycles(&selection.selected).unwrap_or_default()
             });
         let project_dependencies = project_dependencies(&selection, recursive_sort);
-        // Sequenced over borrowed paths: cloning a workspace-scale edge
-        // map just to sort it cost more than the sort.
-        let ordered_dirs = graph_sequencer(
-            &project_dependencies
-                .iter()
-                .map(|(key, value)| {
-                    (
-                        PathNode(key.as_path()),
-                        value.iter().map(|dir| PathNode(dir)).collect::<Vec<_>>(),
-                    )
-                })
-                .collect(),
-            &project_dependencies.keys().map(|dir| PathNode(dir)).collect::<Vec<_>>(),
-        )
-        .order
-        .into_iter()
-        .map(|node| node.0.to_path_buf())
-        .collect();
+        let ordered_dirs = sequence_project_dependencies(&project_dependencies);
         let selected_dirs: Arc<HashSet<PathBuf>> =
             Arc::new(selection.selected.keys().cloned().collect());
         (project_dependencies, ordered_dirs, selected_dirs, workspace_cycles)
     };
 
     let active_dir = manifest_path.parent().expect("manifest path always has a parent dir");
-    let normalized_active_dir = pnpm_fs::lexical_normalize(active_dir);
-    let active_manifest_is_standin = !active_dir.join("package.json").is_file()
-        && pnpm_workspace::try_read_project_manifest(active_dir)
-            .map_err(miette::Report::new)?
-            .is_none()
-        && !projects
-            .iter()
-            .any(|project| pnpm_fs::lexical_normalize(&project.root_dir) == normalized_active_dir);
-    let normalized_workspace_root = pnpm_fs::lexical_normalize(&workspace_root);
-    let mut install_dirs = selected_dirs.as_ref().clone();
-    if let Some(workspace_root_project) = projects
-        .iter()
-        .find(|project| pnpm_fs::lexical_normalize(&project.root_dir) == normalized_workspace_root)
-    {
-        install_dirs.insert(workspace_root_project.root_dir.clone());
-    }
+    let active_manifest_is_standin = active_manifest_is_standin(active_dir, &projects)?;
+    let install_dirs = install_dirs(&selected_dirs, &projects, &workspace_root);
 
     Ok(Some(InstallFamilySelection {
         workspace_root,
@@ -332,6 +301,60 @@ fn select_workspace_projects_with_cycles(
         active_manifest_is_standin,
         workspace_cycles,
     }))
+}
+
+/// The selection in build order. Sequenced over borrowed paths: cloning a
+/// workspace-scale edge map just to sort it cost more than the sort.
+fn sequence_project_dependencies(
+    project_dependencies: &IndexMap<PathBuf, Vec<PathBuf>>,
+) -> Vec<PathBuf> {
+    graph_sequencer(
+        &project_dependencies
+            .iter()
+            .map(|(key, value)| {
+                (PathNode(key.as_path()), value.iter().map(|dir| PathNode(dir)).collect::<Vec<_>>())
+            })
+            .collect(),
+        &project_dependencies.keys().map(|dir| PathNode(dir)).collect::<Vec<_>>(),
+    )
+    .order
+    .into_iter()
+    .map(|node| node.0.to_path_buf())
+    .collect()
+}
+
+/// Whether the active directory has no manifest of its own and is none of
+/// the workspace's projects, so the manifest at hand stands in for one.
+fn active_manifest_is_standin(
+    active_dir: &Path,
+    projects: &[pnpm_workspace::Project],
+) -> miette::Result<bool> {
+    let normalized_active_dir = pnpm_fs::lexical_normalize(active_dir);
+    Ok(!active_dir.join("package.json").is_file()
+        && pnpm_workspace::try_read_project_manifest(active_dir)
+            .map_err(miette::Report::new)?
+            .is_none()
+        && !projects
+            .iter()
+            .any(|project| pnpm_fs::lexical_normalize(&project.root_dir) == normalized_active_dir))
+}
+
+/// The selected projects plus the workspace root project, when the
+/// workspace root is a project.
+fn install_dirs(
+    selected_dirs: &HashSet<PathBuf>,
+    projects: &[pnpm_workspace::Project],
+    workspace_root: &Path,
+) -> HashSet<PathBuf> {
+    let normalized_workspace_root = pnpm_fs::lexical_normalize(workspace_root);
+    let mut install_dirs = selected_dirs.clone();
+    if let Some(workspace_root_project) = projects
+        .iter()
+        .find(|project| pnpm_fs::lexical_normalize(&project.root_dir) == normalized_workspace_root)
+    {
+        install_dirs.insert(workspace_root_project.root_dir.clone());
+    }
+    install_dirs
 }
 
 /// The edges the sequencer orders the selection by. Without `--sort`
@@ -428,17 +451,7 @@ impl InstallPipeline {
     pub(crate) async fn run_with_config<Reporter: self::Reporter + 'static>(
         self,
     ) -> miette::Result<&'static Config> {
-        let InstallPipeline {
-            args,
-            cfg,
-            config_root,
-            prefix,
-            manifest_path,
-            recursive_sort,
-            require_lockfile,
-            frozen_lockfile,
-        } = self;
-        config_deps::prepare::<Reporter>(cfg, &config_root, frozen_lockfile).await?;
+        config_deps::prepare::<Reporter>(self.cfg, &self.config_root, self.frozen_lockfile).await?;
         // Built ahead of project discovery so a run that is certain to
         // read the wanted lockfile parses it on a background thread
         // while discovery walks the workspace. Certain means the fast
@@ -450,28 +463,22 @@ impl InstallPipeline {
         // through the separate repair loader, which this prefetch does
         // not feed. Only the shared-lockfile arms consume this
         // lockfile; the per-project arms load their own.
-        let lockfile = cfg
+        let lockfile = self
+            .cfg
             .shares_one_lockfile()
-            .then(|| State::lazy_lockfile(cfg, &manifest_path, require_lockfile));
-        let certain_full_install = cfg.shares_one_lockfile() && {
-            let manifest_dir =
-                manifest_path.parent().expect("manifest path always has a parent dir");
-            let lockfile_dir = cfg.lockfile_dir_for(manifest_dir);
-            frozen_lockfile
-                || cfg.force
-                || !pnpm_workspace_state::get_file_path(lockfile_dir).is_file()
-        };
+            .then(|| State::lazy_lockfile(self.cfg, &self.manifest_path, self.require_lockfile));
+        let certain_full_install = self.certain_full_install();
         if let Some(lockfile) = lockfile.as_ref()
-            && !args.fix_lockfile
+            && !self.args.fix_lockfile
             && certain_full_install
         {
             lockfile.prefetch();
         }
         let plan = select_install_family_plan::<Reporter>(
-            cfg,
-            &prefix,
-            &manifest_path,
-            recursive_sort,
+            self.cfg,
+            &self.prefix,
+            &self.manifest_path,
+            self.recursive_sort,
             false,
             certain_full_install,
         )?;
@@ -480,20 +487,20 @@ impl InstallPipeline {
             InstallFamilyPlan::Shared(selection) => !selection.selected_dirs.is_empty(),
             InstallFamilyPlan::Single => true,
         };
-        if !installs_node && !ecosystem_install::is_enabled(cfg) {
-            return Ok(cfg);
+        if !installs_node && !ecosystem_install::is_enabled(self.cfg) {
+            return Ok(self.cfg);
         }
 
-        let http_client = State::new_http_client(cfg).wrap_err("initialize the install network")?;
-        let cfg: &'static Config = cfg;
-        let lockfile_only = args.lockfile_only;
+        let http_client =
+            State::new_http_client(self.cfg).wrap_err("initialize the install network")?;
+        let cfg: &'static Config = self.cfg;
         if !ecosystem_install::is_enabled(cfg) {
             run_node_install::<Reporter>(
                 plan,
-                args,
+                self.args,
                 cfg,
-                manifest_path,
-                require_lockfile,
+                self.manifest_path,
+                self.require_lockfile,
                 lockfile,
                 http_client,
             )
@@ -504,19 +511,19 @@ impl InstallPipeline {
             ecosystem_install::InstallContext {
                 config: cfg,
                 http_client: Arc::clone(&http_client),
-                lockfile_only,
-                frozen_lockfile,
+                lockfile_only: self.args.lockfile_only,
+                frozen_lockfile: self.frozen_lockfile,
             },
-            config_root,
-            &args.dependency_options,
+            self.config_root,
+            &self.args.dependency_options,
         )
         .await?;
         let node_install = run_node_install::<Reporter>(
             plan,
-            args,
+            self.args,
             cfg,
-            manifest_path,
-            require_lockfile,
+            self.manifest_path,
+            self.require_lockfile,
             lockfile,
             http_client,
         );
@@ -525,6 +532,19 @@ impl InstallPipeline {
             .run()
             .await?;
         Ok(cfg)
+    }
+
+    /// Whether the fast "Already up to date" return cannot fire, so the run
+    /// is certain to read the wanted lockfile.
+    fn certain_full_install(&self) -> bool {
+        self.cfg.shares_one_lockfile() && {
+            let manifest_dir =
+                self.manifest_path.parent().expect("manifest path always has a parent dir");
+            let lockfile_dir = self.cfg.lockfile_dir_for(manifest_dir);
+            self.frozen_lockfile
+                || self.cfg.force
+                || !pnpm_workspace_state::get_file_path(lockfile_dir).is_file()
+        }
     }
 }
 
@@ -617,37 +637,27 @@ pub(crate) struct AddPipeline {
 
 impl AddPipeline {
     pub(crate) async fn run<Reporter: self::Reporter + 'static>(self) -> miette::Result<()> {
-        let AddPipeline {
-            args,
-            cfg,
-            config_root,
-            prefix,
-            manifest_path,
-            recursive_sort,
-            config_dependencies,
-            package_specifier_plan,
-        } = self;
-        config_deps::prepare::<Reporter>(cfg, &config_root, false).await?;
-        if !package_specifier_plan.ecosystem_packages.is_empty() {
+        config_deps::prepare::<Reporter>(self.cfg, &self.config_root, false).await?;
+        if !self.package_specifier_plan.ecosystem_packages.is_empty() {
             return run_add_with_ecosystems::<Reporter>(
-                args,
-                cfg,
-                prefix,
-                manifest_path,
-                package_specifier_plan,
+                self.args,
+                self.cfg,
+                self.prefix,
+                self.manifest_path,
+                self.package_specifier_plan,
             )
             .await;
         }
         // `--config` targets the workspace's configuration dependencies, not
         // any project's manifest, so it bypasses project selection entirely.
-        let plan = if config_dependencies.is_some() {
+        let plan = if self.config_dependencies.is_some() {
             InstallFamilyPlan::Single
         } else {
             select_install_family_plan::<Reporter>(
-                cfg,
-                &prefix,
-                &manifest_path,
-                recursive_sort,
+                self.cfg,
+                &self.prefix,
+                &self.manifest_path,
+                self.recursive_sort,
                 true,
                 false,
             )?
@@ -656,15 +666,15 @@ impl AddPipeline {
             InstallFamilyPlan::PerProject(projects) => {
                 // Dedicated per-project lockfiles: add the packages to each
                 // selected project independently.
-                let workspace_packages = args.workspace_link_targets(cfg)?;
+                let workspace_packages = self.args.workspace_link_targets(self.cfg)?;
                 DedicatedProjectRuns {
-                    config: cfg,
+                    config: self.cfg,
                     projects,
                     require_lockfile: false,
                     http_client: None,
                 }
                 .run(|state| {
-                    Box::pin(args.clone().run_with_link_targets::<Reporter>(
+                    Box::pin(self.args.clone().run_with_link_targets::<Reporter>(
                         state,
                         None,
                         workspace_packages.as_ref(),
@@ -676,31 +686,32 @@ impl AddPipeline {
                 if selection.selected_dirs.is_empty() {
                     return Ok(());
                 }
-                let cfg: &'static Config = cfg;
+                let cfg: &'static Config = self.cfg;
                 let state =
-                    State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
-                Box::pin(args.run_selected::<Reporter>(state, *selection)).await
+                    State::init(self.manifest_path, cfg, false).wrap_err("initialize the state")?;
+                Box::pin(self.args.run_selected::<Reporter>(state, *selection)).await
             }
             InstallFamilyPlan::Single => {
                 // Dedicated per-project lockfiles: `add` mutates only the
                 // active project, whose outputs anchor at the project dir.
                 // `--config` targets the workspace's configuration
                 // dependencies, which stay workspace-anchored.
-                if config_dependencies.is_none()
-                    && !cfg.shares_one_lockfile()
-                    && cfg.workspace_dir.is_some()
+                if self.config_dependencies.is_none()
+                    && !self.cfg.shares_one_lockfile()
+                    && self.cfg.workspace_dir.is_some()
                 {
-                    let manifest_dir = manifest_path
+                    let manifest_dir = self
+                        .manifest_path
                         .parent()
                         .expect("manifest path always has a parent dir")
                         .to_path_buf();
-                    let name = dedicated_project_name(cfg, &manifest_dir);
-                    cfg.anchor_dedicated_project(&manifest_dir, name.as_deref());
+                    let name = dedicated_project_name(self.cfg, &manifest_dir);
+                    self.cfg.anchor_dedicated_project(&manifest_dir, name.as_deref());
                 }
-                let cfg: &'static Config = cfg;
+                let cfg: &'static Config = self.cfg;
                 let state =
-                    State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
-                Box::pin(args.run::<Reporter>(state, config_dependencies)).await
+                    State::init(self.manifest_path, cfg, false).wrap_err("initialize the state")?;
+                Box::pin(self.args.run::<Reporter>(state, self.config_dependencies)).await
             }
         }
     }
@@ -779,13 +790,12 @@ pub(crate) struct UpdatePipeline {
 
 impl UpdatePipeline {
     pub(crate) async fn run<Reporter: self::Reporter + 'static>(self) -> miette::Result<()> {
-        let UpdatePipeline { args, cfg, config_root, prefix, manifest_path, recursive_sort } = self;
-        config_deps::prepare::<Reporter>(cfg, &config_root, false).await?;
+        config_deps::prepare::<Reporter>(self.cfg, &self.config_root, false).await?;
         let plan = select_install_family_plan::<Reporter>(
-            cfg,
-            &prefix,
-            &manifest_path,
-            recursive_sort,
+            self.cfg,
+            &self.prefix,
+            &self.manifest_path,
+            self.recursive_sort,
             false,
             false,
         )?;
@@ -804,48 +814,49 @@ impl UpdatePipeline {
         // mutates only the active project, whose outputs anchor at the
         // project dir.
         if matches!(plan, InstallFamilyPlan::Single)
-            && !cfg.shares_one_lockfile()
-            && cfg.workspace_dir.is_some()
+            && !self.cfg.shares_one_lockfile()
+            && self.cfg.workspace_dir.is_some()
         {
-            let manifest_dir = manifest_path
+            let manifest_dir = self
+                .manifest_path
                 .parent()
                 .expect("manifest path always has a parent dir")
                 .to_path_buf();
-            let name = dedicated_project_name(cfg, &manifest_dir);
-            cfg.anchor_dedicated_project(&manifest_dir, name.as_deref());
+            let name = dedicated_project_name(self.cfg, &manifest_dir);
+            self.cfg.anchor_dedicated_project(&manifest_dir, name.as_deref());
         }
-        let generate_changeset = if args.changeset {
+        let generate_changeset = if self.args.changeset {
             true
-        } else if args.no_changeset {
+        } else if self.args.no_changeset {
             false
         } else {
-            cfg.update_config.changeset.unwrap_or(false)
+            self.cfg.update_config.changeset.unwrap_or(false)
         };
         let changeset_context = generate_changeset
-            .then(|| UpdateChangesetContext::capture(cfg, &manifest_path))
+            .then(|| UpdateChangesetContext::capture(self.cfg, &self.manifest_path))
             .transpose()?;
         match plan {
             InstallFamilyPlan::PerProject(projects) => {
                 DedicatedProjectRuns {
-                    config: cfg,
+                    config: self.cfg,
                     projects,
                     require_lockfile: false,
                     http_client: None,
                 }
-                .run(|state| Box::pin(args.clone().run::<Reporter>(state)))
+                .run(|state| Box::pin(self.args.clone().run::<Reporter>(state)))
                 .await?;
             }
             InstallFamilyPlan::Shared(selection) => {
-                let cfg: &'static Config = cfg;
+                let cfg: &'static Config = self.cfg;
                 let state =
-                    State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
-                Box::pin(args.run_selected::<Reporter>(state, *selection)).await?;
+                    State::init(self.manifest_path, cfg, false).wrap_err("initialize the state")?;
+                Box::pin(self.args.run_selected::<Reporter>(state, *selection)).await?;
             }
             InstallFamilyPlan::Single => {
-                let cfg: &'static Config = cfg;
+                let cfg: &'static Config = self.cfg;
                 let state =
-                    State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
-                Box::pin(args.run::<Reporter>(state)).await?;
+                    State::init(self.manifest_path, cfg, false).wrap_err("initialize the state")?;
+                Box::pin(self.args.run::<Reporter>(state)).await?;
             }
         }
         if let Some(changeset_context) = changeset_context {
@@ -1063,27 +1074,25 @@ pub(crate) struct DedupePipeline {
 
 impl DedupePipeline {
     pub(crate) async fn run<Reporter: self::Reporter + 'static>(self) -> miette::Result<()> {
-        let DedupePipeline { args, cfg, config_root, prefix, manifest_path, recursive_sort } = self;
-
-        let lockfile_path = config_root.join(cfg.wanted_lockfile_name());
+        let lockfile_path = self.config_root.join(self.cfg.wanted_lockfile_name());
 
         // Snapshot before any config-dep writes so --check detects lockfile
         // changes made by config-dependency syncing as well.
         let existing =
-            if args.check { dedupe::read_lockfile_snapshot(&lockfile_path)? } else { None };
+            if self.args.check { dedupe::read_lockfile_snapshot(&lockfile_path)? } else { None };
         let guard =
-            args.check.then(|| dedupe::LockfileGuard::new(existing.clone(), &lockfile_path));
+            self.args.check.then(|| dedupe::LockfileGuard::new(existing.clone(), &lockfile_path));
 
-        config_deps::prepare::<Reporter>(cfg, &config_root, false).await?;
+        config_deps::prepare::<Reporter>(self.cfg, &self.config_root, false).await?;
         let plan = select_install_family_plan::<Reporter>(
-            cfg,
-            &prefix,
-            &manifest_path,
-            recursive_sort,
+            self.cfg,
+            &self.prefix,
+            &self.manifest_path,
+            self.recursive_sort,
             false,
             false,
         )?;
-        let cfg: &'static Config = cfg;
+        let cfg: &'static Config = self.cfg;
         match plan {
             InstallFamilyPlan::PerProject(projects) => {
                 DedicatedProjectRuns {
@@ -1094,7 +1103,7 @@ impl DedupePipeline {
                 }
                 .run(|state| {
                     Box::pin(dedupe_dedicated_project::<Reporter>(
-                        args.clone(),
+                        self.args.clone(),
                         state,
                         &lockfile_path,
                         existing.as_deref(),
@@ -1111,8 +1120,8 @@ impl DedupePipeline {
                     return Ok(());
                 }
                 let state =
-                    State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
-                Box::pin(args.run::<Reporter>(
+                    State::init(self.manifest_path, cfg, false).wrap_err("initialize the state")?;
+                Box::pin(self.args.run::<Reporter>(
                     state,
                     existing,
                     guard,
@@ -1123,8 +1132,9 @@ impl DedupePipeline {
             }
             InstallFamilyPlan::Single => {
                 let state =
-                    State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
-                Box::pin(args.run::<Reporter>(state, existing, guard, &lockfile_path, None)).await
+                    State::init(self.manifest_path, cfg, false).wrap_err("initialize the state")?;
+                Box::pin(self.args.run::<Reporter>(state, existing, guard, &lockfile_path, None))
+                    .await
             }
         }
     }

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -236,14 +236,13 @@ fn pre_command_plan_from_input(
     config_overrides: &ConfigOverrides,
     process_state: SwitchProcessState,
 ) -> miette::Result<Option<PreCommandPlan>> {
-    let switch = &input.switch;
-    if switch.command.as_deref().is_some_and(should_skip_command_name) {
+    if input.switch.command.as_deref().is_some_and(should_skip_command_name) {
         return Ok(None);
     }
-    let dir = dunce::canonicalize(&switch.dir).into_diagnostic().wrap_err_with(|| {
-        format!("canonicalizing the `--dir` argument: {}", switch.dir.display())
+    let dir = dunce::canonicalize(&input.switch.dir).into_diagnostic().wrap_err_with(|| {
+        format!("canonicalizing the `--dir` argument: {}", input.switch.dir.display())
     })?;
-    let config = load_pre_command_config(switch, config_overrides, &dir)?;
+    let config = load_pre_command_config(&input.switch, config_overrides, &dir)?;
 
     let roots = PinRoots {
         manifest: config.workspace_dir.clone().unwrap_or_else(|| dir.clone()),
@@ -252,17 +251,20 @@ fn pre_command_plan_from_input(
     let manifest = read_manifest_json(&roots.manifest.join("package.json"))?;
 
     let wanted_pm = manifest.as_ref().and_then(wanted_package_manager);
-    let running_matches_pin = wanted_pm.as_ref().is_some_and(|pm| {
-        pm.name == "pnpm"
-            && pm.version.as_deref().is_some_and(|version| version_satisfies(PNPM_VERSION, version))
-    });
+    let running_matches_pin = pin_matches_running(wanted_pm.as_ref());
     let mut package_manager_to_sync = None;
     if !input.skip_pm_handling
         && let Some(root_manifest) = manifest.as_ref()
         && let Some(pm) = wanted_pm
     {
         match resolve_package_manager_pin(
-            &PinResolution { input, config: &config, roots: &roots, process_state, switch },
+            &PinResolution {
+                input,
+                config: &config,
+                roots: &roots,
+                process_state,
+                switch: &input.switch,
+            },
             root_manifest,
             &pm,
         )? {
@@ -273,13 +275,7 @@ fn pre_command_plan_from_input(
         }
     }
 
-    if input.key_issues != KeyIssueReporting::Skip {
-        // A `--global` invocation does not act on the project, so a satisfied
-        // pin does not harden its unrecognized-key report into an error.
-        let strict =
-            input.key_issues == KeyIssueReporting::Enforce && running_matches_pin && !input.global;
-        report_workspace_key_issues(&config.workspace_key_issues, strict)?;
-    }
+    report_key_issues(input, &config, running_matches_pin)?;
 
     if input.check_runtimes
         && !input.skip_pm_handling
@@ -289,14 +285,41 @@ fn pre_command_plan_from_input(
         check_runtimes(manifest, &config, input.emit)?;
     }
     Ok(package_manager_to_sync.map(|package_manager| {
-        let frozen_lockfile = switch.frozen_lockfile.or(config.frozen_lockfile).unwrap_or(false);
         PreCommandPlan::SyncEnvLockfile(EnvLockfileSync {
+            frozen_lockfile: input
+                .switch
+                .frozen_lockfile
+                .or(config.frozen_lockfile)
+                .unwrap_or(false),
             config,
             env_root: roots.env,
             package_manager,
-            frozen_lockfile,
         })
     }))
+}
+
+/// Whether the manifest's pin names the pnpm that is running.
+fn pin_matches_running(wanted_pm: Option<&WantedPackageManager>) -> bool {
+    wanted_pm.is_some_and(|pm| {
+        pm.name == "pnpm"
+            && pm.version.as_deref().is_some_and(|version| version_satisfies(PNPM_VERSION, version))
+    })
+}
+
+/// A `--global` invocation does not act on the project, so a satisfied
+/// pin does not harden its unrecognized-key report into an error.
+fn report_key_issues(
+    input: &PreCommandInput,
+    config: &Config,
+    running_matches_pin: bool,
+) -> miette::Result<()> {
+    if input.key_issues == KeyIssueReporting::Skip {
+        return Ok(());
+    }
+    let strict =
+        input.key_issues == KeyIssueReporting::Enforce && running_matches_pin && !input.global;
+    report_workspace_key_issues(&config.workspace_key_issues, strict)?;
+    Ok(())
 }
 
 /// Load the configuration the pre-command pass reads, with the global
@@ -949,25 +972,8 @@ fn package_manager_dependencies_are_resolved(env: &EnvLockfile, version: &str) -
 fn assert_package_manager_lockfile_uses_registry_resolutions(
     env: &EnvLockfile,
 ) -> miette::Result<()> {
-    let Some(package_manager_dependencies) = env
-        .importers
-        .get(EnvLockfile::ROOT_IMPORTER_KEY)
-        .and_then(|importer| importer.package_manager_dependencies.as_ref())
-    else {
-        return Err(miette::miette!(
-            "The packageManager dependencies were not found in pnpm-lock.yaml"
-        ));
-    };
-
     let mut visited = HashSet::new();
-    let mut pending = Vec::with_capacity(package_manager_dependencies.len());
-    for (name, dependency) in package_manager_dependencies {
-        let key = format!("{name}@{}", dependency.version)
-            .parse::<PackageKey>()
-            .map_err(|_| invalid_package_manager_lockfile(name))?;
-        pending.push(key);
-    }
-
+    let mut pending = package_manager_root_keys(env)?;
     while let Some(key) = pending.pop() {
         if !visited.insert(key.clone()) {
             continue;
@@ -994,6 +1000,27 @@ fn assert_package_manager_lockfile_uses_registry_resolutions(
         }
     }
     Ok(())
+}
+
+/// The lockfile keys of the root importer's `packageManager` dependencies.
+fn package_manager_root_keys(env: &EnvLockfile) -> miette::Result<Vec<PackageKey>> {
+    let Some(package_manager_dependencies) = env
+        .importers
+        .get(EnvLockfile::ROOT_IMPORTER_KEY)
+        .and_then(|importer| importer.package_manager_dependencies.as_ref())
+    else {
+        return Err(miette::miette!(
+            "The packageManager dependencies were not found in pnpm-lock.yaml"
+        ));
+    };
+    let mut pending = Vec::with_capacity(package_manager_dependencies.len());
+    for (name, dependency) in package_manager_dependencies {
+        let key = format!("{name}@{}", dependency.version)
+            .parse::<PackageKey>()
+            .map_err(|_| invalid_package_manager_lockfile(name))?;
+        pending.push(key);
+    }
+    Ok(pending)
 }
 
 fn assert_registry_package_path(

--- a/pnpm/crates/cli/src/cli_args/publish/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/publish/recursive.rs
@@ -105,19 +105,23 @@ impl PublishArgs {
 
         let http_client = build_registry_client(config)?;
         let network = PublishNetwork { client: &http_client, auth_headers: &config.auth_headers };
-        let otp = resolve_otp_from_env::<Host>(self.flags.otp.clone());
-        let opts = self.publish_options(config, otp, stage);
+        let opts = self.publish_options(
+            config,
+            resolve_otp_from_env::<Host>(self.flags.otp.clone()),
+            stage,
+        );
         if self.flags.batch {
             validate_batch_publish_options(&opts)?;
         }
-        let retry_opts = retry_opts_from_config(config);
 
         // Filter the selected graph: keep only packages that have a name and
         // version, are not private, and — unless `--force` — are not already on
         // their registry. The already-published probes are independent registry
         // reads, so run them concurrently rather than one round-trip at a time
         // (the `ThrottledClient` still bounds the actual in-flight fan-out).
-        let to_publish = self.projects_to_publish(graph, config, &http_client, retry_opts).await;
+        let to_publish = self
+            .projects_to_publish(graph, config, &http_client, retry_opts_from_config(config))
+            .await;
 
         if to_publish.is_empty() {
             emit_info::<Reporter>("There are no new packages that should be published", dir);
@@ -125,42 +129,58 @@ impl PublishArgs {
             return Ok(Vec::new());
         }
 
-        // Publishing cannot run
-        // concurrently: an OTP challenge is interactive and per-process.
         let project_dependencies = filtered_projects_dependencies(
             graph,
             selection.full_graph(),
             selection.prod_all.as_ref(),
             &selection.prod_only_selected,
         );
-        if self.flags.batch {
-            let published = self
-                .publish_batch::<Reporter>(
-                    config,
-                    &opts,
-                    &network,
-                    before_packing_hooks,
-                    &to_publish,
-                    &project_dependencies,
-                )
-                .await?;
-            self.write_summary(workspace_root, &published)?;
-            return Ok(published);
-        }
+        let published = if self.flags.batch {
+            self.publish_batch::<Reporter>(
+                config,
+                &opts,
+                &network,
+                before_packing_hooks,
+                &to_publish,
+                &project_dependencies,
+            )
+            .await?
+        } else {
+            self.publish_one_by_one::<Reporter>(
+                config,
+                &opts,
+                &network,
+                before_packing_hooks,
+                &to_publish,
+                &project_dependencies,
+            )
+            .await?
+        };
+        self.write_summary(workspace_root, &published)?;
+        Ok(published)
+    }
+
+    /// Publish in dependency order, one project at a time: an OTP challenge
+    /// is interactive and per-process.
+    async fn publish_one_by_one<Reporter: self::Reporter>(
+        &self,
+        config: &Config,
+        opts: &pnpm_publish::PublishPackedPkgOptions,
+        network: &PublishNetwork<'_>,
+        before_packing_hooks: &[Arc<dyn PnpmfileHooks>],
+        to_publish: &HashSet<PathBuf>,
+        project_dependencies: &indexmap::IndexMap<PathBuf, Vec<PathBuf>>,
+    ) -> miette::Result<Vec<PublishSummary>> {
         let published: Mutex<Vec<PublishSummary>> = Mutex::new(Vec::new());
         let first_error: Mutex<Option<miette::Report>> = Mutex::new(None);
         let run_node = |root: PathBuf| {
-            let command = self;
-            let to_publish = &to_publish;
-            let opts = &opts;
-            let network = &network;
             let published = &published;
             let first_error = &first_error;
             async move {
                 if !to_publish.contains(&root) {
                     return TaskCompletion::Passed;
                 }
-                let result = command
+                let result = self
                     .publish_directory::<Reporter>(
                         &root,
                         config,
@@ -174,17 +194,14 @@ impl PublishArgs {
         };
         let on_node_skipped: fn(&PathBuf) = |_| {};
         schedule_graph_async(
-            &project_dependencies,
+            project_dependencies,
             &ScheduleGraphAsyncOptions::new(1, true, &run_node, &on_node_skipped),
         )
         .await;
         if let Some(error) = first_error.into_inner().expect("publish error lock is not poisoned") {
             return Err(error);
         }
-        let published = published.into_inner().expect("publish results lock is not poisoned");
-
-        self.write_summary(workspace_root, &published)?;
-        Ok(published)
+        Ok(published.into_inner().expect("publish results lock is not poisoned"))
     }
     /// The selected projects that should be published: those with a name
     /// and version, not private, and — unless `--force` — not already on

--- a/pnpm/crates/cli/src/cli_args/rebuild.rs
+++ b/pnpm/crates/cli/src/cli_args/rebuild.rs
@@ -67,63 +67,66 @@ impl RebuildArgs {
         if !cfg.shares_one_lockfile()
             && let Some(workspace_selection) = workspace_selection
         {
-            let base_config = cfg.clone();
-            let names = project_names(cfg, &workspace_selection.projects);
-            let concurrency =
-                usize::try_from(cfg.workspace_concurrency).unwrap_or(usize::MAX).max(1);
-            let first_error: Mutex<Option<miette::Report>> = Mutex::new(None);
-            let run_node = |project_dir: PathBuf| {
-                let args = self.clone();
-                let mut project_config = base_config.clone();
-                project_config.anchor_dedicated_project(
-                    &project_dir,
-                    names.get(&project_dir).map(String::as_str),
-                );
-                let first_error = &first_error;
-                async move {
-                    let result = async {
-                        let project_config = Config::leak(project_config);
-                        let state =
-                            State::init(project_dir.join("package.json"), project_config, true)
-                                .wrap_err_with(|| {
-                                    format!(
-                                        "initialize the rebuild state for {}",
-                                        project_dir.display(),
-                                    )
-                                })?;
-                        Box::pin(args.run::<Reporter>(state, None)).await
-                    }
-                    .await;
-                    match result {
-                        Ok(()) => TaskCompletion::Passed,
-                        Err(error) => {
-                            first_error
-                                .lock()
-                                .expect("rebuild error lock is not poisoned")
-                                .get_or_insert(error);
-                            TaskCompletion::Failed
-                        }
-                    }
-                }
-            };
-            let on_node_skipped: fn(&PathBuf) = |_| {};
-            schedule_graph_async(
-                &workspace_selection.project_dependencies,
-                &ScheduleGraphAsyncOptions::new(concurrency, !no_bail, &run_node, &on_node_skipped)
-                    .continue_on_failure(no_bail),
-            )
-            .await;
-            if let Some(error) =
-                first_error.into_inner().expect("rebuild error lock is not poisoned")
-            {
-                return Err(error);
-            }
-            return Ok(());
+            return self.run_per_project::<Reporter>(cfg, workspace_selection, no_bail).await;
         }
 
         let state =
             State::init(manifest_path, cfg, true).wrap_err("initialize the rebuild state")?;
         Box::pin(self.run::<Reporter>(state, workspace_selection)).await
+    }
+
+    /// One rebuild per selected project, each against its own lockfile.
+    async fn run_per_project<Reporter: self::Reporter + 'static>(
+        self,
+        cfg: &'static Config,
+        workspace_selection: InstallFamilySelection,
+        no_bail: bool,
+    ) -> miette::Result<()> {
+        let base_config = cfg.clone();
+        let names = project_names(cfg, &workspace_selection.projects);
+        let concurrency = usize::try_from(cfg.workspace_concurrency).unwrap_or(usize::MAX).max(1);
+        let first_error: Mutex<Option<miette::Report>> = Mutex::new(None);
+        let run_node = |project_dir: PathBuf| {
+            let args = self.clone();
+            let mut project_config = base_config.clone();
+            project_config.anchor_dedicated_project(
+                &project_dir,
+                names.get(&project_dir).map(String::as_str),
+            );
+            let first_error = &first_error;
+            async move {
+                let result = async {
+                    let project_config = Config::leak(project_config);
+                    let state = State::init(project_dir.join("package.json"), project_config, true)
+                        .wrap_err_with(|| {
+                            format!("initialize the rebuild state for {}", project_dir.display())
+                        })?;
+                    Box::pin(args.run::<Reporter>(state, None)).await
+                }
+                .await;
+                match result {
+                    Ok(()) => TaskCompletion::Passed,
+                    Err(error) => {
+                        first_error
+                            .lock()
+                            .expect("rebuild error lock is not poisoned")
+                            .get_or_insert(error);
+                        TaskCompletion::Failed
+                    }
+                }
+            }
+        };
+        let on_node_skipped: fn(&PathBuf) = |_| {};
+        schedule_graph_async(
+            &workspace_selection.project_dependencies,
+            &ScheduleGraphAsyncOptions::new(concurrency, !no_bail, &run_node, &on_node_skipped)
+                .continue_on_failure(no_bail),
+        )
+        .await;
+        if let Some(error) = first_error.into_inner().expect("rebuild error lock is not poisoned") {
+            return Err(error);
+        }
+        Ok(())
     }
 }
 

--- a/pnpm/crates/cli/src/cli_args/remove.rs
+++ b/pnpm/crates/cli/src/cli_args/remove.rs
@@ -91,18 +91,8 @@ impl RemoveArgs {
     pub(crate) async fn run_selected<Reporter: self::Reporter + 'static>(
         self,
         mut state: State,
-        selection: InstallFamilySelection,
+        mut selection: InstallFamilySelection,
     ) -> miette::Result<()> {
-        let InstallFamilySelection {
-            workspace_root: _,
-            workspace_cycles: _,
-            mut projects,
-            project_dependencies,
-            ordered_dirs,
-            selected_dirs,
-            install_dirs,
-            active_manifest_is_standin,
-        } = selection;
         let lockfile_path = state.lockfile_path();
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &mut state;
@@ -124,12 +114,12 @@ impl RemoveArgs {
             lockfile_only: self.lockfile_only,
         }
         .run_selected::<Reporter>(pnpm_package_manager::SelectedProjects {
-            projects: &mut projects,
-            project_dependencies: &project_dependencies,
-            ordered_dirs: &ordered_dirs,
-            selected_dirs: selected_dirs.as_ref(),
-            install_dirs: install_dirs.as_ref(),
-            active_manifest_is_standin,
+            projects: &mut selection.projects,
+            project_dependencies: &selection.project_dependencies,
+            ordered_dirs: &selection.ordered_dirs,
+            selected_dirs: selection.selected_dirs.as_ref(),
+            install_dirs: selection.install_dirs.as_ref(),
+            active_manifest_is_standin: selection.active_manifest_is_standin,
         })
         .await
         .wrap_err("removing a package")

--- a/pnpm/crates/cli/src/cli_args/repo.rs
+++ b/pnpm/crates/cli/src/cli_args/repo.rs
@@ -306,25 +306,7 @@ fn try_user_repo_shorthand(raw_url: &str, directory: Option<&str>) -> Option<Str
 }
 
 fn try_hosted_url(raw_url: &str, directory: Option<&str>) -> Option<String> {
-    let input = raw_url.strip_prefix("git+").unwrap_or(raw_url);
-
-    let (parsed, fragment) = if let Some(rest) = input.strip_prefix("git@") {
-        // SCP-style SSH: git@<host>:<owner>/<repo>(.git)?(#branch)?
-        let (scp_host, scp_path) = rest.split_once(':')?;
-        let path_only = scp_path.split(&['#', '?'][..]).next().unwrap_or(scp_path);
-        let parsed = url::Url::parse(&format!("https://{scp_host}/{path_only}")).ok()?;
-        let frag = try_extract_fragment(raw_url);
-        (parsed, frag)
-    } else {
-        let normalized = if let Some(rest) = input.strip_prefix("git://") {
-            Cow::Owned(format!("https://{rest}"))
-        } else {
-            Cow::Borrowed(input)
-        };
-        let frag = try_extract_fragment(raw_url);
-        let parsed = url::Url::parse(&normalized).ok()?;
-        (parsed, frag)
-    };
+    let (parsed, fragment) = parse_hosted_input(raw_url)?;
 
     let host = parsed.host_str()?;
 
@@ -348,6 +330,27 @@ fn try_hosted_url(raw_url: &str, directory: Option<&str>) -> Option<String> {
     } else {
         browse_path
     })
+}
+
+/// The repository as an `https://<host>/<path>` URL plus its `#branch`
+/// fragment, from the `git+`, SCP-style SSH or `git://` spelling.
+fn parse_hosted_input(raw_url: &str) -> Option<(url::Url, Option<String>)> {
+    let input = raw_url.strip_prefix("git+").unwrap_or(raw_url);
+    if let Some(rest) = input.strip_prefix("git@") {
+        // SCP-style SSH: git@<host>:<owner>/<repo>(.git)?(#branch)?
+        let (scp_host, scp_path) = rest.split_once(':')?;
+        let path_only = scp_path.split(&['#', '?'][..]).next().unwrap_or(scp_path);
+        let parsed = url::Url::parse(&format!("https://{scp_host}/{path_only}")).ok()?;
+        return Some((parsed, try_extract_fragment(raw_url)));
+    }
+    let normalized = if let Some(rest) = input.strip_prefix("git://") {
+        Cow::Owned(format!("https://{rest}"))
+    } else {
+        Cow::Borrowed(input)
+    };
+    let frag = try_extract_fragment(raw_url);
+    let parsed = url::Url::parse(&normalized).ok()?;
+    Some((parsed, frag))
 }
 
 fn build_hosted_browse_url(

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -204,11 +204,7 @@ impl RunArgs {
         // directory without a project skips the check instead of
         // spawning a doomed install (see check_deps_status_before_run_at).
         super::verify_deps::verify_deps_before_run(dir, config, reporter)?;
-        let silent = matches!(reporter, ReporterType::Silent);
-        let parallel = self.parallel;
-        let sequential = self.sequential;
-        let RunArgs { script, if_present, .. } = self;
-        let Some((script_name, args)) = script.split_first() else {
+        let Some((script_name, args)) = self.script.split_first() else {
             let manifest = read_project_manifest_only(dir).map_err(RunError::Manifest)?;
             println!("{}", render_project_commands(manifest.value(), None));
             return Ok(());
@@ -231,14 +227,28 @@ impl RunArgs {
                 dirs,
                 config,
                 reporter,
-                if_present,
+                self.if_present,
                 fallback_to_exec,
             );
         }
+        self.run_scripts_here(dir, &manifest, config, reporter, specified, args)
+    }
 
+    /// Run the selected scripts of the project at `dir`, several at once
+    /// when the concurrency allows it.
+    fn run_scripts_here(
+        &self,
+        dir: &Path,
+        manifest: &PackageManifest,
+        config: &Config,
+        reporter: ReporterType,
+        specified: Vec<String>,
+        args: &[String],
+    ) -> miette::Result<()> {
         let extra_env = script_extra_env(config, dir);
         let init_cwd: PathBuf = env::current_dir().unwrap_or_else(|_| dir.to_path_buf());
-        let concurrency = script_concurrency(config, specified.len(), parallel, sequential);
+        let concurrency =
+            script_concurrency(config, specified.len(), self.parallel, self.sequential);
         // Several scripts running at once share this process's terminal,
         // so their output is prefixed and their children are tracked for
         // cancellation.
@@ -246,12 +256,12 @@ impl RunArgs {
         let process_tracker = interleaved.then(ProcessTracker::foreground);
         let dep_path = dir.to_string_lossy().into_owned();
         let ctx = RunContext {
-            manifest: &manifest,
+            manifest,
             dir,
             init_cwd: &init_cwd,
             config,
             extra_env: &extra_env,
-            silent,
+            silent: matches!(reporter, ReporterType::Silent),
             output: if interleaved {
                 ScriptOutput::Streamed { dep_path: &dep_path, emit: reporter_emit(reporter) }
             } else {

--- a/pnpm/crates/cli/src/cli_args/run/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/run/recursive.rs
@@ -117,157 +117,289 @@ pub fn run_recursive(
     let Some(script_name) = args.script_name() else {
         return print_selected_project_commands(graph, &projects, workspace_root);
     };
-    // Report what the `--filter` selection resolved to before running a
-    // single script, so the user can confirm it covers what they meant.
-    emit(&LogEvent::Scope(ScopeLog {
-        level: LogLevel::Debug,
-        selected: graph.len(),
-        total: Some(projects.len()),
-        workspace_prefix: config
-            .workspace_dir
-            .as_deref()
-            .map(|dir| dir.to_string_lossy().into_owned()),
-    }));
+    emit_selection_scope(emit, config, graph.len(), projects.len());
     // An empty `--filter` selection is a no-op (exit 0); an empty
     // workspace instead falls through to the no-script error below.
     if !projects.is_empty() && graph.is_empty() {
         return Ok(());
     }
 
-    // Compiled once for the whole run, not per project or task.
-    let selector = ScriptSelector::new(script_name)?;
-    let full_task_graph =
-        build_run_task_graph(script_name, &selector, args, config, graph, &selection, emit)?;
-    let extra_env: HashMap<String, String> = config.extra_env_with_node_options();
-    let state_settings = run_state_settings(config, &extra_env);
-    let task_run_state_context = TaskRunStateContext::new(
-        "run",
-        &args.script,
-        &state_settings,
-        &full_task_graph,
+    let run = RecursiveRun {
+        args,
+        config,
+        dir,
+        emit,
+        silent,
+        graph,
+        selection: &selection,
         workspace_root,
-        |node, script| {
-            let manifest = &graph[&node.project].package.project.manifest;
-            let Some(main) =
-                manifest.script(script, true).expect("if-present script lookup cannot fail")
-            else {
-                return Vec::new();
-            };
-            get_run_script_commands(manifest, script, main, config.enable_pre_post_scripts)
-        },
-    );
-    let mut task_graph =
-        resume_task_graph(&task_run_state_context, args, graph, &full_task_graph, script_name)?;
-    // Also the cycle check: a cyclic graph cannot be scheduled, and
-    // sequenced into an arbitrary order it would succeed or fail by luck.
-    let sequenced_tasks = sequence_tasks(
-        &mut task_graph,
-        &SequenceTasksOptions {
-            workspace_dir: workspace_root,
-            ignore_cycles: config.ignore_workspace_cycles,
-            emit,
-        },
-    )?;
-
-    if args.dry_run {
-        return print_run_dry_run(args, &task_graph, &sequenced_tasks, workspace_root);
-    }
-
-    // Hidden scripts (names starting with `.`) can only be invoked from
-    // within another script, detected by an inherited
-    // `npm_lifecycle_event`. Checked only for the tasks the invocation
-    // named: a `dependsOn` declaration naming a hidden script is a
-    // deliberate reference, like a call from another script.
-    filter_hidden_requested_scripts(&mut task_graph, script_name)?;
-
-    check_a_project_has_the_script(&task_graph, args, script_name, graph.len() == projects.len())?;
-
-    let initially_completed: HashSet<TaskKey> =
-        full_task_graph.keys().filter(|key| !task_graph.contains_key(*key)).cloned().collect();
-    let task_run_state = task_run_state_context.start(&initially_completed)?;
-
-    let bail = !args.no_bail;
-    let concurrency = run_concurrency(args, config, task_graph.len());
-    let runs_concurrently = concurrency > 1 && !is_serial_task_graph(&task_graph, &sequenced_tasks);
-    // pnpm pipes unless the output cannot interleave: `--stream` off, and
-    // the graph cannot put two scripts in flight at once.
-    let inherit_output = !config.stream && !runs_concurrently;
-
-    let result: Mutex<IndexMap<String, ExecutionStatus>> = Mutex::new(
-        task_graph
-            .values()
-            .map(|node| (task_summary_key(node), ExecutionStatus::queued()))
-            .collect(),
-    );
-    let has_command = AtomicUsize::new(0);
-    let first_failure: Mutex<Option<String>> = Mutex::new(None);
-    let abort: Mutex<Option<miette::Report>> = Mutex::new(None);
-    let process_tracker = run_process_tracker(bail, runs_concurrently);
-
-    let init_cwd = env::current_dir().unwrap_or_else(|_| dir.to_path_buf());
-
-    let outcome = RunOutcome {
-        result: &result,
-        has_command: &has_command,
-        first_failure: &first_failure,
-        abort: &abort,
-        process_tracker: process_tracker.as_ref(),
-        task_run_state: &task_run_state,
-        workspace_root,
+        script_name,
+        all_packages_selected: graph.len() == projects.len(),
     };
-    let run_task = |node: &TaskNode| -> TaskCompletion {
-        let summary_key = task_summary_key(node);
-        let on_started = || {
-            result.lock().expect("summary lock is not poisoned")[&summary_key].status =
-                Status::Running;
-        };
-        let execution = run_project(RunProjectOptions {
-            node,
-            graph,
-            args,
-            init_cwd: &init_cwd,
-            config,
-            extra_env: &extra_env,
-            bail,
-            silent,
-            inherit_output,
-            emit,
-            process_tracker: process_tracker.as_ref(),
-            on_started: &on_started,
-        });
-        outcome.record(node, &summary_key, execution)
+    let Some(prepared) = run.prepare()? else {
+        return Ok(());
     };
-    let on_task_skipped = |node: &TaskNode| {
-        result.lock().expect("summary lock is not poisoned")[&task_summary_key(node)].status =
-            Status::Skipped;
-    };
-    schedule_tasks(
-        &task_graph,
-        &ScheduleTasksOptions {
-            concurrency,
-            bail,
-            run_task: &run_task,
-            on_task_skipped: &on_task_skipped,
-        },
-    );
-
-    if let Some(error) = abort.into_inner().expect("abort slot lock is not poisoned") {
-        return Err(error);
-    }
-    let result = result.into_inner().expect("summary lock is not poisoned");
-    let first_failure = first_failure.into_inner().expect("first-failure lock is not poisoned");
+    let results = run.execute(&prepared)?;
     report_run_outcome(
         &RunReporting {
             args,
             script_name,
             workspace_root,
-            all_packages_selected: graph.len() == projects.len(),
-            ran_a_command: has_command.load(Ordering::Relaxed) > 0,
-            task_run_state: &task_run_state,
+            all_packages_selected: run.all_packages_selected,
+            ran_a_command: results.ran_a_command,
+            task_run_state: &prepared.task_run_state,
         },
-        &result,
-        bail.then_some(first_failure).flatten(),
+        &results.statuses,
+        results.first_failure,
     )
+}
+
+/// Report what the `--filter` selection resolved to before running a
+/// single script, so the user can confirm it covers what they meant.
+fn emit_selection_scope(emit: fn(&LogEvent), config: &Config, selected: usize, total: usize) {
+    emit(&LogEvent::Scope(ScopeLog {
+        level: LogLevel::Debug,
+        selected,
+        total: Some(total),
+        workspace_prefix: config
+            .workspace_dir
+            .as_deref()
+            .map(|dir| dir.to_string_lossy().into_owned()),
+    }));
+}
+
+/// One recursive run: the selection it runs over and the settings every
+/// task reads.
+struct RecursiveRun<'a, 'project> {
+    args: &'a RunArgs,
+    config: &'a Config,
+    dir: &'a Path,
+    emit: fn(&LogEvent),
+    silent: bool,
+    graph: &'a ProjectGraph<GraphPkg<'project>>,
+    selection: &'a crate::cli_args::recursive::RecursiveSelection<'project>,
+    workspace_root: &'a Path,
+    script_name: &'a str,
+    all_packages_selected: bool,
+}
+
+/// The task graph ready to schedule, with the run-state journal started.
+struct PreparedRun {
+    task_graph: TaskGraph,
+    sequenced_tasks: Vec<TaskKey>,
+    extra_env: HashMap<String, String>,
+    task_run_state: crate::cli_args::task_run_state::TaskRunState,
+}
+
+/// What the scheduled tasks left behind.
+struct RunResults {
+    statuses: IndexMap<String, ExecutionStatus>,
+    ran_a_command: bool,
+    /// The first failed project's prefix, when `--bail` stopped the run.
+    first_failure: Option<String>,
+}
+
+impl RecursiveRun<'_, '_> {
+    /// Build, resume and sequence the task graph, then start the run-state
+    /// journal. `None` once a dry run has printed the graph instead.
+    fn prepare(&self) -> miette::Result<Option<PreparedRun>> {
+        // Compiled once for the whole run, not per project or task.
+        let selector = ScriptSelector::new(self.script_name)?;
+        let full_task_graph = build_run_task_graph(
+            self.script_name,
+            &selector,
+            self.args,
+            self.config,
+            self.graph,
+            self.selection,
+            self.emit,
+        )?;
+        let extra_env: HashMap<String, String> = self.config.extra_env_with_node_options();
+        let state_settings = run_state_settings(self.config, &extra_env);
+        let task_run_state_context = TaskRunStateContext::new(
+            "run",
+            &self.args.script,
+            &state_settings,
+            &full_task_graph,
+            self.workspace_root,
+            |node, script| self.script_commands(node, script),
+        );
+        let mut task_graph = resume_task_graph(
+            &task_run_state_context,
+            self.args,
+            self.graph,
+            &full_task_graph,
+            self.script_name,
+        )?;
+        // Also the cycle check: a cyclic graph cannot be scheduled, and
+        // sequenced into an arbitrary order it would succeed or fail by luck.
+        let sequenced_tasks = sequence_tasks(
+            &mut task_graph,
+            &SequenceTasksOptions {
+                workspace_dir: self.workspace_root,
+                ignore_cycles: self.config.ignore_workspace_cycles,
+                emit: self.emit,
+            },
+        )?;
+
+        if self.args.dry_run {
+            print_run_dry_run(self.args, &task_graph, &sequenced_tasks, self.workspace_root)?;
+            return Ok(None);
+        }
+
+        // Hidden scripts (names starting with `.`) can only be invoked from
+        // within another script, detected by an inherited
+        // `npm_lifecycle_event`. Checked only for the tasks the invocation
+        // named: a `dependsOn` declaration naming a hidden script is a
+        // deliberate reference, like a call from another script.
+        filter_hidden_requested_scripts(&mut task_graph, self.script_name)?;
+
+        check_a_project_has_the_script(
+            &task_graph,
+            self.args,
+            self.script_name,
+            self.all_packages_selected,
+        )?;
+
+        let task_run_state = task_run_state_context
+            .start(&initially_completed_tasks(&full_task_graph, &task_graph))?;
+        Ok(Some(PreparedRun { task_graph, sequenced_tasks, extra_env, task_run_state }))
+    }
+
+    fn script_commands(&self, node: &TaskNode, script: &str) -> Vec<String> {
+        let manifest = &self.graph[&node.project].package.project.manifest;
+        let Some(main) =
+            manifest.script(script, true).expect("if-present script lookup cannot fail")
+        else {
+            return Vec::new();
+        };
+        get_run_script_commands(manifest, script, main, self.config.enable_pre_post_scripts)
+    }
+
+    /// Schedule every task and collect what each left behind.
+    fn execute(&self, prepared: &PreparedRun) -> miette::Result<RunResults> {
+        let bail = !self.args.no_bail;
+        let concurrency = run_concurrency(self.args, self.config, prepared.task_graph.len());
+        let runs_concurrently = concurrency > 1
+            && !is_serial_task_graph(&prepared.task_graph, &prepared.sequenced_tasks);
+        let slots = RunSlots::queued(&prepared.task_graph);
+        let process_tracker = run_process_tracker(bail, runs_concurrently);
+        let init_cwd = env::current_dir().unwrap_or_else(|_| self.dir.to_path_buf());
+        let runner = TaskRunner {
+            run: self,
+            outcome: RunOutcome {
+                result: &slots.result,
+                has_command: &slots.has_command,
+                first_failure: &slots.first_failure,
+                abort: &slots.abort,
+                process_tracker: process_tracker.as_ref(),
+                task_run_state: &prepared.task_run_state,
+                workspace_root: self.workspace_root,
+            },
+            extra_env: &prepared.extra_env,
+            init_cwd: &init_cwd,
+            bail,
+            inherit_output: !self.config.stream && !runs_concurrently,
+        };
+        let run_task = |node: &TaskNode| runner.run_task(node);
+        let on_task_skipped = |node: &TaskNode| {
+            slots.result.lock().expect("summary lock is not poisoned")[&task_summary_key(node)]
+                .status = Status::Skipped;
+        };
+        schedule_tasks(
+            &prepared.task_graph,
+            &ScheduleTasksOptions {
+                concurrency,
+                bail,
+                run_task: &run_task,
+                on_task_skipped: &on_task_skipped,
+            },
+        );
+        slots.into_results(bail)
+    }
+}
+
+/// The tasks a resumed run already completed: those the full graph has
+/// and the resumed graph does not.
+fn initially_completed_tasks(
+    full_task_graph: &TaskGraph,
+    task_graph: &TaskGraph,
+) -> HashSet<TaskKey> {
+    full_task_graph.keys().filter(|key| !task_graph.contains_key(*key)).cloned().collect()
+}
+
+/// The slots the tasks record into while they run.
+struct RunSlots {
+    result: Mutex<IndexMap<String, ExecutionStatus>>,
+    has_command: AtomicUsize,
+    first_failure: Mutex<Option<String>>,
+    abort: Mutex<Option<miette::Report>>,
+}
+
+impl RunSlots {
+    fn queued(task_graph: &TaskGraph) -> Self {
+        RunSlots {
+            result: Mutex::new(
+                task_graph
+                    .values()
+                    .map(|node| (task_summary_key(node), ExecutionStatus::queued()))
+                    .collect(),
+            ),
+            has_command: AtomicUsize::new(0),
+            first_failure: Mutex::new(None),
+            abort: Mutex::new(None),
+        }
+    }
+
+    fn into_results(self, bail: bool) -> miette::Result<RunResults> {
+        if let Some(error) = self.abort.into_inner().expect("abort slot lock is not poisoned") {
+            return Err(error);
+        }
+        let first_failure =
+            self.first_failure.into_inner().expect("first-failure lock is not poisoned");
+        Ok(RunResults {
+            statuses: self.result.into_inner().expect("summary lock is not poisoned"),
+            ran_a_command: self.has_command.load(Ordering::Relaxed) > 0,
+            first_failure: bail.then_some(first_failure).flatten(),
+        })
+    }
+}
+
+/// Runs one task's project against the run's shared state.
+struct TaskRunner<'a, 'run, 'project> {
+    run: &'a RecursiveRun<'run, 'project>,
+    outcome: RunOutcome<'a>,
+    extra_env: &'a HashMap<String, String>,
+    init_cwd: &'a Path,
+    bail: bool,
+    /// pnpm pipes unless the output cannot interleave: `--stream` off, and
+    /// the graph cannot put two scripts in flight at once.
+    inherit_output: bool,
+}
+
+impl TaskRunner<'_, '_, '_> {
+    fn run_task(&self, node: &TaskNode) -> TaskCompletion {
+        let summary_key = task_summary_key(node);
+        let on_started = || {
+            self.outcome.result.lock().expect("summary lock is not poisoned")[&summary_key]
+                .status = Status::Running;
+        };
+        let execution = run_project(&RunProjectOptions {
+            node,
+            graph: self.run.graph,
+            args: self.run.args,
+            init_cwd: self.init_cwd,
+            config: self.run.config,
+            extra_env: self.extra_env,
+            bail: self.bail,
+            silent: self.run.silent,
+            inherit_output: self.inherit_output,
+            emit: self.run.emit,
+            process_tracker: self.outcome.process_tracker,
+            on_started: &on_started,
+        });
+        self.outcome.record(node, &summary_key, execution)
+    }
 }
 
 /// Before anything is dispatched: when no selected project has the
@@ -631,24 +763,10 @@ struct RunProjectOptions<'a, 'project> {
     on_started: &'a dyn Fn(),
 }
 
-fn run_project(options: RunProjectOptions<'_, '_>) -> miette::Result<ProjectExecution> {
-    let RunProjectOptions {
-        node,
-        graph,
-        args,
-        init_cwd,
-        config,
-        extra_env,
-        bail,
-        silent,
-        inherit_output,
-        emit,
-        process_tracker,
-        on_started,
-    } = options;
-    let root = node.project.as_path();
-    let manifest = &graph[root].package.project.manifest;
-    let extra_env = project_extra_env(config, root, extra_env);
+fn run_project(options: &RunProjectOptions<'_, '_>) -> miette::Result<ProjectExecution> {
+    let root = options.node.project.as_path();
+    let manifest = &options.graph[root].package.project.manifest;
+    let extra_env = project_extra_env(options.config, root, options.extra_env);
 
     // pnpm names the project directory as the `depPath` of a recursive
     // run's lifecycle events; the reporter renders `wd` and only groups
@@ -661,8 +779,8 @@ fn run_project(options: RunProjectOptions<'_, '_>) -> miette::Result<ProjectExec
         recursion_guarded: false,
     };
     let mut project_failed = false;
-    for selected in &node.scripts {
-        let Some(script) = runnable_project_script(manifest, selected, args)? else {
+    for selected in &options.node.scripts {
+        let Some(script) = runnable_project_script(manifest, selected, options.args)? else {
             continue;
         };
         // Running the script pnpm is already inside would recurse; the
@@ -672,7 +790,7 @@ fn run_project(options: RunProjectOptions<'_, '_>) -> miette::Result<ProjectExec
             continue;
         }
 
-        on_started();
+        (options.on_started)();
         if !project_failed {
             execution.status.status = Status::Running;
         }
@@ -680,24 +798,24 @@ fn run_project(options: RunProjectOptions<'_, '_>) -> miette::Result<ProjectExec
         let ctx = RunContext {
             manifest,
             dir: root,
-            init_cwd,
-            config,
+            init_cwd: options.init_cwd,
+            config: options.config,
             extra_env: &extra_env,
-            silent,
-            output: script_output(inherit_output, &root_str, emit),
-            process_tracker,
+            silent: options.silent,
+            output: script_output(options.inherit_output, &root_str, options.emit),
+            process_tracker: options.process_tracker,
         };
         let ran = run_one_project_script(
             &ctx,
             selected,
             &script,
-            args,
+            options.args,
             &mut execution,
             &mut project_failed,
         )?;
         // A cancelled run ends the project outright; `--bail` stops it
         // at the first script that failed.
-        if !ran || (project_failed && bail) {
+        if !ran || (project_failed && options.bail) {
             break;
         }
     }

--- a/pnpm/crates/cli/src/cli_args/sbom.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom.rs
@@ -429,22 +429,7 @@ fn collect_components(
     };
 
     let lockfile_dir = state.lockfile_dir().to_path_buf();
-
-    let manifest_value = read_root_manifest(state, &lockfile_dir, filter_importer_ids);
-    let root_name =
-        manifest_value.get("name").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
-    let root_version =
-        manifest_value.get("version").and_then(|v| v.as_str()).unwrap_or("0.0.0").to_string();
-    let root_license =
-        manifest_value.get("license").and_then(|v| v.as_str()).map(ToString::to_string);
-    let root_description =
-        manifest_value.get("description").and_then(|v| v.as_str()).map(ToString::to_string);
-    let root_author = extract_author(&manifest_value);
-    let root_repository = extract_repository(&manifest_value);
-    let root_bugs_url = extract_bugs_url(&manifest_value);
-
-    let root_purl = build_purl(&root_name, &root_version);
-
+    let root = RootMetadata::of(&read_root_manifest(state, &lockfile_dir, filter_importer_ids));
     let dep_types = detect_dep_types(lockfile, include.optional_dependencies);
 
     let default_virtual_store_dirs = [state.config.effective_virtual_store_dir().to_path_buf()];
@@ -471,30 +456,19 @@ fn collect_components(
         },
     };
 
-    let mut components_map: IndexMap<String, SbomComponent> = IndexMap::new();
-    let mut relationships: Vec<SbomRelationship> = Vec::new();
-    let mut visited: HashSet<PackageKey> = HashSet::new();
-    let mut ws_purl_by_importer: HashMap<String, String> = HashMap::new();
-
-    let initial_importer_ids: Vec<String> = lockfile
-        .importers
-        .keys()
-        .filter(|id| filter_importer_ids.is_none_or(|ids| ids.contains(&id.as_str())))
-        .cloned()
-        .collect();
-
-    let mut importer_queue: Vec<String> = initial_importer_ids;
-    let mut visited_importers: HashSet<String> = HashSet::new();
-
+    let mut stores = WalkStores {
+        queue: initial_importer_ids(lockfile, filter_importer_ids),
+        ..Default::default()
+    };
     let mut walk = ImporterWalk {
-        components_map: &mut components_map,
-        relationships: &mut relationships,
-        visited: &mut visited,
-        ws_purl_by_importer: &mut ws_purl_by_importer,
-        queue: &mut importer_queue,
+        components_map: &mut stores.components_map,
+        relationships: &mut stores.relationships,
+        visited: &mut stores.visited,
+        ws_purl_by_importer: &mut stores.ws_purl_by_importer,
+        queue: &mut stores.queue,
     };
     while let Some(importer_id) = walk.queue.pop() {
-        if !visited_importers.insert(importer_id.clone()) {
+        if !stores.visited_importers.insert(importer_id.clone()) {
             continue;
         }
         let Some(importer) = lockfile.importers.get(importer_id.as_str()) else {
@@ -506,7 +480,7 @@ fn collect_components(
                 lockfile_dir: &lockfile_dir,
                 include,
                 exclude_peers,
-                root_purl: &root_purl,
+                root_purl: &root.purl,
                 ctx: &ctx,
             },
             &importer_id,
@@ -516,17 +490,70 @@ fn collect_components(
     }
 
     Ok(SbomResult {
-        root_name,
-        root_version,
+        root_name: root.name,
+        root_version: root.version,
         root_type: sbom_type,
-        root_license,
-        root_description,
-        root_author,
-        root_repository,
-        root_bugs_url,
-        components: components_map.into_values().collect(),
-        relationships,
+        root_license: root.license,
+        root_description: root.description,
+        root_author: root.author,
+        root_repository: root.repository,
+        root_bugs_url: root.bugs_url,
+        components: stores.components_map.into_values().collect(),
+        relationships: stores.relationships,
     })
+}
+
+/// What the root manifest says about the SBOM's root component.
+struct RootMetadata {
+    name: String,
+    version: String,
+    license: Option<String>,
+    description: Option<String>,
+    author: Option<String>,
+    repository: Option<String>,
+    bugs_url: Option<String>,
+    purl: String,
+}
+
+impl RootMetadata {
+    fn of(manifest: &serde_json::Value) -> Self {
+        let name = manifest.get("name").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
+        let version =
+            manifest.get("version").and_then(|v| v.as_str()).unwrap_or("0.0.0").to_string();
+        RootMetadata {
+            purl: build_purl(&name, &version),
+            license: manifest.get("license").and_then(|v| v.as_str()).map(ToString::to_string),
+            description: manifest
+                .get("description")
+                .and_then(|v| v.as_str())
+                .map(ToString::to_string),
+            author: extract_author(manifest),
+            repository: extract_repository(manifest),
+            bugs_url: extract_bugs_url(manifest),
+            name,
+            version,
+        }
+    }
+}
+
+/// The collections the importer walk fills.
+#[derive(Default)]
+struct WalkStores {
+    components_map: IndexMap<String, SbomComponent>,
+    relationships: Vec<SbomRelationship>,
+    visited: HashSet<PackageKey>,
+    ws_purl_by_importer: HashMap<String, String>,
+    queue: Vec<String>,
+    visited_importers: HashSet<String>,
+}
+
+fn initial_importer_ids(lockfile: &Lockfile, filter_importer_ids: Option<&[&str]>) -> Vec<String> {
+    lockfile
+        .importers
+        .keys()
+        .filter(|id| filter_importer_ids.is_none_or(|ids| ids.contains(&id.as_str())))
+        .cloned()
+        .collect()
 }
 
 /// The manifest the SBOM's root component describes: the single filtered
@@ -593,14 +620,7 @@ fn collect_importer_components(
         .cloned()
         .unwrap_or_else(|| inputs.root_purl.to_owned());
 
-    let importer_peer_names = if inputs.exclude_peers {
-        confined_importer_dir(inputs.lockfile_dir, importer_id)
-            .and_then(|dir| safe_read_package_json_from_dir(&dir).ok().flatten())
-            .map(|manifest| peer_names_from_manifest(&manifest))
-            .unwrap_or_default()
-    } else {
-        HashSet::new()
-    };
+    let importer_peer_names = importer_peer_names(inputs, importer_id);
     let dev_dep_names: HashSet<String> = importer
         .dev_dependencies
         .as_ref()
@@ -652,6 +672,18 @@ fn collect_importer_components(
             );
         }
     }
+}
+
+/// The peer dependency names the importer's own manifest declares, when
+/// peers are left out of the SBOM.
+fn importer_peer_names(inputs: &ImporterComponents<'_>, importer_id: &str) -> HashSet<String> {
+    if !inputs.exclude_peers {
+        return HashSet::new();
+    }
+    confined_importer_dir(inputs.lockfile_dir, importer_id)
+        .and_then(|dir| safe_read_package_json_from_dir(&dir).ok().flatten())
+        .map(|manifest| peer_names_from_manifest(&manifest))
+        .unwrap_or_default()
 }
 
 /// Record a `link:` dependency that resolves to another workspace
@@ -1068,9 +1100,7 @@ fn merged_dedicated_lockfile_state(mut state: State) -> miette::Result<(State, V
         .collect();
     let mut virtual_store_dirs = Vec::with_capacity(project_dirs.len());
     for selected_dir in &project_dirs {
-        let mut project_config = state.config.clone();
-        project_config.anchor_lockfile_paths(selected_dir);
-        virtual_store_dirs.push(project_config.effective_virtual_store_dir().to_path_buf());
+        virtual_store_dirs.push(anchored_virtual_store_dir(state.config, selected_dir));
 
         let Some(mut lockfile) =
             Lockfile::load_wanted(selected_dir, &state.config.wanted_lockfile_selection())
@@ -1078,17 +1108,7 @@ fn merged_dedicated_lockfile_state(mut state: State) -> miette::Result<(State, V
         else {
             continue;
         };
-        let importers = std::mem::take(&mut lockfile.importers);
-        lockfile.importers = importers
-            .into_iter()
-            .map(|(importer_id, importer)| {
-                validate_importer_id(&importer_id).map_err(miette::Report::new)?;
-                let importer_dir = importer_root_dir(selected_dir, &importer_id);
-                let workspace_id =
-                    pnpm_workspace::importer_id_from_root_dir(workspace_root, &importer_dir);
-                Ok((workspace_id, importer))
-            })
-            .collect::<miette::Result<_>>()?;
+        rekey_importers(&mut lockfile, selected_dir, workspace_root)?;
         if let Some(current) = &mut merged {
             extend_dedicated_lockfile(current, lockfile, selected_dir)?;
         } else {
@@ -1096,13 +1116,7 @@ fn merged_dedicated_lockfile_state(mut state: State) -> miette::Result<(State, V
         }
     }
 
-    if let Some(lockfile) = &merged {
-        let importer_ids: Vec<String> = lockfile.importers.keys().cloned().collect();
-        let missing = missing_importers(&required_importer_ids, &importer_ids);
-        if !missing.is_empty() {
-            return Err(missing_importers_error(&missing, "selected or reachable"));
-        }
-    }
+    assert_required_importers(merged.as_ref(), &required_importer_ids)?;
 
     virtual_store_dirs.sort_unstable();
     virtual_store_dirs.dedup();
@@ -1113,44 +1127,69 @@ fn merged_dedicated_lockfile_state(mut state: State) -> miette::Result<(State, V
     Ok((state, virtual_store_dirs))
 }
 
+/// The virtual store dir the project's own lockfile anchors at.
+fn anchored_virtual_store_dir(config: &Config, project_dir: &Path) -> PathBuf {
+    let mut project_config = config.clone();
+    project_config.anchor_lockfile_paths(project_dir);
+    project_config.effective_virtual_store_dir().to_path_buf()
+}
+
+/// Re-key a dedicated lockfile's importers from its own root to the
+/// workspace root.
+fn rekey_importers(
+    lockfile: &mut Lockfile,
+    selected_dir: &Path,
+    workspace_root: &Path,
+) -> miette::Result<()> {
+    let importers = std::mem::take(&mut lockfile.importers);
+    lockfile.importers = importers
+        .into_iter()
+        .map(|(importer_id, importer)| {
+            validate_importer_id(&importer_id).map_err(miette::Report::new)?;
+            let importer_dir = importer_root_dir(selected_dir, &importer_id);
+            let workspace_id =
+                pnpm_workspace::importer_id_from_root_dir(workspace_root, &importer_dir);
+            Ok((workspace_id, importer))
+        })
+        .collect::<miette::Result<_>>()?;
+    Ok(())
+}
+
+fn assert_required_importers(
+    merged: Option<&Lockfile>,
+    required_importer_ids: &HashSet<String>,
+) -> miette::Result<()> {
+    let Some(lockfile) = merged else {
+        return Ok(());
+    };
+    let importer_ids: Vec<String> = lockfile.importers.keys().cloned().collect();
+    let missing = missing_importers(required_importer_ids, &importer_ids);
+    if !missing.is_empty() {
+        return Err(missing_importers_error(&missing, "selected or reachable"));
+    }
+    Ok(())
+}
+
 impl SbomArgs {
     pub async fn run(self, state: State) -> miette::Result<()> {
         let (state, virtual_store_dirs) = self.merged_state(state)?;
         self.check_spec_version()?;
 
         let include = self.include_filter(state.config.optional);
-        let authors: Vec<String> = self
-            .authors
-            .as_deref()
-            .map(|csv| {
-                csv.split(',')
-                    .map(|author| author.trim().to_string())
-                    .filter(|author| !author.is_empty())
-                    .collect()
-            })
-            .unwrap_or_default();
+        let authors = self.author_list();
 
         let lockfile = state
             .lockfile
             .get()
             .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
-        // `importers` is a `HashMap`, so its iteration order is arbitrary.
-        // Sorting fixes the order `--split` emits its SBOMs in, and matches
-        // the lockfile, whose importers are serialized sorted by id.
-        let mut all_importer_ids: Vec<String> =
-            lockfile.as_ref().map(|lf| lf.importers.keys().cloned().collect()).unwrap_or_default();
-        all_importer_ids.sort_unstable();
-
+        let all_importer_ids = sorted_importer_ids(lockfile);
         let all_count = all_importer_ids.len();
         let Some(importer_ids) = select_importer_ids(&state, all_importer_ids, lockfile.is_some())?
         else {
             return Ok(());
         };
 
-        let should_split = self.split
-            || (self.out.as_ref().is_some_and(|o| o.contains("%s")) && importer_ids.len() > 1);
-
-        if should_split {
+        if self.splits_output(&importer_ids) {
             return self.write_split_sboms(
                 &state,
                 &include,
@@ -1171,11 +1210,33 @@ impl SbomArgs {
             filter_ids.as_deref(),
             virtual_store_dirs.as_deref(),
         )?;
-        let output = self.serialize(&result, &authors, false);
+        self.write_single_sbom(&result, &self.serialize(&result, &authors, false))
+    }
+
+    fn author_list(&self) -> Vec<String> {
+        self.authors
+            .as_deref()
+            .map(|csv| {
+                csv.split(',')
+                    .map(|author| author.trim().to_string())
+                    .filter(|author| !author.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// One SBOM per importer: `--split`, or an `--out` template with a `%s`
+    /// placeholder and several importers to fill it.
+    fn splits_output(&self, importer_ids: &[String]) -> bool {
+        self.split
+            || (self.out.as_ref().is_some_and(|o| o.contains("%s")) && importer_ids.len() > 1)
+    }
+
+    fn write_single_sbom(&self, result: &SbomResult, output: &str) -> miette::Result<()> {
         let mut stdout = std::io::stdout();
         if let Some(out_template) = self.out.as_deref() {
-            let file_path = sbom_output_path(out_template, &result);
-            write_sbom_file(&file_path, &output)?;
+            let file_path = sbom_output_path(out_template, result);
+            write_sbom_file(&file_path, output)?;
             let _ = writeln!(stdout, "{file_path}");
         } else {
             let _ = write!(stdout, "{output}");
@@ -1289,6 +1350,11 @@ impl SbomArgs {
             files.push(file_path);
         }
 
+        self.print_split_outputs(&files, &ndjson_lines);
+        Ok(())
+    }
+
+    fn print_split_outputs(&self, files: &[String], ndjson_lines: &[String]) {
         let mut stdout = std::io::stdout();
         if self.out.is_some() {
             let _ = writeln!(
@@ -1301,8 +1367,17 @@ impl SbomArgs {
             let _ = write!(stdout, "{}", ndjson_lines.join("\n"));
         }
         let _ = stdout.flush();
-        Ok(())
     }
+}
+
+/// `importers` is a `HashMap`, so its iteration order is arbitrary.
+/// Sorting fixes the order `--split` emits its SBOMs in, and matches
+/// the lockfile, whose importers are serialized sorted by id.
+fn sorted_importer_ids(lockfile: Option<&Lockfile>) -> Vec<String> {
+    let mut all_importer_ids: Vec<String> =
+        lockfile.map(|lf| lf.importers.keys().cloned().collect()).unwrap_or_default();
+    all_importer_ids.sort_unstable();
+    all_importer_ids
 }
 
 /// The importers the SBOM covers, in lockfile order. `None` when the
@@ -1391,6 +1466,30 @@ fn serialize_cyclonedx(opts: &CycloneDxOpts<'_>) -> String {
         result.components.iter().map(cyclonedx_component).collect();
     let dependencies = cyclonedx_dependencies(result, &root_purl);
 
+    let metadata = cyclonedx_metadata(opts, &root_component);
+
+    let bom = serde_json::json!({
+        "$schema": format!("http://cyclonedx.org/schema/bom-{spec_version}.schema.json"),
+        "bomFormat": "CycloneDX",
+        "specVersion": spec_version,
+        "serialNumber": format!("urn:uuid:{}", generate_uuid_v4()),
+        "version": 1,
+        "metadata": metadata,
+        "components": components,
+        "dependencies": dependencies,
+    });
+
+    if opts.compact {
+        serde_json::to_string(&bom).expect("JSON serialization")
+    } else {
+        serde_json::to_string_pretty(&bom).expect("JSON serialization")
+    }
+}
+
+fn cyclonedx_metadata(
+    opts: &CycloneDxOpts<'_>,
+    root_component: &serde_json::Value,
+) -> serde_json::Value {
     let timestamp = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
     let phase = if opts.lockfile_only { "pre-build" } else { "build" };
 
@@ -1413,23 +1512,7 @@ fn serialize_cyclonedx(opts: &CycloneDxOpts<'_>) -> String {
     if let Some(supplier) = opts.supplier {
         metadata["supplier"] = serde_json::json!({ "name": supplier });
     }
-
-    let bom = serde_json::json!({
-        "$schema": format!("http://cyclonedx.org/schema/bom-{spec_version}.schema.json"),
-        "bomFormat": "CycloneDX",
-        "specVersion": spec_version,
-        "serialNumber": format!("urn:uuid:{}", generate_uuid_v4()),
-        "version": 1,
-        "metadata": metadata,
-        "components": components,
-        "dependencies": dependencies,
-    });
-
-    if opts.compact {
-        serde_json::to_string(&bom).expect("JSON serialization")
-    } else {
-        serde_json::to_string_pretty(&bom).expect("JSON serialization")
-    }
+    metadata
 }
 
 /// The `metadata.component` describing the project the SBOM is for.

--- a/pnpm/crates/cli/src/cli_args/search.rs
+++ b/pnpm/crates/cli/src/cli_args/search.rs
@@ -96,25 +96,9 @@ impl SearchArgs {
             return Err(SearchError::MissingQuery.into());
         }
 
-        let registry_url = self.registry.as_deref().unwrap_or(&config.registry);
-        // Add a trailing slash before joining so a registry with a path
-        // prefix keeps it.
-        let normalized_registry_url = if registry_url.ends_with('/') {
-            registry_url.to_owned()
-        } else {
-            format!("{registry_url}/")
-        };
-
-        let base_url = url::Url::parse(&normalized_registry_url)
-            .map_err(|err| SearchError::NetworkError { message: err.to_string() })?;
-        let mut search_url = base_url
-            .join("./-/v1/search")
-            .map_err(|err| SearchError::NetworkError { message: err.to_string() })?;
-
-        search_url
-            .query_pairs_mut()
-            .append_pair("text", &query_string)
-            .append_pair("size", &self.search_limit.unwrap_or(20).to_string());
+        let normalized_registry_url =
+            with_trailing_slash(self.registry.as_deref().unwrap_or(&config.registry));
+        let search_url = self.search_url(&normalized_registry_url, &query_string)?;
 
         let auth_header = config.auth_headers.for_url(&normalized_registry_url);
         let http_client = build_registry_client(config)?;
@@ -150,7 +134,28 @@ impl SearchArgs {
             .wrap_err("parsing the search response")?;
 
         drop(client);
+        self.render(data)
+    }
 
+    fn search_url(
+        &self,
+        normalized_registry_url: &str,
+        query_string: &str,
+    ) -> miette::Result<url::Url> {
+        let base_url = url::Url::parse(normalized_registry_url)
+            .map_err(|err| SearchError::NetworkError { message: err.to_string() })?;
+        let mut search_url = base_url
+            .join("./-/v1/search")
+            .map_err(|err| SearchError::NetworkError { message: err.to_string() })?;
+        search_url
+            .query_pairs_mut()
+            .append_pair("text", query_string)
+            .append_pair("size", &self.search_limit.unwrap_or(20).to_string());
+        Ok(search_url)
+    }
+
+    /// The results as JSON or as one block per package.
+    fn render(&self, data: RegistrySearchResponse) -> miette::Result<String> {
         if self.json {
             let packages: Vec<&serde_json::Value> =
                 data.objects.iter().map(|obj| &obj.package).collect();
@@ -171,6 +176,12 @@ impl SearchArgs {
 
         Ok(formatted_packages.join("\n\n"))
     }
+}
+
+/// Add a trailing slash before joining so a registry with a path prefix
+/// keeps it.
+fn with_trailing_slash(registry_url: &str) -> String {
+    if registry_url.ends_with('/') { registry_url.to_owned() } else { format!("{registry_url}/") }
 }
 
 /// The registry's own explanation of a rejected search, when it sent one.

--- a/pnpm/crates/cli/src/cli_args/self_update.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update.rs
@@ -257,43 +257,7 @@ async fn handler<Reporter: self::Reporter + 'static>(
         &format!("Switching pnpm from v{PNPM_VERSION} to v{target_version}..."),
     );
 
-    let env_root = config.global_pkg_dir.clone().ok_or(SelfUpdateError::NoGlobalDir)?;
-    // Resolve integrities into the env lockfile so the engine identity can
-    // be verified before install.
-    Box::pin(config_deps::sync_package_manager_dependencies(
-        config,
-        &env_root,
-        &target_version,
-        &target_version,
-        false,
-        false,
-    ))
-    .await?;
-    let env = EnvLockfile::read(&env_root)
-        .map_err(miette::Report::new)
-        .wrap_err("read the env lockfile")?
-        .ok_or_else(|| SelfUpdateError::EngineIdentityUnverifiable {
-            message: format!(
-                "Cannot verify the identity of pnpm@{target_version}: its integrity metadata is missing from pnpm-lock.yaml.",
-            ),
-        })?;
-    let label = format!("pnpm@{target_version}");
-    let package = install_pnpm::pnpm_package_to_install(&target_version);
-    let engine = verify_engine::EngineToVerify {
-        label: &label,
-        package: package.name,
-        version: &target_version,
-        platform_binaries: if package.links_native_binary {
-            verify_engine::PlatformBinaries::PnpmExe
-        } else {
-            verify_engine::PlatformBinaries::None
-        },
-    };
-    if let Some(warning) =
-        Box::pin(verify_engine::verify_engine_identity(&env, &engine, config)).await?
-    {
-        warn::<Reporter>(&prefix, &warning);
-    }
+    verify_target_engine::<Reporter>(config, &target_version, &prefix).await?;
 
     let result = Box::pin(install_pnpm::install_pnpm::<Reporter>(
         config,
@@ -311,6 +275,53 @@ async fn handler<Reporter: self::Reporter + 'static>(
         )));
     }
     Ok(Some(format!("Successfully updated pnpm to v{target_version}")))
+}
+
+/// Resolve the target engine's integrities into the env lockfile and verify
+/// its identity before anything is installed.
+async fn verify_target_engine<Reporter: self::Reporter + 'static>(
+    config: &'static Config,
+    target_version: &str,
+    prefix: &str,
+) -> miette::Result<()> {
+    let env_root = config.global_pkg_dir.clone().ok_or(SelfUpdateError::NoGlobalDir)?;
+    // Resolve integrities into the env lockfile so the engine identity can
+    // be verified before install.
+    Box::pin(config_deps::sync_package_manager_dependencies(
+        config,
+        &env_root,
+        target_version,
+        target_version,
+        false,
+        false,
+    ))
+    .await?;
+    let env = EnvLockfile::read(&env_root)
+        .map_err(miette::Report::new)
+        .wrap_err("read the env lockfile")?
+        .ok_or_else(|| SelfUpdateError::EngineIdentityUnverifiable {
+            message: format!(
+                "Cannot verify the identity of pnpm@{target_version}: its integrity metadata is missing from pnpm-lock.yaml.",
+            ),
+        })?;
+    let label = format!("pnpm@{target_version}");
+    let package = install_pnpm::pnpm_package_to_install(target_version);
+    let engine = verify_engine::EngineToVerify {
+        label: &label,
+        package: package.name,
+        version: target_version,
+        platform_binaries: if package.links_native_binary {
+            verify_engine::PlatformBinaries::PnpmExe
+        } else {
+            verify_engine::PlatformBinaries::None
+        },
+    };
+    if let Some(warning) =
+        Box::pin(verify_engine::verify_engine_identity(&env, &engine, config)).await?
+    {
+        warn::<Reporter>(prefix, &warning);
+    }
+    Ok(())
 }
 
 /// The migration hint for the major boundary this update crosses, if it

--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -383,10 +383,8 @@ pub(crate) fn link_exe_platform_binary(
 ) -> miette::Result<()> {
     let wrapper_dir = package_dir(install_dir, wrapper_pkg_name);
     if !wrapper_dir.exists() {
-        return Err(miette::miette!(
-            "the installed pnpm wrapper is missing at {}",
-            wrapper_dir.display()
-        ));
+        let wrapper_display = wrapper_dir.display();
+        return Err(miette::miette!("the installed pnpm wrapper is missing at {wrapper_display}"));
     }
     let platform = host_platform();
     let executable = if platform == "win32" { "pnpm.exe" } else { "pnpm" };

--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -383,22 +383,48 @@ pub(crate) fn link_exe_platform_binary(
 ) -> miette::Result<()> {
     let wrapper_dir = package_dir(install_dir, wrapper_pkg_name);
     if !wrapper_dir.exists() {
-        let wrapper_display = wrapper_dir.display();
-        return Err(miette::miette!("the installed pnpm wrapper is missing at {wrapper_display}"));
+        return Err(miette::miette!(
+            "the installed pnpm wrapper is missing at {}",
+            wrapper_dir.display()
+        ));
     }
     let platform = host_platform();
-    let arch = host_arch();
-    let libc = host_libc();
     let executable = if platform == "win32" { "pnpm.exe" } else { "pnpm" };
 
-    // Resolve the platform binary by its explicit adjacent path in the
-    // real virtual store, not via a `node_modules` walk (which a
-    // repo-controlled store-dir could shadow). `@pnpm/exe`'s parent is
-    // already `@pnpm`; the unscoped `pnpm` descends into `@pnpm`.
+    let (install_real_dir, wrapper_real_dir) = canonical_wrapper_dirs(install_dir, &wrapper_dir)?;
+    let parent = wrapper_real_dir
+        .parent()
+        .ok_or_else(|| miette::miette!("the pnpm wrapper has no parent directory"))?;
+    let scope_dir =
+        if wrapper_pkg_name.starts_with('@') { parent.to_path_buf() } else { parent.join("@pnpm") };
+
+    let src = find_native_binary(&scope_dir, platform, executable)?;
+    let native_source_root = native_source_trust_root(&install_real_dir, wrapper_pkg_name);
+    let src = validate_native_binary_source(&src, &native_source_root)?;
+    let dest = wrapper_real_dir.join(executable);
+    replace_executable(&src, &dest)
+        .into_diagnostic()
+        .wrap_err("link the native pnpm binary into the wrapper")?;
+
+    if platform == "win32" {
+        link_windows_aliases(&src, &wrapper_real_dir)?;
+        rewrite_windows_bin_field(&wrapper_real_dir);
+    }
+    Ok(())
+}
+
+/// Resolve the platform binary by its explicit adjacent path in the
+/// real virtual store, not via a `node_modules` walk (which a
+/// repo-controlled store-dir could shadow). `@pnpm/exe`'s parent is
+/// already `@pnpm`; the unscoped `pnpm` descends into `@pnpm`.
+fn canonical_wrapper_dirs(
+    install_dir: &Path,
+    wrapper_dir: &Path,
+) -> miette::Result<(PathBuf, PathBuf)> {
     let install_real_dir = fs::canonicalize(install_dir)
         .into_diagnostic()
         .wrap_err_with(|| format!("resolve the pnpm install dir at {}", install_dir.display()))?;
-    let wrapper_real_dir = fs::canonicalize(&wrapper_dir)
+    let wrapper_real_dir = fs::canonicalize(wrapper_dir)
         .into_diagnostic()
         .wrap_err_with(|| format!("resolve the pnpm wrapper at {}", wrapper_dir.display()))?;
     if !wrapper_real_dir.starts_with(&install_real_dir) {
@@ -410,41 +436,40 @@ pub(crate) fn link_exe_platform_binary(
             install_display
         ));
     }
-    let parent = wrapper_real_dir
-        .parent()
-        .ok_or_else(|| miette::miette!("the pnpm wrapper has no parent directory"))?;
-    let scope_dir =
-        if wrapper_pkg_name.starts_with('@') { parent.to_path_buf() } else { parent.join("@pnpm") };
+    Ok((install_real_dir, wrapper_real_dir))
+}
 
+/// The host's `@pnpm/exe` platform binary under `scope_dir`, in either
+/// package-directory spelling.
+fn find_native_binary(
+    scope_dir: &Path,
+    platform: &str,
+    executable: &str,
+) -> miette::Result<PathBuf> {
+    let arch = host_arch();
+    let libc = host_libc();
     let candidate_dir_names = [
         exe_platform_pkg_dir_name(platform, arch, libc),
         exe_platform_pkg_dir_name_next(platform, arch, libc),
     ];
-    let src = candidate_dir_names
+    candidate_dir_names
         .iter()
         .map(|dir_name| scope_dir.join(dir_name).join(executable))
         .find(|candidate| candidate.exists())
         .ok_or_else(|| {
             miette::miette!("no @pnpm/exe.{platform}-{arch} native binary was found for this host")
-        })?;
-    let native_source_root = native_source_trust_root(&install_real_dir, wrapper_pkg_name);
-    let src = validate_native_binary_source(&src, &native_source_root)?;
-    let dest = wrapper_real_dir.join(executable);
-    replace_executable(&src, &dest)
-        .into_diagnostic()
-        .wrap_err("link the native pnpm binary into the wrapper")?;
+        })
+}
 
-    if platform == "win32" {
-        // Aliases (pn / pnpx / pnx) must be .exe hardlinks of the native
-        // binary, not .cmd wrappers — cmd-shim's Bash shim mangles a .cmd
-        // target under MSYS2 / Git Bash. The native binary detects which
-        // name it was launched as and prepends `dlx` for pnpx / pnx.
-        for alias in ["pn", "pnpx", "pnx"] {
-            replace_executable(&src, &wrapper_real_dir.join(format!("{alias}.exe")))
-                .into_diagnostic()
-                .wrap_err_with(|| format!("link the {alias} alias into the wrapper"))?;
-        }
-        rewrite_windows_bin_field(&wrapper_real_dir);
+/// Aliases (pn / pnpx / pnx) must be .exe hardlinks of the native
+/// binary, not .cmd wrappers — cmd-shim's Bash shim mangles a .cmd
+/// target under MSYS2 / Git Bash. The native binary detects which
+/// name it was launched as and prepends `dlx` for pnpx / pnx.
+fn link_windows_aliases(src: &Path, wrapper_real_dir: &Path) -> miette::Result<()> {
+    for alias in ["pn", "pnpx", "pnx"] {
+        replace_executable(src, &wrapper_real_dir.join(format!("{alias}.exe")))
+            .into_diagnostic()
+            .wrap_err_with(|| format!("link the {alias} alias into the wrapper"))?;
     }
     Ok(())
 }

--- a/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/verify_engine.rs
@@ -470,28 +470,11 @@ async fn attempt_signature_verification(
         ));
     };
     let raw_signatures = version.dist.as_ref().and_then(|dist| dist.signatures.as_ref());
-    let parsed_signatures = match raw_signatures {
-        None => Vec::new(),
-        Some(serde_json::Value::Array(elements)) => {
-            let mut parsed = Vec::with_capacity(elements.len());
-            for element in elements {
-                let Ok(signature) = serde_json::from_value::<PackageSignature>(element.clone())
-                else {
-                    return Some((
-                        format!("malformed registry signatures metadata for {label}"),
-                        FailureCategory::Absent,
-                    ));
-                };
-                parsed.push(signature);
-            }
-            parsed
-        }
-        Some(_) => {
-            return Some((
-                format!("malformed registry signatures metadata for {label}"),
-                FailureCategory::Absent,
-            ));
-        }
+    let Some(parsed_signatures) = parse_signatures(raw_signatures) else {
+        return Some((
+            format!("malformed registry signatures metadata for {label}"),
+            FailureCategory::Absent,
+        ));
     };
     if parsed_signatures.is_empty() {
         return Some((
@@ -508,6 +491,18 @@ async fn attempt_signature_verification(
         None
     } else {
         Some(("invalid registry signature".to_string(), FailureCategory::Invalid))
+    }
+}
+
+/// The `dist.signatures` entries; empty when absent, `None` when malformed.
+fn parse_signatures(raw: Option<&serde_json::Value>) -> Option<Vec<PackageSignature>> {
+    match raw {
+        None => Some(Vec::new()),
+        Some(serde_json::Value::Array(elements)) => elements
+            .iter()
+            .map(|element| serde_json::from_value::<PackageSignature>(element.clone()).ok())
+            .collect(),
+        Some(_) => None,
     }
 }
 
@@ -619,8 +614,8 @@ async fn fetch_packument(
     retry_opts: RetryOpts,
     config: &Config,
 ) -> Result<Option<Packument>, String> {
-    let registry_url = with_trailing_slash(registry);
-    let packument_url = format!("{registry_url}{}", encode_package_name(&component.name));
+    let packument_url =
+        format!("{}{}", with_trailing_slash(registry), encode_package_name(&component.name));
     let display_url = redact_and_sanitize(&packument_url);
     // Resolve auth against the request URL *and* the package name so a
     // `@scope:registry`-scoped token applies (plain `for_url` skips the
@@ -647,9 +642,19 @@ async fn fetch_packument(
     if status != 200 {
         return Err(format!("{display_url} responded with {status}"));
     }
-    // Bound the buffered body so an oversized response from a
-    // misconfigured/compromised registry can't exhaust memory on this
-    // trust-critical path.
+    let body_bytes = read_bounded_body(response, &display_url).await?;
+    serde_json::from_slice::<Packument>(&body_bytes)
+        .map(Some)
+        .map_err(|err| format!("{display_url} returned invalid JSON: {err}"))
+}
+
+/// Bound the buffered body so an oversized response from a
+/// misconfigured/compromised registry can't exhaust memory on this
+/// trust-critical path.
+async fn read_bounded_body(
+    response: reqwest::Response,
+    display_url: &str,
+) -> Result<Vec<u8>, String> {
     if let Some(length) = response.content_length()
         && length > MAX_PACKUMENT_BYTES
     {
@@ -667,9 +672,7 @@ async fn fetch_packument(
         }
         body_bytes.extend_from_slice(&chunk);
     }
-    serde_json::from_slice::<Packument>(&body_bytes)
-        .map(Some)
-        .map_err(|err| format!("{display_url} returned invalid JSON: {err}"))
+    Ok(body_bytes)
 }
 
 /// Upper bound on a buffered packument response. Generous relative to the

--- a/pnpm/crates/cli/src/cli_args/stage/approve.rs
+++ b/pnpm/crates/cli/src/cli_args/stage/approve.rs
@@ -23,7 +23,9 @@ use pnpm_resolving_resolver_base::{
     ANY_VERSION_RANGE, is_any_version_range, is_valid_semver_range,
 };
 use pnpm_workspace::{GraphPkg, Project};
-use pnpm_workspace_projects_graph::{CreateProjectsGraphOptions, create_projects_graph};
+use pnpm_workspace_projects_graph::{
+    CreateProjectsGraphOptions, ProjectGraph, create_projects_graph,
+};
 use serde_json::Value;
 
 use super::{
@@ -360,36 +362,7 @@ async fn read_stage_approval_order(
     let mut projects = Vec::with_capacity(items.len());
     let mut stage_id_by_package_version: HashMap<(String, String), String> = HashMap::new();
     for item in items {
-        let root_dir = PathBuf::from(&item.id);
-        let tarball = fetch_stage_tarball(context, &item.id).await?;
-        let manifest = read_tarball_manifest(&tarball)?;
-        let package_name = manifest
-            .get("name")
-            .and_then(Value::as_str)
-            .ok_or(StageError::TarballManifestNotFound)?
-            .to_owned();
-        let version = manifest
-            .get("version")
-            .and_then(Value::as_str)
-            .ok_or(StageError::TarballManifestNotFound)?
-            .to_owned();
-        if let Some(first_stage_id) = stage_id_by_package_version
-            .insert((package_name.clone(), version.clone()), item.id.clone())
-        {
-            return Err(StageError::DuplicateStagePackage {
-                first_stage_id,
-                second_stage_id: item.id.clone(),
-                package_name,
-                version,
-            }
-            .into());
-        }
-        let manifest = manifest_for_graph(manifest);
-        projects.push(Project {
-            manifest: PackageManifest::from_value(root_dir.join("package.json"), manifest),
-            root_dir,
-            dependency_manifest: None,
-        });
+        projects.push(staged_project(context, item, &mut stage_id_by_package_version).await?);
     }
     let graph = create_projects_graph(
         projects.iter().map(|project| GraphPkg { project }).collect(),
@@ -399,10 +372,53 @@ async fn read_stage_approval_order(
         },
     )
     .graph;
+    Ok(approval_order(&graph))
+}
+
+/// The stage's package as a workspace project, refusing a second stage of
+/// the same package version.
+async fn staged_project(
+    context: &StageContext,
+    item: &StageApprovalItem,
+    stage_id_by_package_version: &mut HashMap<(String, String), String>,
+) -> miette::Result<Project> {
+    let root_dir = PathBuf::from(&item.id);
+    let tarball = fetch_stage_tarball(context, &item.id).await?;
+    let manifest = read_tarball_manifest(&tarball)?;
+    let package_name = manifest
+        .get("name")
+        .and_then(Value::as_str)
+        .ok_or(StageError::TarballManifestNotFound)?
+        .to_owned();
+    let version = manifest
+        .get("version")
+        .and_then(Value::as_str)
+        .ok_or(StageError::TarballManifestNotFound)?
+        .to_owned();
+    if let Some(first_stage_id) =
+        stage_id_by_package_version.insert((package_name.clone(), version.clone()), item.id.clone())
+    {
+        return Err(StageError::DuplicateStagePackage {
+            first_stage_id,
+            second_stage_id: item.id.clone(),
+            package_name,
+            version,
+        }
+        .into());
+    }
+    let manifest = manifest_for_graph(manifest);
+    Ok(Project {
+        manifest: PackageManifest::from_value(root_dir.join("package.json"), manifest),
+        root_dir,
+        dependency_manifest: None,
+    })
+}
+
+fn approval_order(graph: &ProjectGraph<GraphPkg<'_>>) -> StageApprovalOrder {
     let mut dependency_stage_ids_by_stage_id = HashMap::new();
     let mut order_index_by_stage_id = HashMap::new();
     let mut package_name_by_stage_id = HashMap::new();
-    for (order_index, root_dir) in sequence_graph(&graph, &graph).order.into_iter().enumerate() {
+    for (order_index, root_dir) in sequence_graph(graph, graph).order.into_iter().enumerate() {
         let stage_id = root_dir.to_string_lossy().into_owned();
         order_index_by_stage_id.insert(stage_id.clone(), order_index);
         dependency_stage_ids_by_stage_id.insert(
@@ -419,11 +435,11 @@ async fn read_stage_approval_order(
             package_name_by_stage_id.insert(stage_id, package_name.to_owned());
         }
     }
-    Ok(StageApprovalOrder {
+    StageApprovalOrder {
         dependency_stage_ids: dependency_stage_ids_by_stage_id,
         order_indices: order_index_by_stage_id,
         package_names: package_name_by_stage_id,
-    })
+    }
 }
 
 /// Approve staged dependencies before the selected packages that need them.

--- a/pnpm/crates/cli/src/cli_args/stage/summarize_tarball.rs
+++ b/pnpm/crates/cli/src/cli_args/stage/summarize_tarball.rs
@@ -75,12 +75,7 @@ fn read_tarball_contents(
             contents.push_file(&path, entry.header().size().unwrap_or(0));
         }
         if path == "package/package.json" {
-            let mut text = String::new();
-            entry
-                .read_to_string(&mut text)
-                .into_diagnostic()
-                .wrap_err("read package/package.json from the staged tarball")?;
-            manifest_text = Some(text);
+            manifest_text = Some(read_entry_text(&mut entry)?);
         }
     }
 
@@ -93,8 +88,21 @@ fn read_tarball_contents(
     }
     validate_package_identity(&name, &version)?;
 
-    let FileSummary { files, bundled, unpacked_size } = contents;
-    Ok(TarballContents { files, bundled, manifest, unpacked_size })
+    Ok(TarballContents {
+        files: contents.files,
+        bundled: contents.bundled,
+        manifest,
+        unpacked_size: contents.unpacked_size,
+    })
+}
+
+fn read_entry_text(entry: &mut tar::Entry<'_, &[u8]>) -> miette::Result<String> {
+    let mut text = String::new();
+    entry
+        .read_to_string(&mut text)
+        .into_diagnostic()
+        .wrap_err("read package/package.json from the staged tarball")?;
+    Ok(text)
 }
 
 /// What the summary records about the tarball's file entries.

--- a/pnpm/crates/cli/src/cli_args/star.rs
+++ b/pnpm/crates/cli/src/cli_args/star.rs
@@ -157,31 +157,9 @@ async fn perform_legacy_star_action(
     let username = fetch_whoami(registry_url, http_client, auth_header, retry_opts).await?;
     let pkg_url = format!("{registry_url}{escaped_name}");
 
-    let (client, response) = send_with_retry(http_client, &pkg_url, retry_opts, |client| {
-        client
-            .get(&pkg_url)
-            .header("authorization", auth_header)
-            .header("accept", "application/json")
-    })
-    .await
-    .into_diagnostic()
-    .wrap_err("requesting the package metadata")?;
-
-    if !response.status().is_success() {
-        let status = response.status();
-        drop(client);
-        if status.as_u16() == 404 {
-            return Err(StarError::PackageNotFound { package: package_name.to_string() }.into());
-        }
-        return Err(StarError::FetchPackageInfo {
-            status: status.as_u16(),
-            status_text: status.canonical_reason().unwrap_or_default().to_string(),
-        }
-        .into());
-    }
-    let mut pkg_data: Value =
-        response.json().await.into_diagnostic().wrap_err("parsing the package metadata")?;
-    drop(client);
+    let mut pkg_data =
+        fetch_package_document(http_client, &pkg_url, auth_header, retry_opts, package_name)
+            .await?;
 
     apply_star_to_users(&mut pkg_data, &username, is_star);
 
@@ -217,6 +195,41 @@ async fn perform_legacy_star_action(
     }
     drop(client2);
     Ok(())
+}
+
+async fn fetch_package_document(
+    http_client: &ThrottledClient,
+    pkg_url: &str,
+    auth_header: &str,
+    retry_opts: RetryOpts,
+    package_name: &str,
+) -> miette::Result<Value> {
+    let (client, response) = send_with_retry(http_client, pkg_url, retry_opts, |client| {
+        client
+            .get(pkg_url)
+            .header("authorization", auth_header)
+            .header("accept", "application/json")
+    })
+    .await
+    .into_diagnostic()
+    .wrap_err("requesting the package metadata")?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        drop(client);
+        if status.as_u16() == 404 {
+            return Err(StarError::PackageNotFound { package: package_name.to_string() }.into());
+        }
+        return Err(StarError::FetchPackageInfo {
+            status: status.as_u16(),
+            status_text: status.canonical_reason().unwrap_or_default().to_string(),
+        }
+        .into());
+    }
+    let pkg_data =
+        response.json().await.into_diagnostic().wrap_err("parsing the package metadata")?;
+    drop(client);
+    Ok(pkg_data)
 }
 
 /// Set or clear `pkg_data.users[username]`, creating the `users` map when it is

--- a/pnpm/crates/cli/src/cli_args/store/add.rs
+++ b/pnpm/crates/cli/src/cli_args/store/add.rs
@@ -112,41 +112,49 @@ pub(super) async fn run<Reporter: self::Reporter>(
 
     let mut has_failures = false;
     for package in packages {
-        let outcome = add_one::<Reporter>(AddOne {
-            config,
-            http_client: &http_client,
-            resolver: &resolver,
-            resolve_options: &resolve_options,
-            store_index: store_index.clone(),
-            store_index_writer: &store_index_writer,
-            verified_files_cache: SharedVerifiedFilesCache::clone(&verified_files_cache),
-            requester: &requester,
-            package,
-        })
-        .await;
-        match outcome {
-            Ok(package_id) => {
-                Reporter::emit(&LogEvent::Global(GlobalLog {
-                    level: LogLevel::Info,
-                    message: format!("+ {package_id}"),
-                }));
-            }
-            // The command keeps going so one bad specifier doesn't strand
-            // the rest, which leaves this line as the only place the cause
-            // is reported — so it carries the code the top-level handler
-            // would otherwise have printed.
-            Err(error) => {
-                has_failures = true;
-                let code = error.code().map_or_else(String::new, |code| format!("{code}: "));
-                emit_global_warning::<Reporter>(&format!("{code}{error}"));
-            }
-        }
+        has_failures |= report_add_outcome::<Reporter>(
+            add_one::<Reporter>(AddOne {
+                config,
+                http_client: &http_client,
+                resolver: &resolver,
+                resolve_options: &resolve_options,
+                store_index: store_index.clone(),
+                store_index_writer: &store_index_writer,
+                verified_files_cache: SharedVerifiedFilesCache::clone(&verified_files_cache),
+                requester: &requester,
+                package,
+            })
+            .await,
+        );
     }
 
     drop(store_index_writer);
     StoreIndexWriter::drain(writer_task, "; some rows may not be persisted").await;
 
     if has_failures { Err(StoreAddFailureError.into()) } else { Ok(()) }
+}
+
+/// Report one specifier's outcome; `true` when it failed.
+///
+/// The command keeps going so one bad specifier doesn't strand
+/// the rest, which leaves this line as the only place the cause
+/// is reported — so it carries the code the top-level handler
+/// would otherwise have printed.
+fn report_add_outcome<Reporter: self::Reporter>(outcome: miette::Result<String>) -> bool {
+    match outcome {
+        Ok(package_id) => {
+            Reporter::emit(&LogEvent::Global(GlobalLog {
+                level: LogLevel::Info,
+                message: format!("+ {package_id}"),
+            }));
+            false
+        }
+        Err(error) => {
+            let code = error.code().map_or_else(String::new, |code| format!("{code}: "));
+            emit_global_warning::<Reporter>(&format!("{code}{error}"));
+            true
+        }
+    }
 }
 
 /// Everything one specifier's resolve-and-fetch needs. Grouped so the
@@ -166,18 +174,7 @@ struct AddOne<'a> {
 /// Resolve one specifier and pull its tarball into the store, returning
 /// the package id pnpm reports it under.
 async fn add_one<Reporter: self::Reporter>(args: AddOne<'_>) -> miette::Result<String> {
-    let AddOne {
-        config,
-        http_client,
-        resolver,
-        resolve_options,
-        store_index,
-        store_index_writer,
-        verified_files_cache,
-        requester,
-        package,
-    } = args;
-    let parsed = parse_wanted_dependency(package);
+    let parsed = parse_wanted_dependency(args.package);
     let wanted_dependency = WantedDependency {
         alias: parsed.alias,
         bare_specifier: parsed.bare_specifier.filter(|spec| !spec.trim().is_empty()),
@@ -185,43 +182,44 @@ async fn add_one<Reporter: self::Reporter>(args: AddOne<'_>) -> miette::Result<S
         prev_specifier: None,
         optional: None,
     };
-    let resolved = resolver
-        .resolve(&wanted_dependency, resolve_options)
+    let resolved = args
+        .resolver
+        .resolve(&wanted_dependency, args.resolve_options)
         .await
-        .map_err(|error| miette::miette!("{package}: {error}"))?;
+        .map_err(|error| miette::miette!("{}: {error}", args.package))?;
     let package_id = resolved.id.to_string();
     let Some((package_url, integrity)) = archive_to_fetch(&resolved.resolution) else {
         return Err(UnsupportedSpecError {
-            package: package.to_owned(),
+            package: args.package.to_owned(),
             resolved_via: resolved.resolved_via,
         }
         .into());
     };
 
     IngestTarballToStore {
-        http_client,
-        store_dir: &config.store_dir,
-        store_index,
-        store_index_writer: Some(Arc::clone(store_index_writer)),
-        verify_store_integrity: config.verify_store_integrity,
-        strict_store_pkg_content_check: config.strict_store_pkg_content_check,
-        verified_files_cache,
+        http_client: args.http_client,
+        store_dir: &args.config.store_dir,
+        store_index: args.store_index,
+        store_index_writer: Some(Arc::clone(args.store_index_writer)),
+        verify_store_integrity: args.config.verify_store_integrity,
+        strict_store_pkg_content_check: args.config.strict_store_pkg_content_check,
+        verified_files_cache: args.verified_files_cache,
         package_integrity: integrity.as_ref(),
         package_unpacked_size: manifest_unpacked_size(resolved.manifest.as_deref()),
         package_file_count: manifest_file_count(resolved.manifest.as_deref()),
         package_url,
         package_id: &package_id,
-        auth_headers: &config.auth_headers,
-        requester,
+        auth_headers: &args.config.auth_headers,
+        requester: args.requester,
         prefetched_cas_paths: None,
         retry_opts: pnpm_network::RetryOpts {
-            retries: config.fetch_retries,
-            factor: config.fetch_retry_factor,
-            min_timeout: std::time::Duration::from_millis(config.fetch_retry_mintimeout),
-            max_timeout: std::time::Duration::from_millis(config.fetch_retry_maxtimeout),
+            retries: args.config.fetch_retries,
+            factor: args.config.fetch_retry_factor,
+            min_timeout: std::time::Duration::from_millis(args.config.fetch_retry_mintimeout),
+            max_timeout: std::time::Duration::from_millis(args.config.fetch_retry_maxtimeout),
         },
         ignore_file_pattern: None,
-        offline: config.offline,
+        offline: args.config.offline,
         progress_reported: None,
         store_projection: pnpm_tarball::ArchiveStoreProjection::Package { append_manifest: None },
     }

--- a/pnpm/crates/cli/src/cli_args/store/status.rs
+++ b/pnpm/crates/cli/src/cli_args/store/status.rs
@@ -9,7 +9,7 @@ use miette::{Diagnostic, IntoDiagnostic};
 use pnpm_config::Config;
 use pnpm_deps_restorer::{safe_join_modules_dir, store_index_key_for_resolution};
 use pnpm_lockfile::Lockfile;
-use pnpm_modules_yaml::{Host, read_modules_manifest};
+use pnpm_modules_yaml::{Host, Modules, read_modules_manifest};
 use pnpm_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
 use pnpm_store_dir::{StoreIndex, StoreIndexError, package_dir_matches_index};
 use rayon::prelude::*;
@@ -45,19 +45,42 @@ pub(super) async fn run<Reporter: self::Reporter>(
     let Some(lockfile) = Lockfile::load_wanted_from_dir(&lockfile_dir).into_diagnostic()? else {
         return report_untouched::<Reporter>(dir);
     };
-    let modules_dir = lockfile_dir.join("node_modules");
-    let modules_manifest = read_modules_manifest::<Host>(&modules_dir).into_diagnostic()?;
+    let modules_manifest =
+        read_modules_manifest::<Host>(&lockfile_dir.join("node_modules")).into_diagnostic()?;
+    let packages = packages_to_check(config, &lockfile, modules_manifest.as_ref(), &lockfile_dir);
+
+    let store_dir = config.store_dir.root().to_path_buf();
+    let frozen_store = config.frozen_store;
+    let mut modified =
+        tokio::task::spawn_blocking(move || find_modified(&store_dir, frozen_store, &packages))
+            .await
+            .into_diagnostic()?
+            .into_diagnostic()?;
+
+    if modified.is_empty() {
+        return report_untouched::<Reporter>(dir);
+    }
+    modified.sort_unstable();
+    Err(ModifiedDependencyError { modified }.into())
+}
+
+/// Every installed package the store can verify, with where each lives.
+fn packages_to_check(
+    config: &Config,
+    lockfile: &Lockfile,
+    modules_manifest: Option<&Modules>,
+    lockfile_dir: &Path,
+) -> Vec<PackageToCheck> {
     let skipped: HashSet<&str> = modules_manifest
-        .as_ref()
         .map(|manifest| manifest.skipped.iter().map(String::as_str).collect())
         .unwrap_or_default();
-    let virtual_store_dir = modules_manifest.as_ref().map_or_else(
-        || resolve_virtual_store_dir(config, &lockfile_dir),
+    let virtual_store_dir = modules_manifest.map_or_else(
+        || resolve_virtual_store_dir(config, lockfile_dir),
         |manifest| PathBuf::from(&manifest.virtual_store_dir),
     );
 
     let max_length = config.virtual_store_dir_max_length as usize;
-    let packages = lockfile
+    lockfile
         .packages
         .iter()
         .flatten()
@@ -73,21 +96,7 @@ pub(super) async fn run<Reporter: self::Reporter>(
                 store_index_key,
             })
         })
-        .collect::<Vec<_>>();
-
-    let store_dir = config.store_dir.root().to_path_buf();
-    let frozen_store = config.frozen_store;
-    let mut modified =
-        tokio::task::spawn_blocking(move || find_modified(&store_dir, frozen_store, &packages))
-            .await
-            .into_diagnostic()?
-            .into_diagnostic()?;
-
-    if modified.is_empty() {
-        return report_untouched::<Reporter>(dir);
-    }
-    modified.sort_unstable();
-    Err(ModifiedDependencyError { modified }.into())
+        .collect()
 }
 
 /// Re-hash every candidate against its store row. Runs on the blocking

--- a/pnpm/crates/cli/src/cli_args/task_run_state.rs
+++ b/pnpm/crates/cli/src/cli_args/task_run_state.rs
@@ -131,49 +131,16 @@ impl TaskRunStateContext {
     ) -> Self {
         let mut keys_by_id = HashMap::with_capacity(graph.len());
         let mut ids_by_key = HashMap::with_capacity(graph.len());
-        let mut tasks: Vec<TaskIdentity> = graph
+        let tasks: Vec<TaskIdentity> = graph
             .iter()
             .map(|(key, node)| {
                 let id = task_id(node, workspace_dir);
                 keys_by_id.insert(id.clone(), key.clone());
                 ids_by_key.insert(key.clone(), id.clone());
-                let mut scripts: Vec<ScriptIdentity> = node
-                    .scripts
-                    .iter()
-                    .map(|name| ScriptIdentity {
-                        name: name.clone(),
-                        commands: script_commands(node, name),
-                    })
-                    .collect();
-                scripts.sort_by(|left, right| left.name.cmp(&right.name));
-                let mut dependencies: Vec<TaskId> = node
-                    .dependencies
-                    .iter()
-                    .map(|dependency| task_id(&graph[dependency], workspace_dir))
-                    .collect();
-                dependencies.sort();
-                TaskIdentity {
-                    project: id.project,
-                    task: id.task,
-                    scripts,
-                    requested: node.requested,
-                    dependencies,
-                }
+                task_identity(node, id, graph, workspace_dir, &script_commands)
             })
             .collect();
-        tasks.sort_by(|left, right| {
-            left.project.cmp(&right.project).then_with(|| left.task.cmp(&right.task))
-        });
-        let mut settings = settings.to_vec();
-        settings.sort();
-        let identity = serde_json::to_string(&InvocationIdentity {
-            command,
-            params,
-            settings: &settings,
-            tasks,
-        })
-        .expect("task invocation identity serializes");
-        let invocation = create_hex_hash(&identity);
+        let invocation = invocation_hash(command, params, settings, tasks);
         let state_dir = workspace_dir.join("node_modules").join(STATE_DIR);
         let latest_state_path = state_dir.join(LATEST_STATE_FILE);
         Self { state_dir, latest_state_path, invocation, keys_by_id, ids_by_key }
@@ -579,6 +546,53 @@ fn task_id(node: &TaskNode, workspace_dir: &Path) -> TaskId {
         relative.to_string_lossy().replace(std::path::MAIN_SEPARATOR, "/")
     };
     TaskId { project, task: node.task_name.clone() }
+}
+
+fn task_identity(
+    node: &TaskNode,
+    id: TaskId,
+    graph: &TaskGraph,
+    workspace_dir: &Path,
+    script_commands: &impl Fn(&TaskNode, &str) -> Vec<String>,
+) -> TaskIdentity {
+    let mut scripts: Vec<ScriptIdentity> = node
+        .scripts
+        .iter()
+        .map(|name| ScriptIdentity { name: name.clone(), commands: script_commands(node, name) })
+        .collect();
+    scripts.sort_by(|left, right| left.name.cmp(&right.name));
+    let mut dependencies: Vec<TaskId> = node
+        .dependencies
+        .iter()
+        .map(|dependency| task_id(&graph[dependency], workspace_dir))
+        .collect();
+    dependencies.sort();
+    TaskIdentity {
+        project: id.project,
+        task: id.task,
+        scripts,
+        requested: node.requested,
+        dependencies,
+    }
+}
+
+/// The invocation's identity hash over its command line and the sorted
+/// settings and tasks.
+fn invocation_hash(
+    command: &str,
+    params: &[String],
+    settings: &[String],
+    mut tasks: Vec<TaskIdentity>,
+) -> String {
+    tasks.sort_by(|left, right| {
+        left.project.cmp(&right.project).then_with(|| left.task.cmp(&right.task))
+    });
+    let mut settings = settings.to_vec();
+    settings.sort();
+    let identity =
+        serde_json::to_string(&InvocationIdentity { command, params, settings: &settings, tasks })
+            .expect("task invocation identity serializes");
+    create_hex_hash(&identity)
 }
 
 fn is_run_id(run: &str) -> bool {

--- a/pnpm/crates/cli/src/cli_args/unpublish.rs
+++ b/pnpm/crates/cli/src/cli_args/unpublish.rs
@@ -282,31 +282,8 @@ async fn unpublish_versions<Sys: UnpublishHost, Reporter: self::Reporter>(
     mut pkg: Packument,
     versions: &[String],
 ) -> miette::Result<String> {
-    let mut tarballs: Vec<String> = Vec::new();
-    for version in versions {
-        let tarball = pkg
-            .versions
-            .get(version)
-            .and_then(|data| data.get("dist"))
-            .and_then(|dist| dist.get("tarball"))
-            .and_then(Value::as_str);
-        if let Some(tarball) = tarball {
-            tarballs.push(tarball.to_string());
-        }
-        pkg.versions.remove(version);
-    }
-
-    let removed: HashSet<&str> = versions.iter().map(String::as_str).collect();
-    let latest_was_removed = pkg
-        .dist_tags
-        .get("latest")
-        .and_then(Value::as_str)
-        .is_some_and(|latest| removed.contains(latest));
-    pkg.dist_tags
-        .retain(|_, target| !target.as_str().is_some_and(|target| removed.contains(target)));
-    if latest_was_removed && let Some(highest) = highest_version(&pkg.versions) {
-        pkg.dist_tags.insert("latest".to_string(), Value::String(highest));
-    }
+    let tarballs = remove_versions(&mut pkg, versions);
+    retag_after_removal(&mut pkg, versions);
 
     // Internal CouchDB metadata must not round-trip into the PUT.
     pkg.other.remove("_revisions");
@@ -343,6 +320,40 @@ async fn unpublish_versions<Sys: UnpublishHost, Reporter: self::Reporter>(
     }
 
     Ok(format!("Successfully unpublished {} version(s) of {}", versions.len(), pkg.name))
+}
+
+/// Drop `versions` from the packument, returning their tarball URLs.
+fn remove_versions(pkg: &mut Packument, versions: &[String]) -> Vec<String> {
+    let mut tarballs: Vec<String> = Vec::new();
+    for version in versions {
+        let tarball = pkg
+            .versions
+            .get(version)
+            .and_then(|data| data.get("dist"))
+            .and_then(|dist| dist.get("tarball"))
+            .and_then(Value::as_str);
+        if let Some(tarball) = tarball {
+            tarballs.push(tarball.to_string());
+        }
+        pkg.versions.remove(version);
+    }
+    tarballs
+}
+
+/// Drop the dist-tags that pointed at the removed versions, moving `latest`
+/// to the highest version left.
+fn retag_after_removal(pkg: &mut Packument, versions: &[String]) {
+    let removed: HashSet<&str> = versions.iter().map(String::as_str).collect();
+    let latest_was_removed = pkg
+        .dist_tags
+        .get("latest")
+        .and_then(Value::as_str)
+        .is_some_and(|latest| removed.contains(latest));
+    pkg.dist_tags
+        .retain(|_, target| !target.as_str().is_some_and(|target| removed.contains(target)));
+    if latest_was_removed && let Some(highest) = highest_version(&pkg.versions) {
+        pkg.dist_tags.insert("latest".to_string(), Value::String(highest));
+    }
 }
 
 /// Send one mutation through the OTP session: the first attempt carries any

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -195,10 +195,10 @@ impl UpdateArgs {
         let workspace_root = self.check_workspace_option(state.config.workspace_dir.as_deref())?;
         let include_direct = self.dependency_options.include_direct();
         let update_actions = self.should_update_github_actions(state.config, &include_direct);
+        let lockfile_path = state.lockfile_path();
         if let Some(pnpr_server) =
             self.delegated_pnpr_server(state.config, update_actions, &include_direct)
         {
-            let lockfile_path = state.lockfile_path();
             return super::install::install_via_pnpr::<Reporter>(
                 &state,
                 pnpr_server,
@@ -206,13 +206,7 @@ impl UpdateArgs {
             )
             .await;
         }
-        let workspace_packages = workspace_root
-            .map(|workspace_root| {
-                recursive::discover_workspace_projects(workspace_root, state.config)
-                    .map(|(projects, _)| build_workspace_packages_map(Some(&projects)))
-            })
-            .transpose()?
-            .flatten();
+        let workspace_packages = discovered_workspace_packages(workspace_root, state.config)?;
 
         let actions_root =
             state.config.workspace_dir.clone().unwrap_or_else(|| manifest_root(&state.manifest));
@@ -229,27 +223,19 @@ impl UpdateArgs {
             return Ok(());
         }
 
-        let lockfile_path = state.lockfile_path();
-        let active_importer_id = state.active_importer_id();
-        let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
-            &mut state;
-        let lockfile =
-            lockfile.get().map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
-
-        let supported_architectures =
-            self.supported_architectures.apply_to(config.supported_architectures.clone());
+        let lockfile = loaded_lockfile(&state.lockfile)?;
 
         let packages = if self.interactive {
             // Nothing outdated, or the user picked nothing — there is
             // nothing to update, so don't fall through to a full update
             // (which an empty selector list would mean).
-            let Some(selected) = crate::cli_args::update_interactive::select_packages::<Reporter>(
+            match crate::cli_args::update_interactive::select_packages::<Reporter>(
                 &actions_root,
-                manifest,
+                &state.manifest,
                 lockfile,
-                &active_importer_id,
-                config,
-                http_client,
+                &state.active_importer_id(),
+                state.config,
+                &state.http_client,
                 InteractiveUpdateOptions {
                     latest: self.latest,
                     include_direct: &include_direct,
@@ -258,10 +244,10 @@ impl UpdateArgs {
                 },
             )
             .await?
-            else {
-                return Ok(());
-            };
-            selected
+            {
+                Some(packages) => packages,
+                None => return Ok(()),
+            }
         } else {
             package_selectors
         };
@@ -272,27 +258,28 @@ impl UpdateArgs {
             action_matcher
         };
         let package_selectors = filter_package_selectors(&packages, update_actions);
-        let run_package_update = self.updates_packages(&package_selectors);
 
-        if run_package_update {
+        if self.updates_packages(&package_selectors) {
             Update {
-                tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
-                resolved_packages,
-                http_client,
-                http_client_arc: std::sync::Arc::clone(http_client),
-                config,
-                manifest,
+                tarball_mem_cache: std::sync::Arc::clone(&state.tarball_mem_cache),
+                resolved_packages: &state.resolved_packages,
+                http_client: &state.http_client,
+                http_client_arc: std::sync::Arc::clone(&state.http_client),
+                config: state.config,
+                manifest: &mut state.manifest,
                 lockfile,
                 lockfile_path: Some(&lockfile_path),
                 packages: &package_selectors,
                 latest: self.latest,
                 patches: self.patches,
-                save_exact: self.save_exact || config.save_exact,
+                save_exact: self.save_exact || state.config.save_exact,
                 save: !self.no_save,
                 include_direct,
                 depth: self.depth.unwrap_or(usize::MAX),
                 workspace_packages: workspace_packages.as_ref(),
-                supported_architectures,
+                supported_architectures: self
+                    .supported_architectures
+                    .apply_to(state.config.supported_architectures.clone()),
                 lockfile_only: self.lockfile_only,
                 resolution_observer: None,
             }
@@ -304,7 +291,7 @@ impl UpdateArgs {
             update_actions,
             &actions_root,
             selected_action_matcher.as_ref(),
-            config,
+            state.config,
         )
         .await?;
         Ok(())
@@ -353,17 +340,17 @@ impl UpdateArgs {
     pub(crate) async fn run_selected<Reporter: self::Reporter + 'static>(
         self,
         mut state: State,
-        selection: InstallFamilySelection,
+        mut selection: InstallFamilySelection,
     ) -> miette::Result<()> {
         self.check_patches_options()?;
         state.http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
         let workspace_root = self.check_workspace_option(state.config.workspace_dir.as_deref())?;
         let include_direct = self.dependency_options.include_direct();
         let update_actions = self.should_update_github_actions(state.config, &include_direct);
+        let lockfile_path = state.lockfile_path();
         if let Some(pnpr_server) =
             self.delegated_pnpr_server(state.config, update_actions, &include_direct)
         {
-            let lockfile_path = state.lockfile_path();
             return super::install::install_selected_via_pnpr::<Reporter>(
                 &state,
                 pnpr_server,
@@ -389,33 +376,26 @@ impl UpdateArgs {
             return Ok(());
         }
 
-        let lockfile_path = state.lockfile_path();
-        let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
-            &mut state;
-        let lockfile =
-            lockfile.get().map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
-        let supported_architectures =
-            self.supported_architectures.apply_to(config.supported_architectures.clone());
+        let lockfile = loaded_lockfile(&state.lockfile)?;
         let packages = if self.interactive {
-            let Some(selected) =
-                crate::cli_args::update_interactive::select_packages_for_projects::<Reporter>(
-                    &actions_root,
-                    &selection,
-                    lockfile,
-                    config,
-                    http_client,
-                    InteractiveUpdateOptions {
-                        latest: self.latest,
-                        include_direct: &include_direct,
-                        include_github_actions: update_actions,
-                        prompt: self.prompt,
-                    },
-                )
-                .await?
-            else {
-                return Ok(());
-            };
-            selected
+            match crate::cli_args::update_interactive::select_packages_for_projects::<Reporter>(
+                &actions_root,
+                &selection,
+                lockfile,
+                state.config,
+                &state.http_client,
+                InteractiveUpdateOptions {
+                    latest: self.latest,
+                    include_direct: &include_direct,
+                    include_github_actions: update_actions,
+                    prompt: self.prompt,
+                },
+            )
+            .await?
+            {
+                Some(packages) => packages,
+                None => return Ok(()),
+            }
         } else {
             package_selectors
         };
@@ -425,47 +405,38 @@ impl UpdateArgs {
             action_matcher
         };
         let package_selectors = filter_package_selectors(&packages, update_actions);
-        let run_package_update = self.updates_packages(&package_selectors);
-        let InstallFamilySelection {
-            workspace_root: _,
-            workspace_cycles: _,
-            mut projects,
-            project_dependencies,
-            ordered_dirs,
-            selected_dirs,
-            install_dirs,
-            active_manifest_is_standin,
-        } = selection;
 
-        if run_package_update {
+        if self.updates_packages(&package_selectors) {
             Update {
-                tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
-                resolved_packages,
-                http_client,
-                http_client_arc: std::sync::Arc::clone(http_client),
-                config,
-                manifest,
+                tarball_mem_cache: std::sync::Arc::clone(&state.tarball_mem_cache),
+                resolved_packages: &state.resolved_packages,
+                http_client: &state.http_client,
+                http_client_arc: std::sync::Arc::clone(&state.http_client),
+                config: state.config,
+                manifest: &mut state.manifest,
                 lockfile,
                 lockfile_path: Some(&lockfile_path),
                 packages: &package_selectors,
                 latest: self.latest,
                 patches: self.patches,
-                save_exact: self.save_exact || config.save_exact,
+                save_exact: self.save_exact || state.config.save_exact,
                 save: !self.no_save,
                 include_direct,
                 depth: self.depth.unwrap_or(usize::MAX),
                 workspace_packages: workspace_packages.as_ref(),
-                supported_architectures,
+                supported_architectures: self
+                    .supported_architectures
+                    .apply_to(state.config.supported_architectures.clone()),
                 lockfile_only: self.lockfile_only,
                 resolution_observer: None,
             }
             .run_selected::<Reporter>(pnpm_package_manager::SelectedProjects {
-                projects: &mut projects,
-                project_dependencies: &project_dependencies,
-                ordered_dirs: &ordered_dirs,
-                selected_dirs: selected_dirs.as_ref(),
-                install_dirs: install_dirs.as_ref(),
-                active_manifest_is_standin,
+                projects: &mut selection.projects,
+                project_dependencies: &selection.project_dependencies,
+                ordered_dirs: &selection.ordered_dirs,
+                selected_dirs: selection.selected_dirs.as_ref(),
+                install_dirs: selection.install_dirs.as_ref(),
+                active_manifest_is_standin: selection.active_manifest_is_standin,
             })
             .await
             .wrap_err("updating dependencies")?;
@@ -474,7 +445,7 @@ impl UpdateArgs {
             update_actions,
             &actions_root,
             selected_action_matcher.as_ref(),
-            config,
+            state.config,
         )
         .await?;
         Ok(())
@@ -603,6 +574,26 @@ fn manifest_root(manifest: &pnpm_package_manifest::PackageManifest) -> std::path
 
 /// The matcher for the workflow selectors, when this run updates
 /// workflow files at all.
+fn loaded_lockfile(
+    lockfile: &pnpm_lockfile::LazyLockfile,
+) -> miette::Result<Option<&pnpm_lockfile::Lockfile>> {
+    lockfile.get().map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))
+}
+
+/// The workspace's packages when the update runs inside one.
+fn discovered_workspace_packages(
+    workspace_root: Option<&Path>,
+    config: &Config,
+) -> miette::Result<Option<pnpm_resolving_resolver_base::WorkspacePackages>> {
+    workspace_root
+        .map(|workspace_root| {
+            recursive::discover_workspace_projects(workspace_root, config)
+                .map(|(projects, _)| build_workspace_packages_map(Some(&projects)))
+        })
+        .transpose()
+        .map(Option::flatten)
+}
+
 fn actions_selector_matcher(update_actions: bool, selectors: &[String]) -> Option<Matcher> {
     update_actions.then(|| github_actions::selector_matcher(selectors)).flatten()
 }

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -224,32 +224,17 @@ impl UpdateArgs {
         }
 
         let lockfile = loaded_lockfile(&state.lockfile)?;
-
-        let packages = if self.interactive {
-            // Nothing outdated, or the user picked nothing — there is
-            // nothing to update, so don't fall through to a full update
-            // (which an empty selector list would mean).
-            match crate::cli_args::update_interactive::select_packages::<Reporter>(
-                &actions_root,
-                &state.manifest,
+        let Some(packages) = self
+            .prompted_or_given::<Reporter>(
+                &state,
                 lockfile,
-                &state.active_importer_id(),
-                state.config,
-                &state.http_client,
-                InteractiveUpdateOptions {
-                    latest: self.latest,
-                    include_direct: &include_direct,
-                    include_github_actions: update_actions,
-                    prompt: self.prompt,
-                },
+                &actions_root,
+                self.interactive_options(&include_direct, update_actions),
+                package_selectors,
             )
             .await?
-            {
-                Some(packages) => packages,
-                None => return Ok(()),
-            }
-        } else {
-            package_selectors
+        else {
+            return Ok(());
         };
 
         let selected_action_matcher = if self.interactive {
@@ -377,27 +362,18 @@ impl UpdateArgs {
         }
 
         let lockfile = loaded_lockfile(&state.lockfile)?;
-        let packages = if self.interactive {
-            match crate::cli_args::update_interactive::select_packages_for_projects::<Reporter>(
-                &actions_root,
+        let Some(packages) = self
+            .prompted_or_given_for_projects::<Reporter>(
+                &state,
                 &selection,
                 lockfile,
-                state.config,
-                &state.http_client,
-                InteractiveUpdateOptions {
-                    latest: self.latest,
-                    include_direct: &include_direct,
-                    include_github_actions: update_actions,
-                    prompt: self.prompt,
-                },
+                &actions_root,
+                self.interactive_options(&include_direct, update_actions),
+                package_selectors,
             )
             .await?
-            {
-                Some(packages) => packages,
-                None => return Ok(()),
-            }
-        } else {
-            package_selectors
+        else {
+            return Ok(());
         };
         let selected_action_matcher = if self.interactive {
             github_actions::selector_matcher(&packages)
@@ -449,6 +425,70 @@ impl UpdateArgs {
         )
         .await?;
         Ok(())
+    }
+
+    fn interactive_options<'a>(
+        &self,
+        include_direct: &'a [DependencyGroup],
+        update_actions: bool,
+    ) -> InteractiveUpdateOptions<'a> {
+        InteractiveUpdateOptions {
+            latest: self.latest,
+            include_direct,
+            include_github_actions: update_actions,
+            prompt: self.prompt,
+        }
+    }
+
+    /// The packages to update: the prompt's picks when interactive, else
+    /// the selectors given. `None` when nothing was outdated or the user
+    /// picked nothing, since an empty selector list would mean a full
+    /// update.
+    async fn prompted_or_given<Reporter: self::Reporter + 'static>(
+        &self,
+        state: &State,
+        lockfile: Option<&pnpm_lockfile::Lockfile>,
+        actions_root: &Path,
+        prompt: InteractiveUpdateOptions<'_>,
+        given: Vec<String>,
+    ) -> miette::Result<Option<Vec<String>>> {
+        if !self.interactive {
+            return Ok(Some(given));
+        }
+        crate::cli_args::update_interactive::select_packages::<Reporter>(
+            actions_root,
+            &state.manifest,
+            lockfile,
+            &state.active_importer_id(),
+            state.config,
+            &state.http_client,
+            prompt,
+        )
+        .await
+    }
+
+    /// [`Self::prompted_or_given`] over the selected projects.
+    async fn prompted_or_given_for_projects<Reporter: self::Reporter + 'static>(
+        &self,
+        state: &State,
+        selection: &InstallFamilySelection,
+        lockfile: Option<&pnpm_lockfile::Lockfile>,
+        actions_root: &Path,
+        prompt: InteractiveUpdateOptions<'_>,
+        given: Vec<String>,
+    ) -> miette::Result<Option<Vec<String>>> {
+        if !self.interactive {
+            return Ok(Some(given));
+        }
+        crate::cli_args::update_interactive::select_packages_for_projects::<Reporter>(
+            actions_root,
+            selection,
+            lockfile,
+            state.config,
+            &state.http_client,
+            prompt,
+        )
+        .await
     }
 
     /// `pnpm update -g`: reinstall each matching global package group,

--- a/pnpm/crates/cli/src/cli_args/update_changeset.rs
+++ b/pnpm/crates/cli/src/cli_args/update_changeset.rs
@@ -148,48 +148,23 @@ impl UpdateChangesetContext {
         let changeset_dir = self.workspace_dir.join(".changeset");
         ensure_changeset_dir_is_safe(&changeset_dir)?;
         let config_path = changeset_dir.join("config.json");
-        let config_text = match fs::read_to_string(&config_path) {
-            Ok(config_text) => config_text,
-            Err(source) if source.kind() == ErrorKind::NotFound => {
-                global_log::<Output>(
-                    LogLevel::Warn,
-                    format!(
-                        "No changeset was generated because {} does not exist",
-                        config_path.display(),
-                    ),
-                );
-                return Ok(());
-            }
-            Err(source) => {
-                return Err(UpdateChangesetError::ReadConfig { path: config_path, source }.into());
-            }
+        let Some(ignored) = read_ignored_matcher(&config_path)? else {
+            global_log::<Output>(
+                LogLevel::Warn,
+                format!(
+                    "No changeset was generated because {} does not exist",
+                    config_path.display(),
+                ),
+            );
+            return Ok(());
         };
-        let config: Value = serde_json::from_str(&config_text).map_err(|source| {
-            UpdateChangesetError::ParseConfig { path: config_path.clone(), source }
-        })?;
-        let ignore_patterns = config
-            .get("ignore")
-            .and_then(Value::as_array)
-            .into_iter()
-            .flatten()
-            .filter_map(Value::as_str)
-            .map(str::to_string)
-            .collect::<Vec<_>>();
-        let ignored = create_matcher(&ignore_patterns);
 
         let workspace_manifest = read_workspace_manifest(&self.workspace_dir)
             .map_err(UpdateChangesetError::ReadWorkspace)?;
         let catalogs_after = get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())?;
         let changed_catalog_entries =
             find_changed_catalog_entries(&self.catalogs_before, &catalogs_after);
-        let mut releases = BTreeMap::new();
-        for root_dir in &self.root_dirs {
-            if let Some((package_name, bump)) =
-                self.project_release(root_dir, &ignored, &changed_catalog_entries)?
-            {
-                releases.insert(package_name, bump);
-            }
-        }
+        let releases = self.collect_releases(&ignored, &changed_catalog_entries)?;
         if releases.is_empty() {
             global_log::<Output>(
                 LogLevel::Info,
@@ -215,6 +190,22 @@ impl UpdateChangesetContext {
             ),
         );
         Ok(())
+    }
+
+    fn collect_releases(
+        &self,
+        ignored: &Matcher,
+        changed_catalog_entries: &BTreeMap<String, BTreeSet<String>>,
+    ) -> Result<BTreeMap<String, IntentBumpType>, UpdateChangesetError> {
+        let mut releases = BTreeMap::new();
+        for root_dir in &self.root_dirs {
+            if let Some((package_name, bump)) =
+                self.project_release(root_dir, ignored, changed_catalog_entries)?
+            {
+                releases.insert(package_name, bump);
+            }
+        }
+        Ok(releases)
     }
     /// The bump a project needs, when the update changed a dependency its
     /// consumers can observe. A private or ignored package never releases.
@@ -259,6 +250,33 @@ impl UpdateChangesetContext {
         Ok(production_dependencies_changed
             .then(|| (package_name.to_string(), IntentBumpType::Patch)))
     }
+}
+
+/// The matcher over the changeset config's `ignore` list, or `None` when
+/// there is no config file.
+fn read_ignored_matcher(config_path: &Path) -> Result<Option<Matcher>, UpdateChangesetError> {
+    let config_text = match fs::read_to_string(config_path) {
+        Ok(config_text) => config_text,
+        Err(source) if source.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(source) => {
+            return Err(UpdateChangesetError::ReadConfig {
+                path: config_path.to_path_buf(),
+                source,
+            });
+        }
+    };
+    let config: Value = serde_json::from_str(&config_text).map_err(|source| {
+        UpdateChangesetError::ParseConfig { path: config_path.to_path_buf(), source }
+    })?;
+    let ignore_patterns = config
+        .get("ignore")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    Ok(Some(create_matcher(&ignore_patterns)))
 }
 
 /// Write `content` to a changeset file under a freshly generated id,

--- a/pnpm/crates/cli/src/cli_args/version.rs
+++ b/pnpm/crates/cli/src/cli_args/version.rs
@@ -396,17 +396,7 @@ impl VersionArgs {
         let engine_projects = to_engine_projects(&projects);
         let published_names = changelog::published_names(&projects);
 
-        let filter = if config.filter.is_empty() {
-            None
-        } else {
-            Some(
-                selected_projects(&projects, config, &workspace_dir)?
-                    .into_iter()
-                    .map(|(_, dir)| dir)
-                    .collect::<HashSet<String>>(),
-            )
-        };
-        let is_filtered = filter.is_some();
+        let filter = filtered_project_dirs(&projects, config, &workspace_dir)?;
         let assemble = |unpublished_dirs: HashSet<String>| {
             assemble_release_plan(
                 &engine_projects,
@@ -433,7 +423,7 @@ impl VersionArgs {
             // consumed them. A filtered run must not — "nothing pending in
             // this scope" is no reason to delete prose belonging to packages
             // outside the filter.
-            if !self.dry_run && !is_filtered {
+            if !self.dry_run && filter.is_none() {
                 let confirmed =
                     confirmed_published_versions(config, &workspace_dir, &published_names).await?;
                 apply_release_plan(
@@ -497,6 +487,23 @@ impl VersionArgs {
         }
         println!("{output}");
     }
+}
+
+/// The project dirs `--filter` selects, or `None` for an unfiltered run.
+fn filtered_project_dirs(
+    projects: &[pnpm_workspace::Project],
+    config: &Config,
+    workspace_dir: &Path,
+) -> miette::Result<Option<HashSet<String>>> {
+    if config.filter.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(
+        selected_projects(projects, config, workspace_dir)?
+            .into_iter()
+            .map(|(_, dir)| dir)
+            .collect::<HashSet<String>>(),
+    ))
 }
 
 /// Run one `preversion` / `version` / `postversion` script of the bumped

--- a/pnpm/crates/cli/src/cli_args/view.rs
+++ b/pnpm/crates/cli/src/cli_args/view.rs
@@ -225,15 +225,7 @@ pub(super) async fn fetch_package_metadata(
 /// fragment is reused so registry key order is preserved in `--json` output,
 /// and the extra fields are appended in place.
 fn assemble_info(meta: &pnpm_registry::Package, picked: &pnpm_registry::PackageVersion) -> Value {
-    let version_key = picked.version.to_string();
-    let data = meta
-        .versions
-        .fragments()
-        .find(|(version, _)| version.as_str() == version_key)
-        .and_then(|(_, json)| serde_json::from_str::<Value>(&json).ok())
-        .unwrap_or_else(|| serde_json::to_value(picked).unwrap_or(Value::Null));
-
-    let mut info = match data {
+    let mut info = match version_data(meta, picked) {
         Value::Object(map) => map,
         _ => Map::new(),
     };
@@ -270,6 +262,16 @@ fn assemble_info(meta: &pnpm_registry::Package, picked: &pnpm_registry::PackageV
     }
 
     Value::Object(info)
+}
+
+/// The picked version's own packument fragment, else the version as parsed.
+fn version_data(meta: &pnpm_registry::Package, picked: &pnpm_registry::PackageVersion) -> Value {
+    let version_key = picked.version.to_string();
+    meta.versions
+        .fragments()
+        .find(|(version, _)| version.as_str() == version_key)
+        .and_then(|(_, json)| serde_json::from_str::<Value>(&json).ok())
+        .unwrap_or_else(|| serde_json::to_value(picked).unwrap_or(Value::Null))
 }
 
 /// Map a metadata-fetch failure to the matching pnpm error. A `404`

--- a/pnpm/crates/cli/src/cli_args/why.rs
+++ b/pnpm/crates/cli/src/cli_args/why.rs
@@ -15,12 +15,15 @@ use crate::{
     cli_args::{
         deps_tree::{
             build::{LoadedState, importer_root_ids, read_project_manifest, safe_importer_dir},
-            dependents::{BuildDependentsOptions, ImporterInfo, build_dependents_tree},
+            dependents::{
+                BuildDependentsOptions, DependentsTree, ImporterInfo, build_dependents_tree,
+            },
             dependents_render::{
                 RenderDependentsOptions, render_dependents_json, render_dependents_parseable,
                 render_dependents_tree,
             },
-            graph::{BuildGraphOptions, build_dependency_graph},
+            graph::{BuildGraphOptions, DependencyGraph, build_dependency_graph},
+            pkg_info::PkgInfoEnv,
             search::Searcher,
         },
         deps_tree_finders::{evaluate_finders, finder_candidates, resolve_finders},
@@ -89,14 +92,16 @@ impl WhyArgs {
             ));
         }
         let lockfile_dir = state.lockfile_dir().to_path_buf();
-        let project_dir = state
-            .manifest
-            .path()
-            .parent()
-            .expect("manifest path always has a parent dir")
-            .to_path_buf();
-
-        let project_dirs = why_project_dirs(state.config, &lockfile_dir, project_dir)?;
+        let project_dirs = why_project_dirs(
+            state.config,
+            &lockfile_dir,
+            state
+                .manifest
+                .path()
+                .parent()
+                .expect("manifest path always has a parent dir")
+                .to_path_buf(),
+        )?;
 
         let loaded =
             LoadedState::load(&lockfile_dir, Some(state.config.modules_dir.as_path()), false)?;
@@ -112,18 +117,7 @@ impl WhyArgs {
 
         let importer_info = collect_importer_info(lockfile, &lockfile_dir);
 
-        let include = {
-            let has_both = self.production == self.dev;
-            IncludedDependencies {
-                dependencies: has_both || self.production,
-                dev_dependencies: has_both || self.dev,
-                optional_dependencies: resolve_bool_override(
-                    self.optional,
-                    self.no_optional,
-                    state.config.optional,
-                ),
-            }
-        };
+        let include = self.included_dependencies(state.config);
 
         let root_ids = importer_root_ids(lockfile, &lockfile_dir, &project_dirs);
         let graph = build_dependency_graph(
@@ -131,13 +125,7 @@ impl WhyArgs {
             &BuildGraphOptions { lockfile, include, only_projects: false },
         );
 
-        let mut searcher = Searcher::from_queries(&self.packages)?;
-        if !self.find_by.is_empty() {
-            let finders = resolve_finders(state.config, &lockfile_dir, &self.find_by).await?;
-            let candidates = finder_candidates(&env, &graph);
-            let results = evaluate_finders(&env, &finders, candidates).await?;
-            searcher.set_finder_results(results);
-        }
+        let searcher = self.searcher(&env, &graph, state.config, &lockfile_dir).await?;
 
         let trees = build_dependents_tree(&BuildDependentsOptions {
             env: &env,
@@ -147,16 +135,50 @@ impl WhyArgs {
             manifest_fields: &[],
         });
 
-        let render_opts = RenderDependentsOptions { long: self.long, depth: self.depth };
-        let output = if self.parseable {
-            render_dependents_parseable(&trees, &render_opts)
-        } else if self.json {
-            render_dependents_json(&trees, &render_opts)
-        } else {
-            render_dependents_tree(&trees, &render_opts)
-        };
-        print_output(&output);
+        print_output(&self.render(&trees));
         Ok(())
+    }
+
+    fn included_dependencies(&self, config: &Config) -> IncludedDependencies {
+        let has_both = self.production == self.dev;
+        IncludedDependencies {
+            dependencies: has_both || self.production,
+            dev_dependencies: has_both || self.dev,
+            optional_dependencies: resolve_bool_override(
+                self.optional,
+                self.no_optional,
+                config.optional,
+            ),
+        }
+    }
+
+    /// The package queries, with the `--find-by` finders' matches folded in.
+    async fn searcher(
+        &self,
+        env: &PkgInfoEnv<'_>,
+        graph: &DependencyGraph,
+        config: &Config,
+        lockfile_dir: &Path,
+    ) -> miette::Result<Searcher> {
+        let mut searcher = Searcher::from_queries(&self.packages)?;
+        if !self.find_by.is_empty() {
+            let finders = resolve_finders(config, lockfile_dir, &self.find_by).await?;
+            let candidates = finder_candidates(env, graph);
+            let results = evaluate_finders(env, &finders, candidates).await?;
+            searcher.set_finder_results(results);
+        }
+        Ok(searcher)
+    }
+
+    fn render(&self, trees: &[DependentsTree]) -> String {
+        let render_opts = RenderDependentsOptions { long: self.long, depth: self.depth };
+        if self.parseable {
+            render_dependents_parseable(trees, &render_opts)
+        } else if self.json {
+            render_dependents_json(trees, &render_opts)
+        } else {
+            render_dependents_tree(trees, &render_opts)
+        }
     }
 }
 

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -169,6 +169,44 @@ pub async fn resolve_engine_version(
 ) -> Result<Option<ResolvedEngine>> {
     let context = EnvInstallerContext::for_package_manager(config)?;
 
+    let wanted = WantedDependency {
+        alias: Some(package.to_string()),
+        bare_specifier: Some(bare_specifier.to_string()),
+        ..WantedDependency::default()
+    };
+    let opts = engine_resolve_options(config)?;
+    let result = context
+        .resolver
+        .resolve(&wanted, &opts)
+        .await
+        .map_err(|error| miette::miette!("{error}"))
+        .wrap_err_with(|| format!("resolve {package}@{bare_specifier}"))?;
+    let Some(result) = result else {
+        return Ok(None);
+    };
+    let Some(name_ver) = result.name_ver else {
+        return Ok(None);
+    };
+    // Fail closed if the specifier resolved to a different package (e.g. an
+    // `npm:other-pkg@x` alias): otherwise the maturity/trust policy decision
+    // would be made against the wrong package's metadata while the caller
+    // still installs `<package>@<version>`.
+    if name_ver.name.to_string() != package {
+        return Ok(None);
+    }
+    Ok(Some(ResolvedEngine {
+        version: name_ver.suffix.to_string(),
+        manifest: result.manifest.clone(),
+        policy_violation: result.policy_violation.map(|violation| EnginePolicyViolation {
+            code: violation.code,
+            reason: violation.reason,
+        }),
+    }))
+}
+
+/// The resolve options carrying the maturity and trust policies of the
+/// install path.
+fn engine_resolve_options(config: &Config) -> Result<ResolveOptions> {
     // `minimumReleaseAge` cutoff, computed the same way as the install
     // path's `PickPolicy::from_config`. When the age is configured, a
     // failure to compute the cutoff fails closed rather than silently
@@ -212,12 +250,7 @@ pub async fn resolve_engine_version(
         .into_diagnostic()
         .wrap_err("compile the trust-policy-exclude policy")?;
 
-    let wanted = WantedDependency {
-        alias: Some(package.to_string()),
-        bare_specifier: Some(bare_specifier.to_string()),
-        ..WantedDependency::default()
-    };
-    let opts = ResolveOptions {
+    Ok(ResolveOptions {
         default_tag: Some("latest".to_string()),
         published_by,
         published_by_exclude,
@@ -225,34 +258,7 @@ pub async fn resolve_engine_version(
         trust_policy_exclude,
         trust_policy_ignore_after: config.trust_policy_ignore_after,
         ..ResolveOptions::default()
-    };
-    let result = context
-        .resolver
-        .resolve(&wanted, &opts)
-        .await
-        .map_err(|error| miette::miette!("{error}"))
-        .wrap_err_with(|| format!("resolve {package}@{bare_specifier}"))?;
-    let Some(result) = result else {
-        return Ok(None);
-    };
-    let Some(name_ver) = result.name_ver else {
-        return Ok(None);
-    };
-    // Fail closed if the specifier resolved to a different package (e.g. an
-    // `npm:other-pkg@x` alias): otherwise the maturity/trust policy decision
-    // would be made against the wrong package's metadata while the caller
-    // still installs `<package>@<version>`.
-    if name_ver.name.to_string() != package {
-        return Ok(None);
-    }
-    Ok(Some(ResolvedEngine {
-        version: name_ver.suffix.to_string(),
-        manifest: result.manifest.clone(),
-        policy_violation: result.policy_violation.map(|violation| EnginePolicyViolation {
-            code: violation.code,
-            reason: violation.reason,
-        }),
-    }))
+    })
 }
 
 /// Add config dependencies: resolve + install them (merged with any
@@ -526,22 +532,11 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
         return Ok(hooks);
     }
 
-    let base_dir = match WorkspaceSettings::find_and_load(root_dir).into_diagnostic()? {
-        Some((path, _)) => path.parent().map_or_else(|| root_dir.to_path_buf(), Path::to_path_buf),
-        None => root_dir.to_path_buf(),
-    };
+    let base_dir = hook_base_dir(root_dir)?;
     let mut input = serde_json::to_value(WorkspaceSettings::from_resolved(config))
         .into_diagnostic()
         .wrap_err("serialize the resolved settings for updateConfig hooks")?;
-    // Seed the hook input with the catalogs read from the workspace
-    // manifest (`catalog:` + `catalogs:`), which `WorkspaceSettings`
-    // doesn't carry, so a hook can read and extend them.
-    let workspace_manifest = pnpm_workspace::read_workspace_manifest(root_dir).into_diagnostic()?;
-    let yaml_catalogs = get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
-        .into_diagnostic()
-        .wrap_err("reading catalogs for updateConfig hooks")?;
-    let catalogs = serde_json::to_value(&yaml_catalogs).into_diagnostic()?;
-    seed_hook_input(&mut input, config, root_dir, &pnpmfiles, catalogs)?;
+    seed_hook_input(&mut input, config, root_dir, &pnpmfiles, manifest_catalogs_value(root_dir)?)?;
 
     let prefix = root_dir.to_string_lossy().into_owned();
     let mut current = input.clone();
@@ -586,6 +581,26 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
 
     apply_hook_delta(config, &input, &current, &base_dir)?;
     Ok(hooks)
+}
+
+/// The directory relative hook-output paths resolve against: the workspace
+/// manifest's, else the root.
+fn hook_base_dir(root_dir: &Path) -> Result<PathBuf> {
+    Ok(match WorkspaceSettings::find_and_load(root_dir).into_diagnostic()? {
+        Some((path, _)) => path.parent().map_or_else(|| root_dir.to_path_buf(), Path::to_path_buf),
+        None => root_dir.to_path_buf(),
+    })
+}
+
+/// The catalogs read from the workspace manifest (`catalog:` +
+/// `catalogs:`), which `WorkspaceSettings` doesn't carry, seeded into the
+/// hook input so a hook can read and extend them.
+fn manifest_catalogs_value(root_dir: &Path) -> Result<Value> {
+    let workspace_manifest = pnpm_workspace::read_workspace_manifest(root_dir).into_diagnostic()?;
+    let yaml_catalogs = get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
+        .into_diagnostic()
+        .wrap_err("reading catalogs for updateConfig hooks")?;
+    serde_json::to_value(&yaml_catalogs).into_diagnostic()
 }
 
 /// Seed the hook input with the values pnpm resolves outside

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -240,12 +240,11 @@ impl ConfigOverrides {
         let argv = argv.into_iter().collect::<Vec<_>>();
         let passthrough_from = crate::parse_boundary::passthrough_from(&argv);
         let claimed_by_command = crate::parse_boundary::subcommand_option_names(&argv);
-        let is_forwarded = |index: usize| passthrough_from.is_some_and(|from| index >= from);
         let mut overrides = Self::default();
         let mut remaining = Vec::new();
         let mut argv = argv.into_iter().enumerate().peekable();
         while let Some((index, arg)) = argv.next() {
-            if is_forwarded(index) {
+            if is_forwarded(passthrough_from, index) {
                 remaining.push(arg);
                 continue;
             }
@@ -257,7 +256,7 @@ impl ConfigOverrides {
             let mut following = |key: &str| {
                 let value = argv
                     .peek()
-                    .filter(|&&(index, _)| !is_forwarded(index))
+                    .filter(|&&(index, _)| !is_forwarded(passthrough_from, index))
                     .and_then(|(_, token)| token.to_str())
                     .filter(|token| claims_as_value(key, token))
                     .map(str::to_owned)?;
@@ -715,6 +714,11 @@ impl ConfigOverrides {
             global_virtual_store_dir_explicit,
         );
     }
+}
+
+/// Whether the token at `index` belongs to the forwarded child command line.
+fn is_forwarded(passthrough_from: Option<usize>, index: usize) -> bool {
+    passthrough_from.is_some_and(|from| index >= from)
 }
 
 /// Presence-only, like pnpm's `!= null` check: an empty value still

--- a/pnpm/crates/cli/src/github_actions.rs
+++ b/pnpm/crates/cli/src/github_actions.rs
@@ -208,7 +208,25 @@ async fn create_plan<Reporter: self::Reporter, Runner: GitCommandRunner + Sync>(
         })
         .collect::<Vec<_>>();
     let repos = actions.iter().map(|action| action.repo.clone()).collect::<BTreeSet<_>>();
-    let refs_by_repo = stream::iter(repos)
+    let refs_by_repo = versions_by_repo::<Reporter, Runner>(repos, server_url, runner).await;
+    let mut plans = Vec::new();
+    for action in actions {
+        let Some(versions) = refs_by_repo.get(&action.repo) else { continue };
+        if let Some(plan) = plan_action_update(action, versions)? {
+            plans.push(plan);
+        }
+    }
+    Ok(plans)
+}
+
+/// Each repository's tagged versions, skipping (with a warning) the ones
+/// whose refs cannot be listed.
+async fn versions_by_repo<Reporter: self::Reporter, Runner: GitCommandRunner + Sync>(
+    repos: BTreeSet<String>,
+    server_url: &str,
+    runner: &Runner,
+) -> HashMap<String, Vec<RepoVersion>> {
+    stream::iter(repos)
         .map(|repo| async move {
             let url = format!("{server_url}/{repo}.git");
             match get_repo_refs(runner, &url, None).await {
@@ -230,38 +248,40 @@ async fn create_plan<Reporter: self::Reporter, Runner: GitCommandRunner + Sync>(
         .buffer_unordered(GIT_CONCURRENCY)
         .filter_map(|entry| async move { entry })
         .collect::<HashMap<_, _>>()
-        .await;
-    let mut plans = Vec::new();
-    for action in actions {
-        let Some(versions) = refs_by_repo.get(&action.repo) else { continue };
-        let Some(current) = find_current(&action, versions) else { continue };
-        let wanted_range =
-            SemverRange::parse(format!("^{}", current.version)).map_err(|error| {
-                miette::miette!(
-                    "Failed to create a compatible GitHub Action range for {}: {error}",
-                    current.version,
-                )
-            })?;
-        let candidates = versions
-            .iter()
-            .filter(|candidate| {
-                !current.version.pre_release.is_empty() || candidate.version.pre_release.is_empty()
-            })
-            .collect::<Vec<_>>();
-        let Some(latest) = candidates.last() else { continue };
-        let Some(wanted) =
-            candidates.iter().rev().find(|candidate| wanted_range.satisfies(&candidate.version))
-        else {
-            continue;
-        };
-        plans.push(PlannedUpdate {
-            action,
-            current,
-            latest: (*latest).clone(),
-            wanted: (*wanted).clone(),
-        });
-    }
-    Ok(plans)
+        .await
+}
+
+/// The update for one action reference: its current version, the newest
+/// compatible one and the latest, or `None` when they cannot be told.
+fn plan_action_update(
+    action: ActionReference,
+    versions: &[RepoVersion],
+) -> miette::Result<Option<PlannedUpdate>> {
+    let Some(current) = find_current(&action, versions) else { return Ok(None) };
+    let wanted_range = SemverRange::parse(format!("^{}", current.version)).map_err(|error| {
+        miette::miette!(
+            "Failed to create a compatible GitHub Action range for {}: {error}",
+            current.version,
+        )
+    })?;
+    let candidates = versions
+        .iter()
+        .filter(|candidate| {
+            !current.version.pre_release.is_empty() || candidate.version.pre_release.is_empty()
+        })
+        .collect::<Vec<_>>();
+    let Some(latest) = candidates.last() else { return Ok(None) };
+    let Some(wanted) =
+        candidates.iter().rev().find(|candidate| wanted_range.satisfies(&candidate.version))
+    else {
+        return Ok(None);
+    };
+    Ok(Some(PlannedUpdate {
+        action,
+        current,
+        latest: (*latest).clone(),
+        wanted: (*wanted).clone(),
+    }))
 }
 
 async fn discover(root: &Path) -> miette::Result<Vec<ActionReference>> {
@@ -445,46 +465,61 @@ struct UsesValue<'a> {
 }
 
 fn uses_values(text: &str) -> Result<Vec<UsesValue<'_>>, QueryError> {
-    let value = yaml_serde::from_str::<Value>(text).map_err(|err| {
-        let (line, column) = err.location().map_or((0, 0), |loc| (loc.line(), loc.column()));
-        QueryError::InvalidInput(line, column)
-    })?;
+    let value = parse_workflow(text)?;
     let document = Document::new(text)?;
     let mut values = Vec::new();
     for route in uses_routes(&value) {
-        let Some(feature) = document.query_exact(&route)? else {
-            continue;
-        };
-        let key = document.query_key_only(&route)?;
-        let (start, scalar_end) = feature.location.byte_span;
-        let separator = start
-            .checked_sub(key.location.byte_span.1)
-            .map(|_| &text[key.location.byte_span.1..start]);
-        if separator.is_none_or(|separator| {
-            !separator.starts_with(':') || !separator[1..].chars().all(char::is_whitespace)
-        }) {
-            continue;
+        if let Some(uses) = uses_value_at(text, &document, &route)? {
+            values.push(uses);
         }
-        let line_end = text[scalar_end..].find('\n').map_or(text.len(), |end| scalar_end + end);
-        let trailing = &text[scalar_end..line_end];
-        let following = trailing.trim_start();
-        let flow_style = matches!(following.chars().next(), Some('}' | ']' | ','));
-        let end = if following.starts_with('#') {
-            scalar_end + trailing.trim_end().len()
-        } else if flow_style {
-            scalar_end + trailing.len() - following.len()
-        } else {
-            scalar_end
-        };
-        let line_start = text[..start].rfind('\n').map_or(0, |line_break| line_break + 1);
-        values.push(UsesValue {
-            flow_style,
-            indentation: " ".repeat(start - line_start),
-            range: start..end,
-            value: &text[start..end],
-        });
     }
     Ok(values)
+}
+
+fn parse_workflow(text: &str) -> Result<Value, QueryError> {
+    yaml_serde::from_str::<Value>(text).map_err(|err| {
+        let (line, column) = err.location().map_or((0, 0), |loc| (loc.line(), loc.column()));
+        QueryError::InvalidInput(line, column)
+    })
+}
+
+/// The `uses:` scalar at `route` with its byte range in `text`, or `None`
+/// when the route names no plain `key: value` scalar.
+fn uses_value_at<'text>(
+    text: &'text str,
+    document: &Document,
+    route: &Route<'_>,
+) -> Result<Option<UsesValue<'text>>, QueryError> {
+    let Some(feature) = document.query_exact(route)? else {
+        return Ok(None);
+    };
+    let key = document.query_key_only(route)?;
+    let (start, scalar_end) = feature.location.byte_span;
+    let separator =
+        start.checked_sub(key.location.byte_span.1).map(|_| &text[key.location.byte_span.1..start]);
+    if separator.is_none_or(|separator| {
+        !separator.starts_with(':') || !separator[1..].chars().all(char::is_whitespace)
+    }) {
+        return Ok(None);
+    }
+    let line_end = text[scalar_end..].find('\n').map_or(text.len(), |end| scalar_end + end);
+    let trailing = &text[scalar_end..line_end];
+    let following = trailing.trim_start();
+    let flow_style = matches!(following.chars().next(), Some('}' | ']' | ','));
+    let end = if following.starts_with('#') {
+        scalar_end + trailing.trim_end().len()
+    } else if flow_style {
+        scalar_end + trailing.len() - following.len()
+    } else {
+        scalar_end
+    };
+    let line_start = text[..start].rfind('\n').map_or(0, |line_break| line_break + 1);
+    Ok(Some(UsesValue {
+        flow_style,
+        indentation: " ".repeat(start - line_start),
+        range: start..end,
+        value: &text[start..end],
+    }))
 }
 
 fn uses_routes(value: &Value) -> Vec<Route<'static>> {

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -141,11 +141,7 @@ fn run_cli() -> miette::Result<()> {
     // A command whose arguments begin at a `--` would otherwise lose it to
     // clap's escape handling. See `leading_separator`.
     let argv = leading_separator::preserve_leading_separator(argv);
-    let mut args = match command.try_get_matches_from(argv.clone()).and_then(|matches| {
-        let dir_from_command_line =
-            matches.value_source("dir") == Some(clap::parser::ValueSource::CommandLine);
-        CliArgs::from_arg_matches(&matches).map(|args| CliArgs { dir_from_command_line, ..args })
-    }) {
+    let mut args = match parse_cli_args(command, argv.clone()) {
         Ok(args) => args,
         Err(err) if err.kind() == clap::error::ErrorKind::DisplayVersion => {
             return print_version(&argv, &child_argv, &config_overrides);
@@ -190,6 +186,15 @@ fn run_cli() -> miette::Result<()> {
         job_guard.disarm();
     }
     result
+}
+
+/// Parse argv, recording whether `--dir` came from the command line.
+fn parse_cli_args(command: clap::Command, argv: Vec<OsString>) -> Result<CliArgs, clap::Error> {
+    command.try_get_matches_from(argv).and_then(|matches| {
+        let dir_from_command_line =
+            matches.value_source("dir") == Some(clap::parser::ValueSource::CommandLine);
+        CliArgs::from_arg_matches(&matches).map(|args| CliArgs { dir_from_command_line, ..args })
+    })
 }
 
 /// pnpm prints the bare version, not clap's `pnpm <version>` rendering —

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -1,3 +1,7 @@
+// A command's install future carries the engine's whole resolve-and-fetch
+// graph; proving it `Send` walks deeper than rustc's default limit.
+#![recursion_limit = "256"]
+
 mod boolean_negations;
 mod boolean_values;
 mod cargo_deps;

--- a/pnpm/crates/cli/src/python.rs
+++ b/pnpm/crates/cli/src/python.rs
@@ -158,14 +158,7 @@ async fn prepare<Reporter: self::Reporter + 'static>(
         resolve,
         selection,
     };
-    let result = async {
-        let mut prepared = Vec::new();
-        for (root, manifest) in roots {
-            prepared.push(prepare.project::<Reporter>(root, manifest).await?);
-        }
-        Ok(prepared)
-    }
-    .await;
+    let result = prepare_projects::<Reporter>(&prepare, roots).await;
     drop(writer);
     writer_task
         .await
@@ -174,6 +167,17 @@ async fn prepare<Reporter: self::Reporter + 'static>(
         .into_diagnostic()
         .wrap_err("flush Python artifact store index")?;
     result
+}
+
+async fn prepare_projects<Reporter: self::Reporter + 'static>(
+    prepare: &PythonPrepare<'_>,
+    roots: Vec<(PathBuf, manifest::Manifest)>,
+) -> Result<Vec<Prepared>> {
+    let mut prepared = Vec::new();
+    for (root, manifest) in roots {
+        prepared.push(prepare.project::<Reporter>(root, manifest).await?);
+    }
+    Ok(prepared)
 }
 
 /// The projects among `manifests`: a `pyproject.toml` without a

--- a/pnpm/crates/cli/src/shim_dispatch/identity.rs
+++ b/pnpm/crates/cli/src/shim_dispatch/identity.rs
@@ -46,19 +46,7 @@ pub(super) fn local_bin_identity(bin: &Path, name: &str) -> Option<LocalBinIdent
         let hash = create_hex_hash(&format!("symlink\0{}", target.display()));
         (target, hash)
     } else {
-        let script = bin.parent()?.join(name);
-        let content = std::fs::read_to_string(&script).ok()?;
-        let target = read_shim_target_from_content(&content)?;
-        // The executed flavor can differ from the trailer-carrying sh
-        // flavor (`tool.cmd` vs `tool` on Windows), so the fingerprint
-        // binds both: replacing either file invalidates an approval.
-        let executed_hash = if script == bin {
-            String::new()
-        } else {
-            let executed_len = std::fs::metadata(bin).ok()?.len();
-            small_file_hash(bin, executed_len)?
-        };
-        (target, create_hex_hash(&format!("script\0{content}\0{executed_hash}")))
+        shim_target_and_hash(bin, name)?
     };
     let resolved = if target.is_absolute() { target } else { bin.parent()?.join(target) };
     let provider = provider_of_target(&resolved)?;
@@ -74,6 +62,23 @@ pub(super) fn local_bin_identity(bin: &Path, name: &str) -> Option<LocalBinIdent
         target_stat,
     ));
     Some(LocalBinIdentity { provider, fingerprint })
+}
+
+/// The target a shim script names, and the fingerprint of the script. The
+/// executed flavor can differ from the trailer-carrying sh flavor
+/// (`tool.cmd` vs `tool` on Windows), so the fingerprint binds both:
+/// replacing either file invalidates an approval.
+fn shim_target_and_hash(bin: &Path, name: &str) -> Option<(PathBuf, String)> {
+    let script = bin.parent()?.join(name);
+    let content = std::fs::read_to_string(&script).ok()?;
+    let target = read_shim_target_from_content(&content)?;
+    let executed_hash = if script == bin {
+        String::new()
+    } else {
+        let executed_len = std::fs::metadata(bin).ok()?.len();
+        small_file_hash(bin, executed_len)?
+    };
+    Some((target, create_hex_hash(&format!("script\0{content}\0{executed_hash}"))))
 }
 
 pub(super) fn project_lockfile_hash(path: &Path) -> String {

--- a/pnpm/crates/cmd-shim/src/link_bins.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins.rs
@@ -659,21 +659,13 @@ fn write_shim<Sys>(spec: ShimSpec<'_>, cache: &ShimTargetCache) -> Result<(), Li
 where
     Sys: FsReadToString + FsReadHead + FsWrite + FsSetExecutable + FsEnsureExecutableBits,
 {
-    let ShimSpec {
-        target_path,
-        probe_path,
-        shim_path,
-        node_path,
-        prefer_symlinked_executables,
-        make_powershell_shim,
-    } = spec;
     // Not writing a `.ps1` is not enough to keep one out of the bin
     // dir: an install that did want one leaves it there, and
     // PowerShell keeps preferring it over the `.cmd` sibling. Delete
     // it up front, above the short-circuits below — they all return
     // without touching the Windows siblings.
-    if !make_powershell_shim {
-        remove_stale_bin(&with_extension_appended(shim_path, "ps1"))?;
+    if !spec.make_powershell_shim {
+        remove_stale_bin(&with_extension_appended(spec.shim_path, "ps1"))?;
     }
 
     let existing_shim = match read_or_create_shim::<Sys>(&spec, cache)? {
@@ -688,8 +680,8 @@ where
     // carry the setting (the injected-deps syncer's workspace-wide
     // relink, for one) leaves symlinked bins alone instead of
     // rewriting them into shims.
-    if symlink_already_points_at(shim_path, target_path) {
-        return cache.ensure_target_executable_once::<Sys>(probe_path);
+    if symlink_already_points_at(spec.shim_path, spec.target_path) {
+        return cache.ensure_target_executable_once::<Sys>(spec.probe_path);
     }
 
     // The node runtime binary is special: never wrap it in a shell
@@ -711,7 +703,7 @@ where
     //    (`$basedir/../node/bin/../node/bin/node` — the `node` segment
     //    appears twice). A direct symlink / hardlink bypasses the
     //    parser entirely.
-    if is_node_bin_name(shim_path) && link_node_bin(target_path, shim_path)? {
+    if is_node_bin_name(spec.shim_path) && link_node_bin(spec.target_path, spec.shim_path)? {
         return Ok(());
     }
 
@@ -720,25 +712,28 @@ where
     // half returns `false` so bins keep their shims there, like pnpm.
     // Stays below the node-runtime special case, which links `node`
     // regardless of the setting.
-    if prefer_symlinked_executables && link_symlinked_executable::<Sys>(target_path, shim_path)? {
+    if spec.prefer_symlinked_executables
+        && link_symlinked_executable::<Sys>(spec.target_path, spec.shim_path)?
+    {
         return Ok(());
     }
 
-    let runtime = cache.runtime_for::<Sys>(probe_path).map_err(|error| {
-        LinkBinsError::ProbeShimSource { path: probe_path.to_path_buf(), error }
+    let runtime = cache.runtime_for::<Sys>(spec.probe_path).map_err(|error| {
+        LinkBinsError::ProbeShimSource { path: spec.probe_path.to_path_buf(), error }
     })?;
 
-    let sh_body = generate_sh_shim(target_path, shim_path, runtime.as_ref(), node_path);
+    let sh_body =
+        generate_sh_shim(spec.target_path, spec.shim_path, runtime.as_ref(), spec.node_path);
     let windows_shims = windows_shim_bodies(&spec, runtime.as_ref());
 
     let current = shim_body_matches(existing_shim.as_deref(), &sh_body, &spec)
         && windows_shims_match::<Sys>(windows_shims.as_ref());
     if !current {
-        replace_shims::<Sys>(shim_path, &sh_body, windows_shims.as_ref())?;
+        replace_shims::<Sys>(spec.shim_path, &sh_body, windows_shims.as_ref())?;
     }
 
-    chmod_tolerating_removal(shim_path, Sys::set_executable)?;
-    cache.ensure_target_executable_once::<Sys>(probe_path)?;
+    chmod_tolerating_removal(spec.shim_path, Sys::set_executable)?;
+    cache.ensure_target_executable_once::<Sys>(spec.probe_path)?;
 
     Ok(())
 }

--- a/pnpm/crates/cmd-shim/src/shim.rs
+++ b/pnpm/crates/cmd-shim/src/shim.rs
@@ -417,25 +417,12 @@ pub fn generate_pwsh_shim(
     runtime: Option<&ScriptRuntime>,
     node_path: &[String],
 ) -> String {
-    let sh_target = relative_target(target_path, shim_path);
-    let quoted_target = if Path::new(&sh_target).is_absolute() {
-        format!(r#""{sh_target}""#)
-    } else {
-        format!(r#""$basedir/{sh_target}""#)
-    };
+    let quoted_target = quoted_pwsh_target(target_path, shim_path);
 
     use std::fmt::Write;
-    let NodePathEnvVar { win32: win32_node_path, posix: posix_node_path } =
-        normalize_node_path_env_var(node_path);
-    let has_node_path = !win32_node_path.is_empty();
-    let mut pwsh = if has_node_path {
-        format!(
-            "#!/usr/bin/env pwsh\n$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent\n\n$exe=\"\"\n$pathsep=\":\"\n$env_node_path=$env:NODE_PATH\n$new_node_path=\"{win32_node_path}\"\nif ($PSVersionTable.PSVersion -lt \"6.0\" -or $IsWindows) {{\n  # Fix case when both the Windows and Linux builds of Node\n  # are installed in the same directory\n  $exe=\".exe\"\n  $pathsep=\";\"\n}} else {{\n  $new_node_path=\"{posix_node_path}\"\n}}\nif ([string]::IsNullOrEmpty($env_node_path)) {{\n  $env:NODE_PATH=$new_node_path\n}} else {{\n  $env:NODE_PATH=\"$new_node_path$pathsep$env_node_path\"\n}}",
-        )
-    } else {
-        String::from(PWSH_SHIM_HEADER)
-    };
-    let restore_node_path = has_node_path.then_some("$env:NODE_PATH=$env_node_path");
+    let node_path_header = pwsh_node_path_header(node_path);
+    let restore_node_path = node_path_header.is_some().then_some("$env:NODE_PATH=$env_node_path");
+    let mut pwsh = node_path_header.unwrap_or_else(|| String::from(PWSH_SHIM_HEADER));
 
     match runtime {
         Some(ScriptRuntime { prog: Some(prog), args }) => {
@@ -482,6 +469,27 @@ pub fn generate_pwsh_shim(
     }
 
     pwsh
+}
+
+fn quoted_pwsh_target(target_path: &Path, shim_path: &Path) -> String {
+    let sh_target = relative_target(target_path, shim_path);
+    if Path::new(&sh_target).is_absolute() {
+        format!(r#""{sh_target}""#)
+    } else {
+        format!(r#""$basedir/{sh_target}""#)
+    }
+}
+
+/// The shim header that also exports `NODE_PATH`, when there is one to
+/// export.
+fn pwsh_node_path_header(node_path: &[String]) -> Option<String> {
+    let NodePathEnvVar { win32: win32_node_path, posix: posix_node_path } =
+        normalize_node_path_env_var(node_path);
+    (!win32_node_path.is_empty()).then(|| {
+        format!(
+            "#!/usr/bin/env pwsh\n$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent\n\n$exe=\"\"\n$pathsep=\":\"\n$env_node_path=$env:NODE_PATH\n$new_node_path=\"{win32_node_path}\"\nif ($PSVersionTable.PSVersion -lt \"6.0\" -or $IsWindows) {{\n  # Fix case when both the Windows and Linux builds of Node\n  # are installed in the same directory\n  $exe=\".exe\"\n  $pathsep=\";\"\n}} else {{\n  $new_node_path=\"{posix_node_path}\"\n}}\nif ([string]::IsNullOrEmpty($env_node_path)) {{\n  $env:NODE_PATH=$new_node_path\n}} else {{\n  $env:NODE_PATH=\"$new_node_path$pathsep$env_node_path\"\n}}",
+        )
+    })
 }
 
 /// `.ps1` template prelude. Sets up `$basedir` and `$exe`.

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -3563,19 +3563,40 @@ impl Config {
         // pnpm's "CLI > _auth > yaml" precedence.
         npmrc_auth.apply_json_env_registries(&mut self, &declared_registries);
 
-        // Apply `PNPM_CONFIG_*` env vars *after* `pnpm-workspace.yaml`:
-        // env vars override yaml. The `WorkspaceSettings::apply_to`
-        // call also runs the post-processing (Windows `unsafe_perm`
-        // override, `hoist: false` short-circuit on `hoist_pattern`)
-        // regardless of where the values came from, so env-var-set
-        // values still go through the same hardening yaml-set values
-        // do.
-        //
-        // `workspace_dir` save/restore is the same trick used for the
-        // global config above — `apply_to` would otherwise clobber
-        // `workspace_dir` with `start_dir`, hiding the workspace yaml's
-        // location (or, if there was no yaml, setting it to a value
-        // that doesn't actually correspond to a discovered workspace).
+        self.apply_env_settings::<Sys>(&mut explicit, &default_state_dir, start_dir);
+
+        if !self.explicit_settings.contains_key("lockfile") {
+            self.lockfile = self.package_lock;
+        }
+
+        self.apply_store_derivations::<Sys>(explicit, &mut npmrc_auth, start_dir)?;
+
+        self.apply_layout_derivations::<Sys>();
+
+        Ok(self)
+    }
+
+    /// Apply `PNPM_CONFIG_*` env vars *after* `pnpm-workspace.yaml`:
+    /// env vars override yaml. The `WorkspaceSettings::apply_to`
+    /// call also runs the post-processing (Windows `unsafe_perm`
+    /// override, `hoist: false` short-circuit on `hoist_pattern`)
+    /// regardless of where the values came from, so env-var-set
+    /// values still go through the same hardening yaml-set values
+    /// do.
+    ///
+    /// `workspace_dir` save/restore is the same trick used for the
+    /// global config above — `apply_to` would otherwise clobber
+    /// `workspace_dir` with `start_dir`, hiding the workspace yaml's
+    /// location (or, if there was no yaml, setting it to a value
+    /// that doesn't actually correspond to a discovered workspace).
+    fn apply_env_settings<Sys>(
+        &mut self,
+        explicit: &mut ExplicitPaths,
+        default_state_dir: &Path,
+        start_dir: &Path,
+    ) where
+        Sys: EnvVar + EnvVarOs + GetCurrentDir + GetHomeDir + LinkProbe,
+    {
         let mut env_settings = WorkspaceSettings::from_pnpm_config_env::<Sys>();
         explicit.note(&env_settings);
         env_settings.substitute_env_trusted::<Sys>();
@@ -3588,13 +3609,13 @@ impl Config {
         env_settings.apply_proxy_to(&mut bootstrap.proxy, &mut bootstrap.proxy_keys);
         let saved_workspace_dir = self.workspace_dir.clone();
         env_settings.expand_global_dir_home_prefixes::<Sys>();
-        env_settings.apply_to(&mut self, start_dir);
+        env_settings.apply_to(self, start_dir);
         self.workspace_dir = saved_workspace_dir;
         self.apply_remote_side_effects_cache_env::<Sys>();
         if let Some(configured_state_dir) =
             configured_state_dir.as_deref().filter(|value| !value.is_empty())
         {
-            self.state_dir = resolve_configured_state_dir(&default_state_dir, configured_state_dir);
+            self.state_dir = resolve_configured_state_dir(default_state_dir, configured_state_dir);
         }
         if let Some(registry) = env_registry_override {
             let normalized =
@@ -3603,16 +3624,6 @@ impl Config {
             self.package_manager_bootstrap.registry.clone_from(&normalized);
             self.package_manager_bootstrap.registries.insert("default".to_string(), normalized);
         }
-
-        if !self.explicit_settings.contains_key("lockfile") {
-            self.lockfile = self.package_lock;
-        }
-
-        self.apply_store_derivations::<Sys>(explicit, &mut npmrc_auth, start_dir)?;
-
-        self.apply_layout_derivations::<Sys>();
-
-        Ok(self)
     }
 
     /// The directory layout and environment every spawned process sees,
@@ -3935,97 +3946,21 @@ impl Config {
     where
         Sys: EnvVar + EnvVarOs + GetCurrentDir + GetHomeDir + LinkProbe,
     {
-        // Resolve the user-level `.npmrc` path. Precedence:
-        // the `npmrc_auth_file` field (CLI `--npmrc-auth-file` /
-        // `--userconfig`) > `PNPM_CONFIG_NPMRC_AUTH_FILE` >
-        // `PNPM_CONFIG_USERCONFIG` > global `config.yaml`'s `npmrcAuthFile`
-        // > `npm_config_userconfig`. Each env var is empty-filtered
-        // individually (a `value !== ''` check).
-        let user_npmrc_path = self.npmrc_auth_file.clone().or_else(|| {
-            read_pnpm_env::<Sys>("npmrc_auth_file", "NPMRC_AUTH_FILE")
-                .or_else(|| read_pnpm_env::<Sys>("userconfig", "USERCONFIG"))
-                .map(PathBuf::from)
-                .or_else(|| {
-                    global_settings
-                        .and_then(|settings| settings.npmrc_auth_file.clone())
-                        .map(PathBuf::from)
-                })
-                .or_else(|| read_npm_env::<Sys>("userconfig", "USERCONFIG").map(PathBuf::from))
-        });
+        let user_npmrc_path = self.user_npmrc_path::<Sys>(global_settings);
 
         // Build the merge sources in priority order (high → low):
         // project `.npmrc` > `auth.ini` > user-level `.npmrc`. Each is
         // parsed and rescoped independently before being folded together.
         // The rescope warning names the file it read, so each source
         // labels itself with the path it was actually loaded from.
-        let parse_trusted_source = |text: String, dir: PathBuf, path: &Path| {
-            let mut auth = NpmrcAuth::from_ini::<Sys>(&text, &dir);
-            auth.rescope_unscoped(&path.display().to_string());
-            auth
-        };
         let project_npmrc_dir =
             workspace_yaml.as_ref().map_or(start_dir, |(base_dir, _)| base_dir.as_path());
-        let project_npmrc_path = project_npmrc_dir.join(".npmrc");
-        // When npmrcAuthFile explicitly points at the project .npmrc, the user has
-        // opted in to trusting it — allow auth env expansion and suppress the warning.
-        // A relative value (e.g. `PNPM_CONFIG_NPMRC_AUTH_FILE=.npmrc`) is anchored
-        // at the cwd — where the user-level read below actually reads it from, and
-        // how pnpm's `path.resolve` anchors it.
-        let project_is_trusted_auth_file = user_npmrc_path.as_deref().is_some_and(|user| {
-            if user.is_absolute() {
-                user == project_npmrc_path
-            } else {
-                Sys::current_dir().is_ok_and(|cwd| cwd.join(user) == project_npmrc_path)
-            }
-        });
-        let project_source = read_npmrc(project_npmrc_dir).map(|text| {
-            let mut auth = if project_is_trusted_auth_file {
-                NpmrcAuth::from_ini::<Sys>(&text, project_npmrc_dir)
-            } else {
-                NpmrcAuth::from_project_ini::<Sys>(&text, project_npmrc_dir)
-            };
-            auth.rescope_unscoped(&project_npmrc_path.display().to_string());
-            auth
-        });
-        let auth_ini_source = global_config_dir.and_then(|dir| {
-            let path = dir.join("auth.ini");
-            read_npmrc_file(&path).map(|text| parse_trusted_source(text, dir.to_path_buf(), &path))
-        });
-        let user_source = match &user_npmrc_path {
-            Some(path) => read_npmrc_file(path).map(|text| {
-                // Relative `cafile`/`certfile` entries resolve against
-                // the file's directory; for a bare filename (no parent)
-                // that's the empty path — i.e. the process cwd — never
-                // the file itself.
-                let dir = path.parent().map(std::path::Path::to_path_buf).unwrap_or_default();
-                parse_trusted_source(text, dir, path)
-            }),
-            None => Sys::home_dir().and_then(|dir| {
-                let path = dir.join(".npmrc");
-                read_npmrc(&dir).map(|text| parse_trusted_source(text, dir, &path))
-            }),
-        };
-
-        // URL-scoped credentials from `npm_config_//...` / `pnpm_config_//...`
-        // environment variables. These are trusted (they come from the
-        // environment, not the repository) and host-scoped by construction, so
-        // they sit at the top of the precedence chain — above the project
-        // `.npmrc` — following the env-over-workspace ordering.
-        let env_scoped_source = {
-            let auth = NpmrcAuth::from_url_scoped_env::<Sys>();
-            (!auth.creds_by_scope_by_uri.is_empty()).then_some(auth)
-        };
-
-        // Structured `_auth` registry auth from its two trusted sources:
-        // the `pnpm_config__auth` env var and the global `config.yaml`'s
-        // `_auth` key (env wins on conflict). See `from_json_sources`.
-        let json_auth = global_settings
-            .and_then(|settings| settings.auth.as_ref())
-            .pipe(NpmrcAuth::from_json_sources::<Sys>)
-            .map_err(|source| LoadWorkspaceYamlError::InvalidJsonAuth { source })?;
-        let json_auth_has_content = !json_auth.creds_by_scope_by_uri.is_empty()
-            || !json_auth.json_env_registries.is_empty();
-        let env_json_source = json_auth_has_content.then_some(json_auth);
+        let project_source =
+            project_auth_source::<Sys>(project_npmrc_dir, user_npmrc_path.as_deref());
+        let auth_ini_source = auth_ini_source::<Sys>(global_config_dir);
+        let user_source = user_auth_source::<Sys>(user_npmrc_path.as_deref());
+        let env_scoped_source = env_scoped_auth_source::<Sys>();
+        let env_json_source = env_json_auth_source::<Sys>(global_settings)?;
 
         // Capture the trusted sources (everything but `project_source`) for
         // [`PackageManagerBootstrap`] before the fold below consumes them.
@@ -4036,30 +3971,24 @@ impl Config {
             user_source.clone(),
         ];
 
-        // Fold high-priority-first: the first present source is the
-        // base, each lower source fills the gaps it left
-        // ([`NpmrcAuth::merge_under`]). `env_json_source` is listed before
-        // `env_scoped_source` so the JSON env var wins on the rare occasion
-        // both define the same `//host/:_authToken` key — the JSON auth is
-        // applied after the env-scoped config, so it wins.
-        let mut sources =
-            [env_json_source, env_scoped_source, project_source, auth_ini_source, user_source]
-                .into_iter()
-                .flatten();
-        let mut npmrc_auth = sources.next().unwrap_or_default();
-        for lower in sources {
-            npmrc_auth.merge_under(lower);
-        }
+        // `env_json_source` is listed before `env_scoped_source` so the JSON
+        // env var wins on the rare occasion both define the same
+        // `//host/:_authToken` key — the JSON auth is applied after the
+        // env-scoped config, so it wins.
+        let mut npmrc_auth = merge_auth_sources([
+            env_json_source,
+            env_scoped_source,
+            project_source,
+            auth_ini_source,
+            user_source,
+        ]);
+
         // Retain the merged raw `.npmrc` / `auth.ini` config keys for
         // `pnpm config get` / `pnpm config list` before the structured fields
         // are consumed below.
         self.raw_auth_config = std::mem::take(&mut npmrc_auth.raw_ini_config);
 
-        let mut trusted_sources = trusted_sources.into_iter().flatten();
-        let mut trusted_auth = trusted_sources.next().unwrap_or_default();
-        for lower in trusted_sources {
-            trusted_auth.merge_under(lower);
-        }
+        let trusted_auth = merge_auth_sources(trusted_sources);
 
         // A `tokenHelper` names an executable, so it is honored only from a
         // trusted, non-repo source. Reject one that a workspace or project
@@ -4068,6 +3997,28 @@ impl Config {
         crate::npmrc_auth::enforce_token_helper_trust(&npmrc_auth, &trusted_auth)?;
 
         Ok(AuthSources { npmrc_auth, trusted_auth })
+    }
+
+    /// Resolve the user-level `.npmrc` path. Precedence: the
+    /// `npmrc_auth_file` field (CLI `--npmrc-auth-file` / `--userconfig`),
+    /// then `PNPM_CONFIG_NPMRC_AUTH_FILE`, `PNPM_CONFIG_USERCONFIG`, the
+    /// global `config.yaml`'s `npmrcAuthFile` and `npm_config_userconfig`.
+    /// Each env var is empty-filtered individually (a `value !== ''` check).
+    fn user_npmrc_path<Sys: EnvVar>(
+        &self,
+        global_settings: Option<&WorkspaceSettings>,
+    ) -> Option<PathBuf> {
+        self.npmrc_auth_file.clone().or_else(|| {
+            read_pnpm_env::<Sys>("npmrc_auth_file", "NPMRC_AUTH_FILE")
+                .or_else(|| read_pnpm_env::<Sys>("userconfig", "USERCONFIG"))
+                .map(PathBuf::from)
+                .or_else(|| {
+                    global_settings
+                        .and_then(|settings| settings.npmrc_auth_file.clone())
+                        .map(PathBuf::from)
+                })
+                .or_else(|| read_npm_env::<Sys>("userconfig", "USERCONFIG").map(PathBuf::from))
+        })
     }
 
     /// Find the workspace root and read its `pnpm-workspace.yaml`.
@@ -4126,6 +4077,108 @@ impl Config {
     pub fn leak(self) -> &'static mut Self {
         self.pipe(Box::new).pipe(Box::leak)
     }
+}
+
+/// The project `.npmrc`, parsed as untrusted unless the user-level auth
+/// file explicitly points at it.
+fn project_auth_source<Sys>(
+    project_npmrc_dir: &Path,
+    user_npmrc_path: Option<&Path>,
+) -> Option<NpmrcAuth>
+where
+    Sys: EnvVar + GetCurrentDir,
+{
+    let project_npmrc_path = project_npmrc_dir.join(".npmrc");
+    // When npmrcAuthFile explicitly points at the project .npmrc, the user has
+    // opted in to trusting it — allow auth env expansion and suppress the warning.
+    // A relative value (e.g. `PNPM_CONFIG_NPMRC_AUTH_FILE=.npmrc`) is anchored
+    // at the cwd — where the user-level read actually reads it from, and
+    // how pnpm's `path.resolve` anchors it.
+    let project_is_trusted_auth_file = user_npmrc_path.is_some_and(|user| {
+        if user.is_absolute() {
+            user == project_npmrc_path
+        } else {
+            Sys::current_dir().is_ok_and(|cwd| cwd.join(user) == project_npmrc_path)
+        }
+    });
+    read_npmrc(project_npmrc_dir).map(|text| {
+        let mut auth = if project_is_trusted_auth_file {
+            NpmrcAuth::from_ini::<Sys>(&text, project_npmrc_dir)
+        } else {
+            NpmrcAuth::from_project_ini::<Sys>(&text, project_npmrc_dir)
+        };
+        auth.rescope_unscoped(&project_npmrc_path.display().to_string());
+        auth
+    })
+}
+
+fn auth_ini_source<Sys: EnvVar>(global_config_dir: Option<&Path>) -> Option<NpmrcAuth> {
+    global_config_dir.and_then(|dir| {
+        let path = dir.join("auth.ini");
+        read_npmrc_file(&path).map(|text| parse_trusted_source::<Sys>(&text, dir, &path))
+    })
+}
+
+fn user_auth_source<Sys>(user_npmrc_path: Option<&Path>) -> Option<NpmrcAuth>
+where
+    Sys: EnvVar + GetHomeDir,
+{
+    match user_npmrc_path {
+        Some(path) => read_npmrc_file(path).map(|text| {
+            // Relative `cafile`/`certfile` entries resolve against
+            // the file's directory; for a bare filename (no parent)
+            // that's the empty path — i.e. the process cwd — never
+            // the file itself.
+            let dir = path.parent().map(std::path::Path::to_path_buf).unwrap_or_default();
+            parse_trusted_source::<Sys>(&text, &dir, path)
+        }),
+        None => Sys::home_dir().and_then(|dir| {
+            let path = dir.join(".npmrc");
+            read_npmrc(&dir).map(|text| parse_trusted_source::<Sys>(&text, &dir, &path))
+        }),
+    }
+}
+
+fn parse_trusted_source<Sys: EnvVar>(text: &str, dir: &Path, path: &Path) -> NpmrcAuth {
+    let mut auth = NpmrcAuth::from_ini::<Sys>(text, dir);
+    auth.rescope_unscoped(&path.display().to_string());
+    auth
+}
+
+/// URL-scoped credentials from `npm_config_//...` / `pnpm_config_//...`
+/// environment variables. These are trusted (they come from the
+/// environment, not the repository) and host-scoped by construction, so
+/// they sit at the top of the precedence chain — above the project
+/// `.npmrc` — following the env-over-workspace ordering.
+fn env_scoped_auth_source<Sys: EnvVar>() -> Option<NpmrcAuth> {
+    let auth = NpmrcAuth::from_url_scoped_env::<Sys>();
+    (!auth.creds_by_scope_by_uri.is_empty()).then_some(auth)
+}
+
+/// Structured `_auth` registry auth from its two trusted sources:
+/// the `pnpm_config__auth` env var and the global `config.yaml`'s
+/// `_auth` key (env wins on conflict). See `from_json_sources`.
+fn env_json_auth_source<Sys: EnvVar>(
+    global_settings: Option<&WorkspaceSettings>,
+) -> Result<Option<NpmrcAuth>, LoadWorkspaceYamlError> {
+    let json_auth = global_settings
+        .and_then(|settings| settings.auth.as_ref())
+        .pipe(NpmrcAuth::from_json_sources::<Sys>)
+        .map_err(|source| LoadWorkspaceYamlError::InvalidJsonAuth { source })?;
+    let json_auth_has_content =
+        !json_auth.creds_by_scope_by_uri.is_empty() || !json_auth.json_env_registries.is_empty();
+    Ok(json_auth_has_content.then_some(json_auth))
+}
+
+/// Fold high-priority-first: the first present source is the base, each
+/// lower source fills the gaps it left ([`NpmrcAuth::merge_under`]).
+fn merge_auth_sources(sources: impl IntoIterator<Item = Option<NpmrcAuth>>) -> NpmrcAuth {
+    let mut sources = sources.into_iter().flatten();
+    let mut merged = sources.next().unwrap_or_default();
+    for lower in sources {
+        merged.merge_under(lower);
+    }
+    merged
 }
 
 /// Fold a source's explicitly-set settings into the running record.

--- a/pnpm/crates/config/src/npmrc_auth.rs
+++ b/pnpm/crates/config/src/npmrc_auth.rs
@@ -691,22 +691,7 @@ impl NpmrcAuth {
             return;
         }
         let names = unscoped.join(", ");
-        // Take each setting's raw INI spelling along with its structured
-        // value, so both move to the pinned key together. `tokenHelper` is
-        // not an INI-readable key on its own ([`is_ini_config_key`] mirrors
-        // npm, which has no unscoped form), so the parser never captured it
-        // — its raw value comes from the parsed credential instead.
-        let raw_values: Vec<(&str, String)> = unscoped
-            .iter()
-            .filter_map(|key| {
-                self.raw_ini_config
-                    .remove(*key)
-                    .or_else(|| {
-                        (*key == "tokenHelper").then(|| creds.token_helper.clone()).flatten()
-                    })
-                    .map(|value| (*key, value))
-            })
-            .collect();
+        let raw_values = self.take_unscoped_raw_values(&unscoped, &creds);
 
         let declared_registry = self
             .registry
@@ -753,6 +738,29 @@ impl NpmrcAuth {
              unscoped per-registry settings. Write them as \"{uri}:{}=...\" instead.",
             unscoped[0],
         ));
+    }
+
+    /// Take each setting's raw INI spelling along with its structured
+    /// value, so both move to the pinned key together. `tokenHelper` is
+    /// not an INI-readable key on its own ([`is_ini_config_key`] mirrors
+    /// npm, which has no unscoped form), so the parser never captured it
+    /// — its raw value comes from the parsed credential instead.
+    fn take_unscoped_raw_values(
+        &mut self,
+        unscoped: &[&'static str],
+        creds: &RawCreds,
+    ) -> Vec<(&'static str, String)> {
+        unscoped
+            .iter()
+            .filter_map(|key| {
+                self.raw_ini_config
+                    .remove(*key)
+                    .or_else(|| {
+                        (*key == "tokenHelper").then(|| creds.token_helper.clone()).flatten()
+                    })
+                    .map(|value| (*key, value))
+            })
+            .collect()
     }
 
     /// Merge a lower-priority source under `self` (the higher-priority

--- a/pnpm/crates/config/src/npmrc_auth.rs
+++ b/pnpm/crates/config/src/npmrc_auth.rs
@@ -742,7 +742,7 @@ impl NpmrcAuth {
 
     /// Take each setting's raw INI spelling along with its structured
     /// value, so both move to the pinned key together. `tokenHelper` is
-    /// not an INI-readable key on its own ([`is_ini_config_key`] mirrors
+    /// not an INI-readable key on its own ([`crate::config_types::is_ini_config_key`] mirrors
     /// npm, which has no unscoped form), so the parser never captured it
     /// — its raw value comes from the parsed credential instead.
     fn take_unscoped_raw_values(

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -2557,29 +2557,7 @@ impl WorkspaceSettings {
             minimum_release_age: as_set(config, "minimumReleaseAge"),
             prefer_symlinked_executables: as_set(config, "preferSymlinkedExecutables"),
 
-            global_shims: Some(crate::GlobalShimsSetting::Entries(
-                config
-                    .global_shims
-                    .entries()
-                    .map(|(name, policy)| {
-                        // `Off` has no named spelling; it is written as the
-                        // `false` shorthand.
-                        let value = match policy {
-                            crate::ShimPolicy::Off => crate::ShimPolicyValue::Toggle(false),
-                            crate::ShimPolicy::Auto => {
-                                crate::ShimPolicyValue::Named(crate::NamedShimPolicy::Auto)
-                            }
-                            crate::ShimPolicy::Prompt => {
-                                crate::ShimPolicyValue::Named(crate::NamedShimPolicy::Prompt)
-                            }
-                            crate::ShimPolicy::Always => {
-                                crate::ShimPolicyValue::Named(crate::NamedShimPolicy::Always)
-                            }
-                        };
-                        (name.to_string(), value)
-                    })
-                    .collect(),
-            )),
+            global_shims: Some(global_shims_setting(config)),
 
             frozen_lockfile: config.frozen_lockfile,
             git_branch_lockfile: Some(config.use_git_branch_lockfile),
@@ -2644,22 +2622,7 @@ impl WorkspaceSettings {
                 i32::try_from(config.workspace_concurrency).unwrap_or(i32::MAX),
             ),
 
-            // Reads and writes as resolved, in the boolean shorthand when they
-            // agree and no remote cache is configured. That is the shape pnpm
-            // reports and the one a hook is likeliest to assign.
-            side_effects_cache: Some({
-                let read = config.side_effects_cache_read();
-                let write = config.side_effects_cache_write();
-                if read == write && config.remote_side_effects_cache.is_none() {
-                    SideEffectsCacheSetting::Enabled(read)
-                } else {
-                    SideEffectsCacheSetting::Settings(Box::new(SideEffectsCacheSettings {
-                        read: Some(read),
-                        write: Some(write),
-                        remote: config.remote_side_effects_cache.clone(),
-                    }))
-                }
-            }),
+            side_effects_cache: Some(side_effects_cache_setting(config)),
 
             catalogs: config.catalogs.as_ref().map(|catalogs| {
                 catalogs
@@ -2879,6 +2842,49 @@ impl WorkspaceSettings {
             }
         }
         *proxy_config = keys.resolve();
+    }
+}
+
+fn global_shims_setting(config: &Config) -> crate::GlobalShimsSetting {
+    crate::GlobalShimsSetting::Entries(
+        config
+            .global_shims
+            .entries()
+            .map(|(name, policy)| {
+                // `Off` has no named spelling; it is written as the
+                // `false` shorthand.
+                let value = match policy {
+                    crate::ShimPolicy::Off => crate::ShimPolicyValue::Toggle(false),
+                    crate::ShimPolicy::Auto => {
+                        crate::ShimPolicyValue::Named(crate::NamedShimPolicy::Auto)
+                    }
+                    crate::ShimPolicy::Prompt => {
+                        crate::ShimPolicyValue::Named(crate::NamedShimPolicy::Prompt)
+                    }
+                    crate::ShimPolicy::Always => {
+                        crate::ShimPolicyValue::Named(crate::NamedShimPolicy::Always)
+                    }
+                };
+                (name.to_string(), value)
+            })
+            .collect(),
+    )
+}
+
+/// Reads and writes as resolved, in the boolean shorthand when they agree
+/// and no remote cache is configured. That is the shape pnpm reports and
+/// the one a hook is likeliest to assign.
+fn side_effects_cache_setting(config: &Config) -> SideEffectsCacheSetting {
+    let read = config.side_effects_cache_read();
+    let write = config.side_effects_cache_write();
+    if read == write && config.remote_side_effects_cache.is_none() {
+        SideEffectsCacheSetting::Enabled(read)
+    } else {
+        SideEffectsCacheSetting::Settings(Box::new(SideEffectsCacheSettings {
+            read: Some(read),
+            write: Some(write),
+            remote: config.remote_side_effects_cache.clone(),
+        }))
     }
 }
 

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -395,21 +395,6 @@ impl ReporterState {
         colors: Colors,
         options: ReporterOptions,
     ) -> Self {
-        let ReporterOptions {
-            append_only,
-            hide_added_pkgs_progress,
-            hide_progress_prefix,
-            summary_scope,
-            reports_scope,
-            is_recursive,
-            max_log_level,
-            hide_lifecycle_output,
-            stream_lifecycle_output,
-            aggregate_output,
-            hide_lifecycle_prefix,
-            ignored_builds_instruction_text,
-            hide_linked_pkgs_diff,
-        } = options;
         let mut diff = HashMap::new();
         for kind in SUMMARY_ORDER {
             diff.insert(diff_key(kind), HashMap::new());
@@ -418,11 +403,11 @@ impl ReporterState {
             cwd,
             width,
             colors,
-            append_only,
-            hide_added_pkgs_progress,
-            hide_progress_prefix,
-            max_log_level,
-            frame: Frame::new(append_only),
+            append_only: options.append_only,
+            hide_added_pkgs_progress: options.hide_added_pkgs_progress,
+            hide_progress_prefix: options.hide_progress_prefix,
+            max_log_level: options.max_log_level,
+            frame: Frame::new(options.append_only),
             last_frame: None,
             progress: HashMap::new(),
             context: None,
@@ -437,9 +422,9 @@ impl ReporterState {
             summary_slot: BlockSlot::default(),
             summary_seen: false,
             summary_rendered: false,
-            summary_scope,
-            reports_scope,
-            is_recursive,
+            summary_scope: options.summary_scope,
+            reports_scope: options.reports_scope,
+            is_recursive: options.is_recursive,
             scope_slot: BlockSlot::default(),
             lifecycle: HashMap::new(),
             lifecycle_buffers: HashMap::new(),
@@ -456,12 +441,12 @@ impl ReporterState {
             deprecated_subdeps: Vec::new(),
             deprecated_slot: BlockSlot::default(),
             reported_peer_dependency_issues: false,
-            hide_lifecycle_output,
-            stream_lifecycle_output,
-            aggregate_output,
-            hide_lifecycle_prefix,
-            ignored_builds_instruction_text,
-            hidden_linked_pkgs: create_matcher(&hide_linked_pkgs_diff),
+            hide_lifecycle_output: options.hide_lifecycle_output,
+            stream_lifecycle_output: options.stream_lifecycle_output,
+            aggregate_output: options.aggregate_output,
+            hide_lifecycle_prefix: options.hide_lifecycle_prefix,
+            ignored_builds_instruction_text: options.ignored_builds_instruction_text,
+            hidden_linked_pkgs: create_matcher(&options.hide_linked_pkgs_diff),
         }
     }
 
@@ -799,23 +784,22 @@ impl ReporterState {
         if !self.is_current_prefix(prefix) {
             return;
         }
-        let (added, kind, name, version, real_name, from, latest) = match message {
-            RootMessage::Added { added, .. } => added_fields(added),
-            RootMessage::Removed { removed, .. } => removed_fields(removed),
+        let (kind, entry) = match message {
+            RootMessage::Added { added, .. } => added_diff(added),
+            RootMessage::Removed { removed, .. } => removed_diff(removed),
         };
         let key = diff_key(kind);
-        let opposite_key = format!("{}{}", if added { '-' } else { '+' }, name);
+        let opposite_key = format!("{}{}", if entry.added { '-' } else { '+' }, entry.name);
         if let Some(prev) = self.diff.get(key).and_then(|b| b.get(&opposite_key))
-            && prev.version == version
+            && prev.version == entry.version
         {
             self.diff.get_mut(key).unwrap().remove(&opposite_key);
             return;
         }
-        let entry = PackageDiff { added, from, name: name.clone(), real_name, version, latest };
         self.diff
             .get_mut(key)
             .unwrap()
-            .insert(format!("{}{name}", if added { '+' } else { '-' }), entry);
+            .insert(format!("{}{}", if entry.added { '+' } else { '-' }, entry.name), entry);
     }
 
     fn on_manifest(&mut self, message: &PackageManifestMessage) {
@@ -1011,34 +995,37 @@ impl ReporterState {
     fn update_lifecycle_cache(&mut self, key: &str, message: &LifecycleMessage) {
         match message {
             LifecycleMessage::Script { stage, wd, script, .. } => {
-                let prefix =
-                    format!("{} {}", format_prefix(&self.cwd, wd), self.colors.cyan_bright(stage));
-                let max = self.width as isize - visible_width(&prefix) as isize - 2;
-                let line = format!("{prefix}$ {}", cut_line(script, max));
+                let line = self.script_line(stage, wd, script);
                 self.lifecycle.get_mut(key).unwrap().script = line;
             }
             LifecycleMessage::Exit { exit_code, wd, .. } => {
-                let time = self
-                    .lifecycle
-                    .get(key)
-                    .and_then(|e| e.start)
-                    .map(|start| pretty_ms(start.elapsed().as_millis()))
-                    .unwrap_or_default();
-                let status = if *exit_code == 0 {
-                    self.format_indented_status(
-                        &self.colors.magenta_bright(&format!("Done in {time}")),
-                    )
-                } else {
-                    self.format_indented_status(
-                        &self.colors.red(&format!("Failed in {time} at {wd}")),
-                    )
-                };
+                let status = self.exit_status(key, *exit_code, wd);
                 self.lifecycle.get_mut(key).unwrap().status = status;
             }
             LifecycleMessage::Stdio { line, stdio, .. } => {
                 let formatted = self.format_indented_output(line, *stdio);
                 self.lifecycle.get_mut(key).unwrap().output.push(formatted);
             }
+        }
+    }
+
+    fn script_line(&self, stage: &str, wd: &str, script: &str) -> String {
+        let prefix = format!("{} {}", format_prefix(&self.cwd, wd), self.colors.cyan_bright(stage));
+        let max = self.width as isize - visible_width(&prefix) as isize - 2;
+        format!("{prefix}$ {}", cut_line(script, max))
+    }
+
+    fn exit_status(&self, key: &str, exit_code: i32, wd: &str) -> String {
+        let time = self
+            .lifecycle
+            .get(key)
+            .and_then(|e| e.start)
+            .map(|start| pretty_ms(start.elapsed().as_millis()))
+            .unwrap_or_default();
+        if exit_code == 0 {
+            self.format_indented_status(&self.colors.magenta_bright(&format!("Done in {time}")))
+        } else {
+            self.format_indented_status(&self.colors.red(&format!("Failed in {time} at {wd}")))
         }
     }
 
@@ -1502,30 +1489,31 @@ fn diff_key(kind: DepKind) -> &'static str {
     }
 }
 
-type RootFields =
-    (bool, DepKind, String, Option<String>, Option<String>, Option<String>, Option<String>);
-
-fn added_fields(added: &AddedRoot) -> RootFields {
+fn added_diff(added: &AddedRoot) -> (DepKind, PackageDiff) {
     (
-        true,
         DepKind::from_dependency_type(added.dependency_type),
-        added.name.clone(),
-        added.version.clone().or_else(|| added.id.clone()),
-        Some(added.real_name.clone()),
-        added.linked_from.clone(),
-        added.latest.clone(),
+        PackageDiff {
+            added: true,
+            from: added.linked_from.clone(),
+            name: added.name.clone(),
+            real_name: Some(added.real_name.clone()),
+            version: added.version.clone().or_else(|| added.id.clone()),
+            latest: added.latest.clone(),
+        },
     )
 }
 
-fn removed_fields(removed: &RemovedRoot) -> RootFields {
+fn removed_diff(removed: &RemovedRoot) -> (DepKind, PackageDiff) {
     (
-        false,
         DepKind::from_dependency_type(removed.dependency_type),
-        removed.name.clone(),
-        removed.version.clone(),
-        None,
-        None,
-        None,
+        PackageDiff {
+            added: false,
+            from: None,
+            name: removed.name.clone(),
+            real_name: None,
+            version: removed.version.clone(),
+            latest: None,
+        },
     )
 }
 

--- a/pnpm/crates/deps-inspection-peers/src/lib.rs
+++ b/pnpm/crates/deps-inspection-peers/src/lib.rs
@@ -279,40 +279,30 @@ struct LinkedPackagePeers<'a> {
 fn check_linked_package_peers(
     inputs: LinkedPackagePeers<'_>,
 ) -> Result<(), CatalogResolutionError> {
-    let LinkedPackagePeers {
-        lockfile,
-        importer,
-        linked_importer,
-        importer_dir,
-        linked_importer_dir,
-        lockfile_dir,
-        manifest,
-        alias,
-        linked_version,
-        catalogs,
-        issues,
-    } = inputs;
+    let issues = inputs.issues;
     let Some(peer_deps) =
-        manifest.value().get("peerDependencies").and_then(|deps_val| deps_val.as_object())
+        inputs.manifest.value().get("peerDependencies").and_then(|deps_val| deps_val.as_object())
     else {
         return Ok(());
     };
 
-    let current_parents =
-        vec![ParentPkg { name: alias.to_string(), version: linked_version.to_string() }];
+    let current_parents = vec![ParentPkg {
+        name: inputs.alias.to_string(),
+        version: inputs.linked_version.to_string(),
+    }];
 
     for (peer_name, peer_range_val) in peer_deps {
         let Some(peer_range) = peer_range_val.as_str() else { continue };
-        let peer_range = resolve_peer_range(peer_name, peer_range, catalogs)?;
+        let peer_range = resolve_peer_range(peer_name, peer_range, inputs.catalogs)?;
         check_one_linked_peer(LinkedPeerCheck {
-            lockfile,
-            importer,
-            linked_importer,
-            importer_dir,
-            linked_importer_dir,
-            lockfile_dir,
+            lockfile: inputs.lockfile,
+            importer: inputs.importer,
+            linked_importer: inputs.linked_importer,
+            importer_dir: inputs.importer_dir,
+            linked_importer_dir: inputs.linked_importer_dir,
+            lockfile_dir: inputs.lockfile_dir,
             parents: &current_parents,
-            optional: peer_is_optional(manifest, peer_name),
+            optional: peer_is_optional(inputs.manifest, peer_name),
             peer_name,
             peer_range: &get_peer_version_range(&peer_range),
             issues,
@@ -338,39 +328,46 @@ struct LinkedPeerCheck<'a> {
 }
 
 fn check_one_linked_peer(check: LinkedPeerCheck<'_>) {
-    let LinkedPeerCheck {
-        lockfile,
-        importer,
-        linked_importer,
-        importer_dir,
-        linked_importer_dir,
-        lockfile_dir,
-        parents,
-        optional,
-        peer_name,
-        peer_range,
-        issues,
-    } = check;
-    let Ok(peer_pkg_name) = peer_name.parse::<PkgName>() else { return };
+    let issues = check.issues;
+    let Ok(peer_pkg_name) = check.peer_name.parse::<PkgName>() else { return };
 
     // The linked package's own project comes second: a peer the depending
     // project provides is the one that ends up resolved.
-    let resolved_ref = project_dependency(importer, &peer_pkg_name)
-        .map(|spec| (spec, importer_dir))
+    let resolved_ref = project_dependency(check.importer, &peer_pkg_name)
+        .map(|spec| (spec, check.importer_dir))
         .or_else(|| {
-            linked_importer
+            check
+                .linked_importer
                 .and_then(|importer| project_dependency(importer, &peer_pkg_name))
-                .map(|spec| (spec, linked_importer_dir))
+                .map(|spec| (spec, check.linked_importer_dir))
         });
     let Some((spec, dependency_dir)) = resolved_ref else {
-        record_missing_peer(issues, peer_name, parents, optional, peer_range);
+        record_missing_peer(
+            issues,
+            check.peer_name,
+            check.parents,
+            check.optional,
+            check.peer_range,
+        );
         return;
     };
 
-    let found_version =
-        resolved_peer_version(lockfile, lockfile_dir, dependency_dir, &peer_pkg_name, spec);
+    let found_version = resolved_peer_version(
+        check.lockfile,
+        check.lockfile_dir,
+        dependency_dir,
+        &peer_pkg_name,
+        spec,
+    );
     let Some(found_version) = found_version else { return };
-    record_bad_peer(issues, peer_name, parents, optional, peer_range, found_version);
+    record_bad_peer(
+        issues,
+        check.peer_name,
+        check.parents,
+        check.optional,
+        check.peer_range,
+        found_version,
+    );
 }
 
 /// An unresolved peer is an issue unless the declaration marks it optional.
@@ -638,8 +635,8 @@ struct SnapshotPeers<'a> {
 /// Record every peer dependency the package declares that its snapshot
 /// leaves unsatisfied.
 fn check_snapshot_peers(inputs: SnapshotPeers<'_>) {
-    let SnapshotPeers { key, snapshot, packages, lockfile_dir, parents, issues } = inputs;
-    let Some(meta) = packages.get(&key.without_peer()) else { return };
+    let issues = inputs.issues;
+    let Some(meta) = inputs.packages.get(&inputs.key.without_peer()) else { return };
     let Some(peers) = &meta.peer_dependencies else { return };
 
     for (peer_name, peer_range) in peers {
@@ -651,16 +648,16 @@ fn check_snapshot_peers(inputs: SnapshotPeers<'_>) {
             .is_some_and(|peer_meta| peer_meta.optional);
 
         let Ok(peer_pkg_name) = peer_name.parse::<PkgName>() else { continue };
-        let dep_ref = snapshot.and_then(|entry| snapshot_dependency(entry, &peer_pkg_name));
+        let dep_ref = inputs.snapshot.and_then(|entry| snapshot_dependency(entry, &peer_pkg_name));
         let Some(dep_ref) = dep_ref else {
-            record_missing_peer(issues, peer_name, parents, optional, &peer_range);
+            record_missing_peer(issues, peer_name, inputs.parents, optional, &peer_range);
             continue;
         };
 
-        let Some(found_version) = resolved_snapshot_version(dep_ref, lockfile_dir) else {
+        let Some(found_version) = resolved_snapshot_version(dep_ref, inputs.lockfile_dir) else {
             continue;
         };
-        record_bad_peer(issues, peer_name, parents, optional, &peer_range, found_version);
+        record_bad_peer(issues, peer_name, inputs.parents, optional, &peer_range, found_version);
     }
 }
 
@@ -1261,34 +1258,39 @@ fn parse_allowed_versions(
 
     for (selector, spec) in allowed {
         if let Some((parent, target)) = selector.split_once('>') {
-            let parsed_parent = parse_wanted_dependency(parent.trim());
-            let parent_name = parsed_parent.alias.unwrap_or_else(|| parent.trim().to_string());
-            let parent_range = parsed_parent.bare_specifier;
-
-            let parsed_peer = parse_wanted_dependency(target.trim());
-            let peer_name = parsed_peer.alias.unwrap_or_else(|| target.trim().to_string());
-
-            let ranges: Vec<String> = spec.split("||").map(|seg| seg.trim().to_string()).collect();
-
-            let parent_entry = by_parent.entry(parent_name).or_default();
-            if let Some(rule) =
-                parent_entry.iter_mut().find(|rule_entry| rule_entry.parent_range == parent_range)
-            {
-                rule.peer_rules.entry(peer_name).or_default().extend(ranges);
-            } else {
-                let mut peer_rules = HashMap::new();
-                peer_rules.insert(peer_name, ranges);
-                parent_entry.push(ParentRule { parent_range, peer_rules });
-            }
+            add_parent_rule(&mut by_parent, parent, target, spec);
         } else {
             let parsed = parse_wanted_dependency(selector);
             let target_name = parsed.alias.unwrap_or_else(|| selector.clone());
-            let ranges: Vec<String> = spec.split("||").map(|seg| seg.trim().to_string()).collect();
-            match_all.entry(target_name).or_default().extend(ranges);
+            match_all.entry(target_name).or_default().extend(split_ranges(spec));
         }
     }
 
     (match_all, by_parent)
+}
+
+fn add_parent_rule(by_parent: &mut AllowByParentMatcher, parent: &str, target: &str, spec: &str) {
+    let parsed_parent = parse_wanted_dependency(parent.trim());
+    let parent_name = parsed_parent.alias.unwrap_or_else(|| parent.trim().to_string());
+    let parent_range = parsed_parent.bare_specifier;
+
+    let parsed_peer = parse_wanted_dependency(target.trim());
+    let peer_name = parsed_peer.alias.unwrap_or_else(|| target.trim().to_string());
+
+    let parent_entry = by_parent.entry(parent_name).or_default();
+    if let Some(rule) =
+        parent_entry.iter_mut().find(|rule_entry| rule_entry.parent_range == parent_range)
+    {
+        rule.peer_rules.entry(peer_name).or_default().extend(split_ranges(spec));
+    } else {
+        let mut peer_rules = HashMap::new();
+        peer_rules.insert(peer_name, split_ranges(spec));
+        parent_entry.push(ParentRule { parent_range, peer_rules });
+    }
+}
+
+fn split_ranges(spec: &str) -> Vec<String> {
+    spec.split("||").map(|seg| seg.trim().to_string()).collect()
 }
 
 #[must_use]

--- a/pnpm/crates/deps-inspection/src/dependents.rs
+++ b/pnpm/crates/deps-inspection/src/dependents.rs
@@ -210,32 +210,44 @@ pub fn build_dependents_tree(opts: &BuildDependentsOptions<'_>) -> Vec<Dependent
             continue;
         }
 
-        let mut ctx = WalkCtx {
-            reverse_map: &reverse_map,
-            lockfile,
-            importer_info: opts.importer_info,
-            manifest_reader: ManifestProjector {
-                fields: opts.manifest_fields,
-                resolved: &resolved_nodes,
-            },
-            visited: HashSet::from([node_id.clone()]),
-            expanded: HashSet::new(),
-        };
-        let dependents = walk_reverse(&mut ctx, node_id, 0);
-
         trees.push(DependentsTree {
             name,
             display_name: None,
             version,
             path: Some(resolved.path.to_string_lossy().into_owned()),
             peers_suffix_hash: peers_suffix_hash(dep_path),
-            dependents,
+            dependents: walk_dependents_of(opts, &reverse_map, &resolved_nodes, node_id),
             search_message: matched.message().map(str::to_string),
             manifest: ManifestProjector { fields: opts.manifest_fields, resolved: &resolved_nodes }
                 .project(node_id),
         });
     }
 
+    sort_trees(&mut trees);
+    trees
+}
+
+fn walk_dependents_of(
+    opts: &BuildDependentsOptions<'_>,
+    reverse_map: &HashMap<TreeNodeId, Vec<ReverseEdge>>,
+    resolved_nodes: &HashMap<TreeNodeId, ManifestSource>,
+    node_id: &TreeNodeId,
+) -> Vec<DependentNode> {
+    let mut ctx = WalkCtx {
+        reverse_map,
+        lockfile: opts.env.current_lockfile,
+        importer_info: opts.importer_info,
+        manifest_reader: ManifestProjector {
+            fields: opts.manifest_fields,
+            resolved: resolved_nodes,
+        },
+        visited: HashSet::from([node_id.clone()]),
+        expanded: HashSet::new(),
+    };
+    walk_reverse(&mut ctx, node_id, 0)
+}
+
+fn sort_trees(trees: &mut [DependentsTree]) {
     trees.sort_by(|a, b| {
         a.name.cmp(&b.name).then_with(|| compare_versions(&a.version, &b.version)).then_with(|| {
             a.peers_suffix_hash
@@ -244,7 +256,6 @@ pub fn build_dependents_tree(opts: &BuildDependentsOptions<'_>) -> Vec<Dependent
                 .cmp(b.peers_suffix_hash.as_deref().unwrap_or(""))
         })
     });
-    trees
 }
 
 /// Match the search against the package's canonical name first, then against

--- a/pnpm/crates/deps-inspection/src/get_tree.rs
+++ b/pnpm/crates/deps-inspection/src/get_tree.rs
@@ -169,26 +169,14 @@ struct MaterializeEdge<'a> {
 }
 
 fn materialize_edge(inputs: MaterializeEdge<'_>) {
-    let MaterializeEdge {
-        opts,
-        cache,
-        ancestors,
-        edge,
-        peers,
-        linked_path_base_dir,
-        parent_dir,
-        max_depth,
-        guard_depth,
-        result,
-    } = inputs;
-
+    let MaterializeEdge { opts, edge, result, .. } = inputs;
     let edge_ctx = EdgeContext {
-        peers: Some(peers),
-        linked_path_base_dir: linked_path_base_dir.to_path_buf(),
+        peers: Some(inputs.peers),
+        linked_path_base_dir: inputs.linked_path_base_dir.to_path_buf(),
         rewrite_link_version_dir: Some(opts.rewrite_link_version_dir.clone()),
-        parent_dir: parent_dir.map(Path::to_path_buf),
+        parent_dir: inputs.parent_dir.map(Path::to_path_buf),
     };
-    let (package_info, _manifest) = get_pkg_info(opts.env, edge, &edge_ctx);
+    let (package_info, _) = get_pkg_info(opts.env, edge, &edge_ctx);
     let search_match = opts.search.map(|search| {
         search.matches(&edge.alias, &package_info.name, &package_info.version, edge.target.as_ref())
     });
@@ -199,12 +187,12 @@ fn materialize_edge(inputs: MaterializeEdge<'_>) {
         None => Subtree::default(),
         Some(target) => materialize_subtree(SubtreeWalk {
             opts,
-            cache,
-            ancestors,
+            cache: inputs.cache,
+            ancestors: inputs.ancestors,
             target,
             package_path: &package_info.path,
-            max_depth,
-            guard_depth,
+            max_depth: inputs.max_depth,
+            guard_depth: inputs.guard_depth,
         }),
     };
     result.has_search_match |= subtree.walked_has_search_match || subtree.deduped_has_search_match;
@@ -232,8 +220,7 @@ fn materialize_edge(inputs: MaterializeEdge<'_>) {
     if entry.is_peer && opts.exclude_peer_dependencies && entry.dependencies.is_empty() {
         return;
     }
-    let has_children = !entry.dependencies.is_empty();
-    result.count += 1 + if has_children { subtree.count } else { 0 };
+    result.count += 1 + if entry.dependencies.is_empty() { 0 } else { subtree.count };
     result.nodes.push(entry);
 }
 

--- a/pnpm/crates/deps-inspection/src/pkg_info.rs
+++ b/pnpm/crates/deps-inspection/src/pkg_info.rs
@@ -84,46 +84,45 @@ pub fn get_pkg_info(
     edge: &GraphEdge,
     ctx: &EdgeContext<'_>,
 ) -> (DependencyNode, ManifestSource) {
-    let LockedPkg { name, mut version, resolved, integrity, optional, is_skipped, dev } =
-        match &edge.dep_path {
-            Some(dep_path) => locked_pkg(env, edge, dep_path),
-            None => LockedPkg::unlocked(edge),
-        };
+    let mut locked = match &edge.dep_path {
+        Some(dep_path) => locked_pkg(env, edge, dep_path),
+        None => LockedPkg::unlocked(edge),
+    };
     let full_package_path = if let Some(dep_path) = &edge.dep_path {
-        resolve_package_path(env, dep_path, &name, &edge.alias, ctx)
+        resolve_package_path(env, dep_path, &locked.name, &edge.alias, ctx)
     } else {
         let link_target = edge.link_target.as_deref().unwrap_or("");
         lexical_normalize(&ctx.linked_path_base_dir.join(link_target))
     };
 
-    if version.is_empty() {
-        version.clone_from(&edge.ref_display);
+    if locked.version.is_empty() {
+        locked.version.clone_from(&edge.ref_display);
     }
-    if version.starts_with("link:")
+    if locked.version.starts_with("link:")
         && let Some(rewrite_dir) = &ctx.rewrite_link_version_dir
     {
         let relative = pathdiff::diff_paths(&full_package_path, rewrite_dir)
             .unwrap_or_else(|| full_package_path.clone());
-        version = format!("link:{}", relative.to_string_lossy().replace('\\', "/"));
+        locked.version = format!("link:{}", relative.to_string_lossy().replace('\\', "/"));
     }
 
     let path = full_package_path.to_string_lossy().into_owned();
     let manifest_source = ManifestSource {
         path: full_package_path,
-        integrity,
-        name: name.clone(),
-        version: version.clone(),
+        integrity: locked.integrity,
+        name: locked.name.clone(),
+        version: locked.version.clone(),
     };
     let node = DependencyNode {
         alias: edge.alias.clone(),
-        name,
-        version,
+        name: locked.name,
+        version: locked.version,
         path,
-        resolved,
+        resolved: locked.resolved,
         is_peer: ctx.peers.is_some_and(|peers| peers.contains(&edge.alias)),
-        is_skipped,
-        dev,
-        optional,
+        is_skipped: locked.is_skipped,
+        dev: locked.dev,
+        optional: locked.optional,
         peers_suffix_hash: edge.dep_path.as_ref().and_then(peers_suffix_hash),
         ..DependencyNode::default()
     };

--- a/pnpm/crates/deps-restorer/src/build_modules.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules.rs
@@ -729,7 +729,7 @@ mod tests;
 /// The executor's canonical `scriptsPrependNodePath`. Config's mirror
 /// enum carries the yaml-deserialize impl; the executor's stays free of
 /// serde wiring.
-pub(crate) fn exec_scripts_prepend_node_path(config: &Config) -> ScriptsPrependNodePath {
+pub fn exec_scripts_prepend_node_path(config: &Config) -> ScriptsPrependNodePath {
     match config.scripts_prepend_node_path {
         pnpm_config::ScriptsPrependNodePath::Always => ScriptsPrependNodePath::Always,
         pnpm_config::ScriptsPrependNodePath::Never => ScriptsPrependNodePath::Never,

--- a/pnpm/crates/deps-restorer/src/build_modules.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules.rs
@@ -365,193 +365,62 @@ impl BuildModules<'_> {
     /// Run the build, reporting the packages that needed one but did
     /// not get it — see [`BuildModulesOutput`].
     pub fn run<Reporter: self::Reporter>(self) -> Result<BuildModulesOutput, BuildModulesError> {
-        let BuildModules {
-            layout,
-            modules_dir,
-            lockfile_dir,
-            snapshots,
-            packages,
-            importers,
-            allow_build_policy,
-            side_effects_maps_by_snapshot,
-            requires_build_by_snapshot,
-            engine_name,
-            side_effects_cache,
-            side_effects_cache_write,
-            shared_side_effects_publisher,
-            store_dir,
-            store_index_writer,
-            patches,
-            scripts_prepend_node_path,
-            script_shell,
-            shell_emulator,
-            extra_env,
-            user_agent,
-            unsafe_perm,
-            child_concurrency,
-            skipped,
-            pkg_roots_by_key,
-            gather_ancestor_bin_paths,
-            frozen_store,
-            ignore_scripts,
-            import_method,
-            logged_methods,
-            rebuild,
-        } = self;
-
-        let Some(snapshots) = snapshots else { return Ok(BuildModulesOutput::default()) };
+        let Some(snapshots) = self.snapshots else { return Ok(BuildModulesOutput::default()) };
 
         let requires_build_map = requires_build_by_key(RequiresBuildInputs {
             snapshots,
-            skipped,
-            pkg_roots: PkgRoots { layout, by_key: pkg_roots_by_key },
-            prefetched: requires_build_by_snapshot,
-            patches,
+            skipped: self.skipped,
+            pkg_roots: PkgRoots { layout: self.layout, by_key: self.pkg_roots_by_key },
+            prefetched: self.requires_build_by_snapshot,
+            patches: self.patches,
         });
-
-        // Build the dep graph + state cache only when the
-        // side-effects-cache gate has a chance of firing — on
-        // either the READ side (prefetch surfaced cache rows) or
-        // the WRITE side (the install will be populating new
-        // cache entries after a successful build).
-        //
-        // The graph is bounded to the *forward closure of
-        // `requires_build` snapshots* via `build_deps_subgraph`.
-        // The upload-site and gate-check loops only ever compute
-        // cache keys for `requires_build` snapshots, and
-        // `calc_dep_state` only recurses into a snapshot's own
-        // children, so the closure-bounded graph produces the
-        // exact same cache keys as the full graph for every
-        // root we'll query. A pure-JS install with no
-        // `requires_build` snapshots feeds in an empty root
-        // iterator and the function returns immediately —
-        // O(0) walk for that path.
-        //
-        // The per-install dep-state cache memoizes per-node hash
-        // across diamond-shaped subgraphs so the recursive walk stays
-        // linear in |closure| even when the same dep is reachable
-        // through many parents.
-        let cache_gate_active = side_effects_cache_gate_active(&SideEffectsCacheGate {
-            side_effects_cache,
-            side_effects_cache_write,
-            has_publisher: shared_side_effects_publisher.is_some(),
-            frozen_store,
-            has_engine_name: engine_name.is_some(),
-            has_store_writer: store_index_writer.is_some(),
-            has_store_dir: store_dir.is_some(),
-            has_packages: packages.is_some(),
-            has_cache_rows: side_effects_maps_by_snapshot.is_some_and(|map| !map.is_empty()),
-        });
-        let dep_graph = cache_gate_active.then(|| {
-            let roots = requires_build_map
-                .iter()
-                .filter(|&(_, &requires_build)| requires_build)
-                .map(|(key, _)| key.clone());
-            crate::build_deps_subgraph(
-                snapshots,
-                packages.expect("`cache_gate_active` requires packages: Some"),
-                roots,
-            )
-        });
-        // `deps_state_cache` memoizes per-snapshot hashes across the
-        // recursive walk in `calc_dep_state`. Shared across all
-        // scheduled nodes so diamond-shaped subgraphs hit the memo from
-        // earlier builds too. Wrapped in `Mutex` because the scheduler
-        // dispatches ready nodes concurrently. `calc_dep_state`
-        // mutates the cache through `&mut`, and worker threads would
-        // otherwise need each task to own a private cache, defeating
-        // the point of memoization.
-        let deps_state_cache: Mutex<pnpm_graph_hasher::DepsStateCache<PackageKey>> =
-            Mutex::new(pnpm_graph_hasher::DepsStateCache::new());
-        // Prime it in lockfile key order before any build runs. The
-        // ready nodes race for the mutex, and a snapshot inside a
-        // dependency cycle takes the digest of whichever walk reached
-        // it first — so an unprimed cache would hand the same install
-        // a different side-effects-cache key on every run, and every
-        // repeat install would re-run the build it already has cached.
-        if let Some(graph) = &dep_graph {
-            let mut cache_guard =
-                deps_state_cache.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-            pnpm_graph_hasher::warm_deps_state_cache(
-                graph,
-                &mut cache_guard,
-                crate::deps_graph::in_lockfile_order(graph).into_iter().map(|(key, _)| key),
-            );
-        }
-
-        let build_graph = build_graph(&requires_build_map, patches, snapshots, importers, skipped);
+        let dep_states = self.dep_states(snapshots, &requires_build_map);
+        let build_graph =
+            build_graph(&requires_build_map, self.patches, snapshots, self.importers, self.skipped);
 
         // Collect peer-stripped keys so the final list is unique and
         // sorted lexicographically — matches `dedupePackageNamesFromIgnoredBuilds`.
-        // `Mutex` for the same parallelism reason as `deps_state_cache` above.
+        // `Mutex` for the same parallelism reason as the dep-state cache.
         let ignored_builds: Mutex<BTreeSet<String>> = Mutex::new(BTreeSet::new());
-
-        let first_error: Mutex<Option<BuildModulesError>> = Mutex::new(None);
-        let on_node_skipped: fn(&PackageKey) = |_| {};
         let slot_mutations = std::sync::atomic::AtomicBool::new(false);
-        let build_context = build_one_snapshot::BuildOneSnapshot {
-            snapshots,
-            packages,
-            patches,
-            requires_build_map: &requires_build_map,
-            allow_build_policy,
-            side_effects_maps_by_snapshot,
-            engine_name,
-            side_effects_cache,
-            side_effects_cache_write,
-            shared_side_effects_publisher,
-            store_dir,
-            store_index_writer,
-            dep_graph: dep_graph.as_ref(),
-            deps_state_cache: &deps_state_cache,
-            ignored_builds: &ignored_builds,
-            layout,
-            pkg_roots_by_key,
-            gather_ancestor_bin_paths,
-            modules_dir,
-            lockfile_dir,
-            extra_env,
-            user_agent,
-            scripts_prepend_node_path,
-            script_shell,
-            shell_emulator,
-            unsafe_perm,
-            frozen_store,
-            ignore_scripts,
-            import_method,
-            logged_methods,
-            slot_mutations: &slot_mutations,
-            rebuild,
-        };
-        let run_node = |snapshot_key: PackageKey| match build_one_snapshot::<Reporter>(
-            &snapshot_key,
-            &build_context,
-        ) {
-            Ok(()) => TaskCompletion::Passed,
-            Err(error) => {
-                first_error
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                    .get_or_insert(error);
-                TaskCompletion::Failed
-            }
-        };
-        schedule_graph(
+        schedule_builds::<Reporter>(
             &build_graph,
-            &ScheduleGraphOptions {
-                concurrency: crate::script_thread_count(child_concurrency, build_graph.len()),
-                bail: true,
-                continue_on_failure: false,
-                run_node: &run_node,
-                on_node_skipped: &on_node_skipped,
+            &build_one_snapshot::BuildOneSnapshot {
+                snapshots,
+                packages: self.packages,
+                patches: self.patches,
+                requires_build_map: &requires_build_map,
+                allow_build_policy: self.allow_build_policy,
+                side_effects_maps_by_snapshot: self.side_effects_maps_by_snapshot,
+                engine_name: self.engine_name,
+                side_effects_cache: self.side_effects_cache,
+                side_effects_cache_write: self.side_effects_cache_write,
+                shared_side_effects_publisher: self.shared_side_effects_publisher,
+                store_dir: self.store_dir,
+                store_index_writer: self.store_index_writer,
+                dep_graph: dep_states.graph.as_ref(),
+                deps_state_cache: &dep_states.cache,
+                ignored_builds: &ignored_builds,
+                layout: self.layout,
+                pkg_roots_by_key: self.pkg_roots_by_key,
+                gather_ancestor_bin_paths: self.gather_ancestor_bin_paths,
+                modules_dir: self.modules_dir,
+                lockfile_dir: self.lockfile_dir,
+                extra_env: self.extra_env,
+                user_agent: self.user_agent,
+                scripts_prepend_node_path: self.scripts_prepend_node_path,
+                script_shell: self.script_shell,
+                shell_emulator: self.shell_emulator,
+                unsafe_perm: self.unsafe_perm,
+                frozen_store: self.frozen_store,
+                ignore_scripts: self.ignore_scripts,
+                import_method: self.import_method,
+                logged_methods: self.logged_methods,
+                slot_mutations: &slot_mutations,
+                rebuild: self.rebuild,
             },
-        )
-        .map_err(|source| BuildModulesError::ThreadPoolBuild { source })?;
-        if let Some(error) =
-            first_error.into_inner().unwrap_or_else(std::sync::PoisonError::into_inner)
-        {
-            return Err(error);
-        }
+            self.child_concurrency,
+        )?;
 
         // If a scheduler worker panicked while holding the
         // `ignored_builds` lock, the scheduler will have
@@ -564,9 +433,118 @@ impl BuildModules<'_> {
             ignored_builds.into_inner().unwrap_or_else(std::sync::PoisonError::into_inner);
         Ok(BuildModulesOutput {
             ignored_builds: ignored_builds.into_iter().collect(),
-            deferred_builds: deferred_builds(requires_build_map.iter(), ignore_scripts),
+            deferred_builds: deferred_builds(requires_build_map.iter(), self.ignore_scripts),
             mutated_slots: slot_mutations.into_inner(),
         })
+    }
+
+    /// Build the dep graph + state cache only when the
+    /// side-effects-cache gate has a chance of firing — on either the
+    /// READ side (prefetch surfaced cache rows) or the WRITE side (the
+    /// install will be populating new cache entries after a successful
+    /// build).
+    ///
+    /// The graph is bounded to the *forward closure of `requires_build`
+    /// snapshots* via `build_deps_subgraph`. The upload-site and
+    /// gate-check loops only ever compute cache keys for
+    /// `requires_build` snapshots, and `calc_dep_state` only recurses
+    /// into a snapshot's own children, so the closure-bounded graph
+    /// produces the exact same cache keys as the full graph for every
+    /// root we'll query. A pure-JS install with no `requires_build`
+    /// snapshots feeds in an empty root iterator and the function
+    /// returns immediately — O(0) walk for that path.
+    fn dep_states(
+        &self,
+        snapshots: &HashMap<PackageKey, SnapshotEntry>,
+        requires_build_map: &HashMap<PackageKey, bool>,
+    ) -> DepStates {
+        let cache_gate_active = side_effects_cache_gate_active(&SideEffectsCacheGate {
+            side_effects_cache: self.side_effects_cache,
+            side_effects_cache_write: self.side_effects_cache_write,
+            has_publisher: self.shared_side_effects_publisher.is_some(),
+            frozen_store: self.frozen_store,
+            has_engine_name: self.engine_name.is_some(),
+            has_store_writer: self.store_index_writer.is_some(),
+            has_store_dir: self.store_dir.is_some(),
+            has_packages: self.packages.is_some(),
+            has_cache_rows: self.side_effects_maps_by_snapshot.is_some_and(|map| !map.is_empty()),
+        });
+        let graph = cache_gate_active.then(|| {
+            let roots = requires_build_map
+                .iter()
+                .filter(|&(_, &requires_build)| requires_build)
+                .map(|(key, _)| key.clone());
+            crate::build_deps_subgraph(
+                snapshots,
+                self.packages.expect("`cache_gate_active` requires packages: Some"),
+                roots,
+            )
+        });
+        let cache = Mutex::new(pnpm_graph_hasher::DepsStateCache::new());
+        // Prime it in lockfile key order before any build runs. The
+        // ready nodes race for the mutex, and a snapshot inside a
+        // dependency cycle takes the digest of whichever walk reached
+        // it first — so an unprimed cache would hand the same install
+        // a different side-effects-cache key on every run, and every
+        // repeat install would re-run the build it already has cached.
+        if let Some(graph) = &graph {
+            let mut cache_guard = cache.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            pnpm_graph_hasher::warm_deps_state_cache(
+                graph,
+                &mut cache_guard,
+                crate::deps_graph::in_lockfile_order(graph).into_iter().map(|(key, _)| key),
+            );
+        }
+        DepStates { graph, cache }
+    }
+}
+
+/// What the side-effects-cache gate hashes over.
+struct DepStates {
+    graph: Option<HashMap<PackageKey, pnpm_graph_hasher::DepsGraphNode<PackageKey>>>,
+    /// Memoizes per-snapshot hashes across the recursive walk in
+    /// `calc_dep_state`. Shared across all scheduled nodes so
+    /// diamond-shaped subgraphs hit the memo from earlier builds too.
+    /// Wrapped in `Mutex` because the scheduler dispatches ready nodes
+    /// concurrently. `calc_dep_state` mutates the cache through `&mut`,
+    /// and worker threads would otherwise need each task to own a
+    /// private cache, defeating the point of memoization.
+    cache: Mutex<pnpm_graph_hasher::DepsStateCache<PackageKey>>,
+}
+
+/// Run every build in dependency order, bailing on the first failure.
+fn schedule_builds<Reporter: self::Reporter>(
+    build_graph: &indexmap::IndexMap<PackageKey, Vec<PackageKey>>,
+    context: &build_one_snapshot::BuildOneSnapshot<'_>,
+    child_concurrency: u32,
+) -> Result<(), BuildModulesError> {
+    let first_error: Mutex<Option<BuildModulesError>> = Mutex::new(None);
+    let on_node_skipped: fn(&PackageKey) = |_| {};
+    let run_node =
+        |snapshot_key: PackageKey| match build_one_snapshot::<Reporter>(&snapshot_key, context) {
+            Ok(()) => TaskCompletion::Passed,
+            Err(error) => {
+                first_error
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .get_or_insert(error);
+                TaskCompletion::Failed
+            }
+        };
+    schedule_graph(
+        build_graph,
+        &ScheduleGraphOptions {
+            concurrency: crate::script_thread_count(child_concurrency, build_graph.len()),
+            bail: true,
+            continue_on_failure: false,
+            run_node: &run_node,
+            on_node_skipped: &on_node_skipped,
+        },
+    )
+    .map_err(|source| BuildModulesError::ThreadPoolBuild { source })?;
+    match first_error.into_inner().unwrap_or_else(std::sync::PoisonError::into_inner) {
+        Some(error) => Err(error),
+        None => Ok(()),
     }
 }
 
@@ -747,3 +725,14 @@ pub(crate) fn deferred_builds<'a>(
 
 #[cfg(test)]
 mod tests;
+
+/// The executor's canonical `scriptsPrependNodePath`. Config's mirror
+/// enum carries the yaml-deserialize impl; the executor's stays free of
+/// serde wiring.
+pub(crate) fn exec_scripts_prepend_node_path(config: &Config) -> ScriptsPrependNodePath {
+    match config.scripts_prepend_node_path {
+        pnpm_config::ScriptsPrependNodePath::Always => ScriptsPrependNodePath::Always,
+        pnpm_config::ScriptsPrependNodePath::Never => ScriptsPrependNodePath::Never,
+        pnpm_config::ScriptsPrependNodePath::WarnOnly => ScriptsPrependNodePath::WarnOnly,
+    }
+}

--- a/pnpm/crates/deps-restorer/src/build_modules/allow_build_policy.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules/allow_build_policy.rs
@@ -73,36 +73,19 @@ impl AllowBuildPolicy {
     /// from `pnpm-workspace.yaml`. pnpm v11 stopped reading these
     /// from `package.json#pnpm` — see pnpm/pacquet#397 item 5.
     pub fn from_config(config: &Config) -> Result<Self, VersionPolicyError> {
-        let mut allowed_specs: Vec<&str> = Vec::new();
-        let mut disallowed_specs: Vec<&str> = Vec::new();
-        let mut allowed_dep_paths = HashSet::new();
-        let mut disallowed_dep_paths = HashSet::new();
-        let mut allowed_git_repos = HashSet::new();
-        let mut disallowed_git_repos = HashSet::new();
+        let mut allowed = BuildKeys::default();
+        let mut disallowed = BuildKeys::default();
         for (spec, &value) in &config.allow_builds {
-            let (git_repos, dep_paths, specs) = if value {
-                (&mut allowed_git_repos, &mut allowed_dep_paths, &mut allowed_specs)
-            } else {
-                (&mut disallowed_git_repos, &mut disallowed_dep_paths, &mut disallowed_specs)
-            };
-            if is_git_repo_allow_build_key(spec) {
-                git_repos.insert(spec.clone());
-            } else if is_dep_path_allow_build_key(spec) {
-                dep_paths.insert(normalize_build_dep_path(spec));
-            } else {
-                specs.push(spec);
-            }
+            if value { &mut allowed } else { &mut disallowed }.add(spec);
         }
-        let expanded_allowed = expand_package_version_specs(allowed_specs)?;
-        let expanded_disallowed = expand_package_version_specs(disallowed_specs)?;
         Ok(Self::new_with_dep_paths(
-            expanded_allowed,
-            expanded_disallowed,
-            allowed_dep_paths,
-            disallowed_dep_paths,
+            expand_package_version_specs(allowed.specs)?,
+            expand_package_version_specs(disallowed.specs)?,
+            allowed.dep_paths,
+            disallowed.dep_paths,
             config.dangerously_allow_all_builds,
         )
-        .with_git_repo_rules(allowed_git_repos, disallowed_git_repos))
+        .with_git_repo_rules(allowed.git_repos, disallowed.git_repos))
     }
 
     #[must_use]
@@ -223,6 +206,26 @@ pub(crate) fn parse_dep_path_name_version(pkg_id: &str) -> Option<(&str, &str)> 
         version = &version[..idx];
     }
     Some((name, version))
+}
+
+/// One side of `allowBuilds`, split by the shape of its keys.
+#[derive(Default)]
+struct BuildKeys<'c> {
+    specs: Vec<&'c str>,
+    dep_paths: HashSet<String>,
+    git_repos: HashSet<String>,
+}
+
+impl<'c> BuildKeys<'c> {
+    fn add(&mut self, spec: &'c str) {
+        if is_git_repo_allow_build_key(spec) {
+            self.git_repos.insert(spec.to_owned());
+        } else if is_dep_path_allow_build_key(spec) {
+            self.dep_paths.insert(normalize_build_dep_path(spec));
+        } else {
+            self.specs.push(spec);
+        }
+    }
 }
 
 pub(crate) fn is_git_repo_allow_build_key(spec: &str) -> bool {

--- a/pnpm/crates/deps-restorer/src/build_modules/allow_build_policy.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules/allow_build_policy.rs
@@ -76,7 +76,8 @@ impl AllowBuildPolicy {
         let mut allowed = BuildKeys::default();
         let mut disallowed = BuildKeys::default();
         for (spec, &value) in &config.allow_builds {
-            if value { &mut allowed } else { &mut disallowed }.add(spec);
+            let keys = if value { &mut allowed } else { &mut disallowed };
+            keys.add(spec);
         }
         Ok(Self::new_with_dep_paths(
             expand_package_version_specs(allowed.specs)?,

--- a/pnpm/crates/deps-restorer/src/build_modules/build_one_snapshot.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules/build_one_snapshot.rs
@@ -69,126 +69,25 @@ pub(crate) fn build_one_snapshot<Reporter: self::Reporter>(
     snapshot_key: &PackageKey,
     context: &BuildOneSnapshot<'_>,
 ) -> Result<(), BuildModulesError> {
-    let &BuildOneSnapshot {
-        snapshots,
-        patches,
-        requires_build_map,
-        side_effects_maps_by_snapshot,
-        engine_name,
-        side_effects_cache,
-        dep_graph,
-        deps_state_cache,
-        layout,
-        pkg_roots_by_key,
-        gather_ancestor_bin_paths,
-        lockfile_dir,
-        rebuild,
-        ..
-    } = context;
-    let metadata_key = snapshot_key.without_peer();
-    // Look up against the peer-stripped key because patches are
-    // configured at the (name, version) granularity in
-    // `pnpm-workspace.yaml`, not per peer-resolution variant.
-    let patch = patches.and_then(|map| map.get(&metadata_key));
-    let has_patch = patch.is_some();
-    let requires_build = requires_build_map.get(snapshot_key).copied().unwrap_or(false);
-
     // Ancestors of a build/patch candidate are included in the
     // sequence (so the topo order stays correct) but only run
     // scripts / apply patches when they themselves are candidates.
-    if !is_build_candidate(requires_build, has_patch) {
+    let Some(candidate) = BuildCandidate::of(context, snapshot_key) else { return Ok(()) };
+    let cache_key = side_effects_cache_key(context, snapshot_key, &candidate);
+    if already_built::<Reporter>(context, snapshot_key, &candidate, cache_key.as_deref())? {
         return Ok(());
     }
 
-    let dep_path = metadata_key.to_string();
-    let (name, version) = parse_name_version_from_key(&dep_path);
-
-    // An explicit `pacquet rebuild` re-runs the build scripts of the
-    // selected packages even when the side-effects cache reports them
-    // already built; `force_rebuild` marks those so they bypass the
-    // `is_built` gate below. The selection holds allow-build keys (the
-    // package name for registry deps, the full pkgId for git/tarball
-    // artifacts), so match either form — a selected non-registry artifact
-    // is forced past the gate too. The allow-policy gate still applies — a
-    // rebuild never builds a disallowed package. Non-selected
-    // packages still run the allow-policy gate below (so their
-    // `.modules.yaml` ignored-builds record stays intact), but their
-    // scripts are suppressed by the rebuild-selection gate after it.
-    let force_rebuild = rebuild_forces_build(rebuild, &name, &dep_path);
-    let should_run_scripts =
-        snapshot_runs_scripts(context, snapshot_key, &dep_path, (requires_build, force_rebuild));
-
-    // Compute the side-effects cache key once per snapshot, before
-    // the `is_built` gate. The same value is later consumed by the
-    // WRITE-path upload call after `run_postinstall_hooks`
-    // succeeds, so recomputing it there would just duplicate work —
-    // `deps_state_cache` makes the second call free anyway, but
-    // routing through one `let` keeps the gate-side and write-side
-    // keys provably identical.
-    //
-    // `None` when the cache gate can't fire (no engine, no graph,
-    // etc.); both downstream consumers short-circuit on `None`.
-    //
-    // The `deps_state_cache` is shared across all scheduled nodes via
-    // `Mutex` because `calc_dep_state` is recursive and memoizes —
-    // a per-task cache would defeat the memoization for
-    // diamond-shaped subgraphs.
-    let cache_key = (dep_graph.zip(engine_name)).map(|(graph, engine)| {
-        // Poison-recover: `calc_dep_state` mutates the cache by
-        // inserting one entry per recursive walk node, each
-        // insert atomic from `HashMap`'s POV. A panic mid-walk
-        // leaves the map in a usable state — the worst case is
-        // an unfinished sub-walk that the next caller will redo.
-        let mut cache_guard =
-            deps_state_cache.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
-        pnpm_graph_hasher::calc_dep_state(
-            graph,
-            &mut cache_guard,
-            snapshot_key,
-            &pnpm_graph_hasher::CalcDepStateOptions {
-                engine_name: engine,
-                // `None` for unpatched snapshots leaves the
-                // `;patch=...` segment off the cache key entirely.
-                patch_file_hash: patch.map(|patch| patch.hash.as_str()),
-                // The deps-graph hash is included only when scripts
-                // will run. A patched-only snapshot leaves it off so
-                // the cache key stays stable across dep-graph changes
-                // that don't affect this package's patched output.
-                include_dep_graph_hash: should_run_scripts,
-            },
-        )
-    });
-
-    // Side-effects-cache `is_built` gate. We're already past the
-    // policy gate, so this snapshot would otherwise run its scripts
-    // — but if the prefetch surfaced a matching side-effects-cache
-    // entry, the build is already represented on disk (seeded on a
-    // previous install) and we can skip. An explicit `pacquet rebuild`
-    // (`force_rebuild`) always re-runs the scripts, so it bypasses
-    // this gate.
-    if !force_rebuild
-        && side_effects_cache
-        && let Some(maps_by_snapshot) = side_effects_maps_by_snapshot
-        && let Some(maps) = maps_by_snapshot.get(snapshot_key)
-        && let Some(key) = cache_key.as_deref()
-        && let Some(overlay) = maps.get(key)
-        && satisfy_from_side_effects_cache::<Reporter>(
-            context,
-            snapshot_key,
-            (key, overlay),
-            (&name, &version),
-        )?
-    {
-        return Ok(());
-    }
-
-    let optional = snapshots.get(snapshot_key).is_some_and(|entry| entry.optional);
-
+    let optional = context.snapshots.get(snapshot_key).is_some_and(|entry| entry.optional);
     if reject_frozen_store_build::<Reporter>(
         context,
         snapshot_key,
-        (&name, &version),
-        &FrozenStoreWrites { optional, has_patch, should_run_scripts },
+        (&candidate.name, &candidate.version),
+        &FrozenStoreWrites {
+            optional,
+            has_patch: candidate.patch.is_some(),
+            should_run_scripts: candidate.should_run_scripts,
+        },
     )? {
         return Ok(());
     }
@@ -196,8 +95,7 @@ pub(crate) fn build_one_snapshot<Reporter: self::Reporter>(
     // Hoisted snapshots without a recorded `pkgRoot` (the walker
     // dropped them — pre-skipped, optional skip, etc.) take the
     // same exit as the isolated path's `!pkg_dir.exists()` skip.
-    let Some(pkg_dir) = PkgRoots { layout, by_key: pkg_roots_by_key }.canonical(snapshot_key)
-    else {
+    let Some(pkg_dir) = context.pkg_roots().canonical(snapshot_key) else {
         return Ok(());
     };
     if !pkg_dir.exists() {
@@ -208,8 +106,8 @@ pub(crate) fn build_one_snapshot<Reporter: self::Reporter>(
     // hoisted gathers every ancestor's `node_modules/.bin` up to
     // `lockfile_dir` so a lifecycle script invoked at a nested
     // hoisted location can resolve bins added by parents.
-    let extra_bin_paths = if gather_ancestor_bin_paths {
-        bin_dirs_in_all_parent_dirs(&pkg_dir, lockfile_dir)
+    let extra_bin_paths = if context.gather_ancestor_bin_paths {
+        bin_dirs_in_all_parent_dirs(&pkg_dir, context.lockfile_dir)
     } else {
         Vec::new()
     };
@@ -219,14 +117,14 @@ pub(crate) fn build_one_snapshot<Reporter: self::Reporter>(
     // error (`PatchFilePathMissing`).
     // `is_patched` feeds the cache-write gate below
     // (`is_patched || has_side_effects`).
-    let is_patched = apply_configured_patch(context, snapshot_key, patch)?;
+    let is_patched = apply_configured_patch(context, snapshot_key, candidate.patch)?;
 
     let Some(has_side_effects) = run_snapshot_scripts::<Reporter>(
         context,
         snapshot_key,
         &pkg_dir,
         &extra_bin_paths,
-        (should_run_scripts, optional, &name, &version),
+        (candidate.should_run_scripts, optional, &candidate.name, &candidate.version),
     )?
     else {
         return Ok(());
@@ -235,23 +133,143 @@ pub(crate) fn build_one_snapshot<Reporter: self::Reporter>(
     clear_global_virtual_store_build_markers(
         context,
         snapshot_key,
-        has_patch || should_run_scripts,
+        candidate.patch.is_some() || candidate.should_run_scripts,
     );
 
     upload_side_effects_cache(
         context,
         snapshot_key,
         &SideEffectsUpload {
-            metadata_key: &metadata_key,
+            metadata_key: &candidate.metadata_key,
             pkg_dir: &pkg_dir,
             cache_key: cache_key.as_deref(),
-            patch,
+            patch: candidate.patch,
             is_patched,
             has_side_effects,
         },
     );
 
     Ok(())
+}
+
+/// A snapshot whose build scripts or patch this install applies, with
+/// what the gates decide from.
+struct BuildCandidate<'c> {
+    metadata_key: PackageKey,
+    /// Looked up against the peer-stripped key because patches are
+    /// configured at the (name, version) granularity in
+    /// `pnpm-workspace.yaml`, not per peer-resolution variant.
+    patch: Option<&'c pnpm_patching::ExtendedPatchInfo>,
+    name: String,
+    version: String,
+    /// An explicit `pacquet rebuild` re-runs the build scripts of the
+    /// selected packages even when the side-effects cache reports them
+    /// already built; this marks those so they bypass the `is_built`
+    /// gate. The selection holds allow-build keys (the package name for
+    /// registry deps, the full pkgId for git/tarball artifacts), so
+    /// either form matches — a selected non-registry artifact is forced
+    /// past the gate too. The allow-policy gate still applies — a
+    /// rebuild never builds a disallowed package. Non-selected packages
+    /// still run the allow-policy gate (so their `.modules.yaml`
+    /// ignored-builds record stays intact), but their scripts are
+    /// suppressed by the rebuild-selection gate after it.
+    force_rebuild: bool,
+    should_run_scripts: bool,
+}
+
+impl<'c> BuildCandidate<'c> {
+    fn of(context: &BuildOneSnapshot<'c>, snapshot_key: &PackageKey) -> Option<Self> {
+        let metadata_key = snapshot_key.without_peer();
+        let patch = context.patches.and_then(|patches| patches.get(&metadata_key));
+        let requires_build = context.requires_build_map.get(snapshot_key).copied().unwrap_or(false);
+        if !is_build_candidate(requires_build, patch.is_some()) {
+            return None;
+        }
+        let dep_path = metadata_key.to_string();
+        let (name, version) = parse_name_version_from_key(&dep_path);
+        let force_rebuild = rebuild_forces_build(context.rebuild, &name, &dep_path);
+        let should_run_scripts = snapshot_runs_scripts(
+            context,
+            snapshot_key,
+            &dep_path,
+            (requires_build, force_rebuild),
+        );
+        Some(Self { metadata_key, patch, name, version, force_rebuild, should_run_scripts })
+    }
+}
+
+/// The side-effects cache key, computed once per snapshot before the
+/// `is_built` gate. The same value is later consumed by the WRITE-path
+/// upload after `run_postinstall_hooks` succeeds, so recomputing it
+/// there would just duplicate work — `deps_state_cache` makes the second
+/// call free anyway, but routing through one value keeps the gate-side
+/// and write-side keys provably identical.
+///
+/// `None` when the cache gate can't fire (no engine, no graph, etc.);
+/// both downstream consumers short-circuit on `None`.
+///
+/// The `deps_state_cache` is shared across all scheduled nodes via
+/// `Mutex` because `calc_dep_state` is recursive and memoizes — a
+/// per-task cache would defeat the memoization for diamond-shaped
+/// subgraphs.
+fn side_effects_cache_key(
+    context: &BuildOneSnapshot<'_>,
+    snapshot_key: &PackageKey,
+    candidate: &BuildCandidate<'_>,
+) -> Option<String> {
+    let (graph, engine) = context.dep_graph.zip(context.engine_name)?;
+    // Poison-recover: `calc_dep_state` mutates the cache by
+    // inserting one entry per recursive walk node, each
+    // insert atomic from `HashMap`'s POV. A panic mid-walk
+    // leaves the map in a usable state — the worst case is
+    // an unfinished sub-walk that the next caller will redo.
+    let mut cache_guard =
+        context.deps_state_cache.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    Some(pnpm_graph_hasher::calc_dep_state(
+        graph,
+        &mut cache_guard,
+        snapshot_key,
+        &pnpm_graph_hasher::CalcDepStateOptions {
+            engine_name: engine,
+            // `None` for unpatched snapshots leaves the
+            // `;patch=...` segment off the cache key entirely.
+            patch_file_hash: candidate.patch.map(|patch| patch.hash.as_str()),
+            // The deps-graph hash is included only when scripts
+            // will run. A patched-only snapshot leaves it off so
+            // the cache key stays stable across dep-graph changes
+            // that don't affect this package's patched output.
+            include_dep_graph_hash: candidate.should_run_scripts,
+        },
+    ))
+}
+
+/// Side-effects-cache `is_built` gate. Past the policy gate, this
+/// snapshot would otherwise run its scripts — but if the prefetch
+/// surfaced a matching side-effects-cache entry, the build is already
+/// represented on disk (seeded on a previous install) and can be
+/// skipped. An explicit `pacquet rebuild` (`force_rebuild`) always
+/// re-runs the scripts, so it bypasses this gate.
+fn already_built<Reporter: self::Reporter>(
+    context: &BuildOneSnapshot<'_>,
+    snapshot_key: &PackageKey,
+    candidate: &BuildCandidate<'_>,
+    cache_key: Option<&str>,
+) -> Result<bool, BuildModulesError> {
+    if !candidate.force_rebuild
+        && context.side_effects_cache
+        && let Some(maps_by_snapshot) = context.side_effects_maps_by_snapshot
+        && let Some(maps) = maps_by_snapshot.get(snapshot_key)
+        && let Some(key) = cache_key
+        && let Some(overlay) = maps.get(key)
+    {
+        return satisfy_from_side_effects_cache::<Reporter>(
+            context,
+            snapshot_key,
+            (key, overlay),
+            (&candidate.name, &candidate.version),
+        );
+    }
+    Ok(false)
 }
 
 /// Whether a side-effects-cache hit already put this snapshot's build output

--- a/pnpm/crates/deps-restorer/src/create_virtual_dir_by_snapshot.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_dir_by_snapshot.rs
@@ -146,125 +146,43 @@ pub enum CreateVirtualDirError {
 impl CreateVirtualDirBySnapshot<'_> {
     /// Execute the subroutine.
     pub fn run<Reporter: self::Reporter>(self) -> Result<(), CreateVirtualDirError> {
-        let CreateVirtualDirBySnapshot {
-            layout,
-            cas_paths,
-            import_method,
-            logged_methods,
-            requester,
-            package_id: _package_id,
-            package_key,
-            snapshot,
-            source_is_mutable,
-            force_import,
-            include_optional_dependencies,
-            symlink,
-            skipped,
-            removed_aliases,
-            needs_build_marker_source,
-            dir_clone_cache,
-            #[cfg(test)]
-            link_concurrency_probe,
-        } = self;
-
         #[cfg(test)]
         let _link_concurrency_guard =
-            link_concurrency_probe.map(tests::LinkConcurrencyProbe::enter);
+            self.link_concurrency_probe.map(tests::LinkConcurrencyProbe::enter);
 
-        let slot_dir = layout.slot_dir(package_key);
-        let virtual_node_modules_dir = slot_dir.join("node_modules");
-        // Two direct `mkdir`s instead of one `create_dir_all` on the
-        // deepest path: the recursive form probes bottom-up with a
-        // failing `mkdir` per missing ancestor before creating them
-        // top-down, which on the APFS-serialized metadata path costs a
-        // large install ~3 extra syscalls per slot. The virtual-store
-        // root exists (steady state) — only its absence falls back to
-        // the recursive form.
-        create_slot_dirs(&slot_dir, &virtual_node_modules_dir)?;
-
-        let save_path =
-            safe_join_modules_dir(&virtual_node_modules_dir, &package_key.name.to_string())
-                .map_err(CreateVirtualDirError::InvalidAlias)?;
-
-        let interrupted_build = save_path.join(NEEDS_BUILD_MARKER).is_file();
+        let slot = SlotPaths::create(self.layout, self.package_key)?;
+        let interrupted_build = slot.save_path.join(NEEDS_BUILD_MARKER).is_file();
         let marked_cas_paths = cas_paths_with_build_marker(
-            cas_paths,
-            &save_path,
-            needs_build_marker_source,
+            self.cas_paths,
+            &slot.save_path,
+            self.needs_build_marker_source,
             interrupted_build,
         );
-        let cas_paths = marked_cas_paths.as_ref().unwrap_or(cas_paths);
-        let import_opts =
-            slot_import_opts(layout, (interrupted_build, source_is_mutable, force_import));
+        let cas_paths = marked_cas_paths.as_ref().unwrap_or(self.cas_paths);
 
-        let import_package = || {
-            // A slot with an interrupted build re-imports with `force`,
-            // which the cache's fresh-destination clone cannot serve.
-            if !interrupted_build
-                && let Some(cache) = dir_clone_cache
-                && cache.try_import::<Reporter>(
-                    logged_methods,
-                    import_method,
-                    package_key,
-                    &save_path,
-                    cas_paths,
-                )
-            {
-                return Ok(());
-            }
-            import_indexed_dir::<Reporter>(
-                logged_methods,
-                import_method,
-                &save_path,
-                cas_paths,
-                import_opts,
-            )
-            .map_err(CreateVirtualDirError::ImportIndexedDir)
-        };
-        if symlink {
+        let import_package =
+            || self.import_slot::<Reporter>(&slot.save_path, cas_paths, interrupted_build);
+        if self.symlink {
             // `rayon::join` runs both closures in parallel on rayon's pool,
             // returning only once both finish. `import_indexed_dir` is itself
             // a rayon par_iter over CAS entries; `create_symlink_layout` is
             // a small serial loop over dep refs.
-            let (cas_result, symlink_result) = rayon::join(import_package, || {
-                create_symlink_layout(
-                    snapshot.dependencies.as_ref(),
-                    snapshot.optional_dependencies.as_ref(),
-                    include_optional_dependencies,
-                    &package_key.name,
-                    skipped,
-                    layout,
-                    &virtual_node_modules_dir,
-                )
-                .map_err(CreateVirtualDirError::SymlinkPackage)
-            });
+            let (cas_result, symlink_result) =
+                rayon::join(import_package, || self.link_children(&slot.node_modules));
             cas_result?;
             symlink_result?;
-            if !include_optional_dependencies {
-                remove_obsolete_children(
-                    &virtual_node_modules_dir,
-                    &package_key.name,
-                    snapshot.optional_dependencies.iter().flatten().map(|(alias, _)| alias),
-                )?;
+            if !self.include_optional_dependencies {
+                self.remove_optional_children(&slot.node_modules)?;
             }
         } else {
             import_package()?;
-            remove_obsolete_children(
-                &virtual_node_modules_dir,
-                &package_key.name,
-                snapshot.dependencies.iter().flat_map(|dependencies| dependencies.keys()).chain(
-                    snapshot
-                        .optional_dependencies
-                        .iter()
-                        .flat_map(|dependencies| dependencies.keys()),
-                ),
-            )?;
+            self.remove_all_children(&slot.node_modules)?;
         }
 
         // Unlink children the package no longer depends on after the
         // package has materialized. The removed aliases are disjoint
         // from the package's own `node_modules/<self>` directory.
-        remove_obsolete_children(&virtual_node_modules_dir, &package_key.name, removed_aliases)?;
+        remove_obsolete_children(&slot.node_modules, &self.package_key.name, self.removed_aliases)?;
 
         // `pnpm:progress imported` fires one event per (resolved +
         // fetched) package once its CAFS import has finished. `to` is
@@ -281,13 +199,106 @@ impl CreateVirtualDirBySnapshot<'_> {
         Reporter::emit(&LogEvent::Progress(ProgressLog {
             level: LogLevel::Debug,
             message: ProgressMessage::Imported {
-                method: optimistic_wire_method(import_method),
-                requester: requester.to_owned(),
-                to: save_path.to_string_lossy().into_owned(),
+                method: optimistic_wire_method(self.import_method),
+                requester: self.requester.to_owned(),
+                to: slot.save_path.to_string_lossy().into_owned(),
             },
         }));
 
         Ok(())
+    }
+
+    fn import_slot<Reporter: self::Reporter>(
+        &self,
+        save_path: &Path,
+        cas_paths: &HashMap<String, PathBuf>,
+        interrupted_build: bool,
+    ) -> Result<(), CreateVirtualDirError> {
+        // A slot with an interrupted build re-imports with `force`,
+        // which the cache's fresh-destination clone cannot serve.
+        if !interrupted_build
+            && let Some(cache) = self.dir_clone_cache
+            && cache.try_import::<Reporter>(
+                self.logged_methods,
+                self.import_method,
+                self.package_key,
+                save_path,
+                cas_paths,
+            )
+        {
+            return Ok(());
+        }
+        import_indexed_dir::<Reporter>(
+            self.logged_methods,
+            self.import_method,
+            save_path,
+            cas_paths,
+            slot_import_opts(
+                self.layout,
+                (interrupted_build, self.source_is_mutable, self.force_import),
+            ),
+        )
+        .map_err(CreateVirtualDirError::ImportIndexedDir)
+    }
+
+    fn link_children(&self, node_modules: &Path) -> Result<(), CreateVirtualDirError> {
+        create_symlink_layout(
+            self.snapshot.dependencies.as_ref(),
+            self.snapshot.optional_dependencies.as_ref(),
+            self.include_optional_dependencies,
+            &self.package_key.name,
+            self.skipped,
+            self.layout,
+            node_modules,
+        )
+        .map_err(CreateVirtualDirError::SymlinkPackage)
+    }
+
+    fn remove_optional_children(&self, node_modules: &Path) -> Result<(), CreateVirtualDirError> {
+        remove_obsolete_children(
+            node_modules,
+            &self.package_key.name,
+            self.snapshot.optional_dependencies.iter().flatten().map(|(alias, _)| alias),
+        )
+    }
+
+    fn remove_all_children(&self, node_modules: &Path) -> Result<(), CreateVirtualDirError> {
+        remove_obsolete_children(
+            node_modules,
+            &self.package_key.name,
+            self.snapshot
+                .dependencies
+                .iter()
+                .flat_map(|dependencies| dependencies.keys())
+                .chain(self.snapshot.optional_dependencies.iter().flat_map(|deps| deps.keys())),
+        )
+    }
+}
+
+/// The slot's directories, created.
+struct SlotPaths {
+    node_modules: PathBuf,
+    save_path: PathBuf,
+}
+
+impl SlotPaths {
+    fn create(
+        layout: &VirtualStoreLayout,
+        package_key: &PackageKey,
+    ) -> Result<Self, CreateVirtualDirError> {
+        let slot_dir = layout.slot_dir(package_key);
+        let node_modules = slot_dir.join("node_modules");
+        // Two direct `mkdir`s instead of one `create_dir_all` on the
+        // deepest path: the recursive form probes bottom-up with a
+        // failing `mkdir` per missing ancestor before creating them
+        // top-down, which on the APFS-serialized metadata path costs a
+        // large install ~3 extra syscalls per slot. The virtual-store
+        // root exists (steady state) — only its absence falls back to
+        // the recursive form.
+        create_slot_dirs(&slot_dir, &node_modules)?;
+        let save_path = safe_join_modules_dir(&node_modules, &package_key.name.to_string())
+            .map_err(CreateVirtualDirError::InvalidAlias)?;
+        Ok(Self { node_modules, save_path })
     }
 }
 

--- a/pnpm/crates/deps-restorer/src/create_virtual_store.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store.rs
@@ -131,7 +131,6 @@ impl CasPrefetch {
         supported_architectures: Option<&pnpm_package_is_installable::SupportedArchitectures>,
         store_context: Option<&CreateVirtualStoreStoreContext<'_>>,
     ) -> Self {
-        let LockfileEntries { packages, snapshots } = entries;
         let store_dir: &'static _ = &config.store_dir;
         // Open the read-only SQLite index once for the whole run instead
         // of per snapshot. Every `InstallPackageBySnapshot` performs a
@@ -157,47 +156,52 @@ impl CasPrefetch {
             .map_or_else(SharedVerifiedFilesCache::default, |context| {
                 Arc::clone(context.verified_files_cache)
             });
-        let cache_keys: HashMap<PackageKey, Result<SnapshotCacheKey, CreateVirtualStoreError>> =
-            match (snapshots, packages) {
-                (Some(snapshots), Some(packages)) => {
-                    let selector = runtime_platform_selector(supported_architectures);
-                    snapshots
-                        .keys()
-                        .map(|snapshot_key| {
-                            let cache_key = snapshot_cache_key(
-                                snapshot_key,
-                                packages,
-                                config.ignore_scripts,
-                                &selector,
-                            );
-                            (snapshot_key.clone(), cache_key)
-                        })
-                        .collect()
-                }
-                _ => HashMap::new(),
-            };
-        // Sorted + deduplicated so `prefetch_cas_paths` doesn't redo
-        // identical SELECT + integrity-check work for peer variants of
-        // one package. Derived leniently over the whole lockfile — the
-        // superset over what the plan pass will keep merely prefetches
-        // a few rows nothing reads.
-        let mut cache_key_refs: Vec<&str> = cache_keys
-            .values()
-            .filter_map(|cache_key| cache_key.as_ref().ok())
-            .filter_map(|cache_key| cache_key.value.as_deref())
-            .collect();
-        cache_key_refs.sort_unstable();
-        cache_key_refs.dedup();
-        let prefetch_keys: Vec<String> = cache_key_refs.into_iter().map(String::from).collect();
+        let cache_keys = derive_cache_keys(config, entries, supported_architectures);
         let task = tokio::spawn(prefetch_cas_paths(
             store_index.clone(),
             store_dir,
-            prefetch_keys,
+            prefetch_keys(&cache_keys),
             config.verify_store_integrity,
             SharedVerifiedFilesCache::clone(&verified_files_cache),
         ));
         CasPrefetch { store_index, verified_files_cache, cache_keys, task }
     }
+}
+
+fn derive_cache_keys(
+    config: &Config,
+    entries: LockfileEntries<'_>,
+    supported_architectures: Option<&pnpm_package_is_installable::SupportedArchitectures>,
+) -> HashMap<PackageKey, Result<SnapshotCacheKey, CreateVirtualStoreError>> {
+    let (Some(snapshots), Some(packages)) = (entries.snapshots, entries.packages) else {
+        return HashMap::new();
+    };
+    let selector = runtime_platform_selector(supported_architectures);
+    snapshots
+        .keys()
+        .map(|snapshot_key| {
+            let cache_key =
+                snapshot_cache_key(snapshot_key, packages, config.ignore_scripts, &selector);
+            (snapshot_key.clone(), cache_key)
+        })
+        .collect()
+}
+
+/// Sorted + deduplicated so `prefetch_cas_paths` doesn't redo identical
+/// SELECT + integrity-check work for peer variants of one package.
+/// Derived leniently over the whole lockfile — the superset over what
+/// the plan pass will keep merely prefetches a few rows nothing reads.
+fn prefetch_keys(
+    cache_keys: &HashMap<PackageKey, Result<SnapshotCacheKey, CreateVirtualStoreError>>,
+) -> Vec<String> {
+    let mut refs: Vec<&str> = cache_keys
+        .values()
+        .filter_map(|cache_key| cache_key.as_ref().ok())
+        .filter_map(|cache_key| cache_key.value.as_deref())
+        .collect();
+    refs.sort_unstable();
+    refs.dedup();
+    refs.into_iter().map(String::from).collect()
 }
 
 /// A snapshot paired with the store-index cache key it is looked up
@@ -1235,67 +1239,69 @@ async fn run_cold_batch<'a, Reporter: self::Reporter>(
     state: &mut ColdBatchState<'_>,
     cold_cas_paths: &mut Vec<ColdCapture<'a>>,
 ) -> Result<(), CreateVirtualStoreError> {
-    let ColdBatch {
-        cold,
-        installer,
-        packages,
-        current_packages,
-        marker_source,
-        removed_aliases_by_key,
-        link_template,
-        shared_packages,
-        is_hoisted,
-    } = batch;
-    if cold.is_empty() {
+    if batch.cold.is_empty() {
         return Ok(());
     }
 
-    let installer = &installer;
-    let mut downloads: FuturesUnordered<_> = cold
+    let batch = &batch;
+    let mut downloads: FuturesUnordered<_> = batch
+        .cold
         .iter()
-        .map(|(snapshot_key, snapshot)| async move {
-            let metadata_key = snapshot_key.without_peer();
-            let metadata = packages.get(&metadata_key).ok_or_else(|| {
-                CreateVirtualStoreError::MissingPackageMetadata {
-                    snapshot_key: snapshot_key.to_string(),
-                    metadata_key: metadata_key.to_string(),
-                }
-            })?;
-            let installed = match installer.run::<Reporter>(snapshot_key, metadata, snapshot).await
-            {
-                Ok(installed) => installed,
-                Err(err) => return swallow_optional_fetch_failure(snapshot_key, snapshot, err),
-            };
-            let crate::InstalledPackage { cas_paths, source_is_mutable } = installed;
-            Ok((
-                None,
-                Some(ColdCapture {
-                    snapshot_key,
-                    snapshot,
-                    requires_build: requires_build_from_cas_paths(&cas_paths),
-                    cas_paths,
-                    source_is_mutable,
-                    force_import: package_content_changed(current_packages, packages, snapshot_key),
-                }),
-            ))
-        })
+        .map(|&(snapshot_key, snapshot)| download_one::<Reporter>(batch, snapshot_key, snapshot))
         .collect();
 
-    let cold_template = LinkSlotsParallel { batch: "cold", ..*link_template };
+    let cold_template = LinkSlotsParallel { batch: "cold", ..*batch.link_template };
     drain_cold_downloads::<Reporter, _>(
         &mut downloads,
         ColdDrain {
-            packages,
-            marker_path: marker_source.map(tempfile::NamedTempFile::path),
-            removed_aliases_by_key,
+            packages: batch.packages,
+            marker_path: batch.marker_source.map(tempfile::NamedTempFile::path),
+            removed_aliases_by_key: batch.removed_aliases_by_key,
             template: &cold_template,
-            shared_packages,
-            is_hoisted,
+            shared_packages: batch.shared_packages,
+            is_hoisted: batch.is_hoisted,
         },
         state,
         cold_cas_paths,
     )
     .await
+}
+
+/// One cold download. A failed optional snapshot lands in the first
+/// slot instead of failing the batch; the second carries what the link
+/// pass still has to place.
+async fn download_one<'a, Reporter: self::Reporter>(
+    batch: &ColdBatch<'a>,
+    snapshot_key: &'a PackageKey,
+    snapshot: &'a SnapshotEntry,
+) -> Result<(Option<PackageKey>, Option<ColdCapture<'a>>), CreateVirtualStoreError> {
+    let metadata_key = snapshot_key.without_peer();
+    let metadata = batch.packages.get(&metadata_key).ok_or_else(|| {
+        CreateVirtualStoreError::MissingPackageMetadata {
+            snapshot_key: snapshot_key.to_string(),
+            metadata_key: metadata_key.to_string(),
+        }
+    })?;
+    let installed = match batch.installer.run::<Reporter>(snapshot_key, metadata, snapshot).await {
+        Ok(installed) => installed,
+        Err(err) => return swallow_optional_fetch_failure(snapshot_key, snapshot, err),
+    };
+    let crate::InstalledPackage { cas_paths, source_is_mutable } = installed;
+    Ok((
+        None,
+        Some(ColdCapture {
+            snapshot_key,
+            snapshot,
+            requires_build: requires_build_from_cas_paths(&cas_paths),
+            cas_paths,
+            source_is_mutable,
+            force_import: package_content_changed(
+                batch.current_packages,
+                batch.packages,
+                snapshot_key,
+            ),
+        }),
+    ))
 }
 
 struct ColdDrain<'a> {
@@ -1513,58 +1519,10 @@ fn link_slots_parallel<Reporter: self::Reporter>(
 ) -> Result<(), CreateVirtualStoreError> {
     use rayon::prelude::*;
 
-    let LinkSlotsParallel {
-        batch,
-        slots,
-        layout,
-        dir_clone_cache,
-        symlink,
-        import_method,
-        logged_methods,
-        requester,
-        skipped,
-        include_optional_dependencies,
-        progress_reported,
-        #[cfg(test)]
-        link_concurrency_probe,
-    } = opts;
-
     let phase_start = std::time::Instant::now();
-    let groups = group_slots_by_dir(slots, layout);
-    let link_work = || {
-        groups.par_iter().try_for_each(|group| {
-            let slot = group.representative;
-            let package_id = slot.snapshot_key.pkg_id();
-            emit_group_warm_progress::<Reporter>(group, requester, progress_reported);
-
-            crate::CreateVirtualDirBySnapshot {
-                layout,
-                cas_paths: slot.cas_paths,
-                import_method,
-                logged_methods,
-                requester,
-                package_id: &package_id,
-                package_key: slot.snapshot_key,
-                snapshot: slot.snapshot,
-                source_is_mutable: slot.source_is_mutable,
-                force_import: slot.force_import,
-                include_optional_dependencies,
-                symlink,
-                skipped,
-                removed_aliases: group.removed_aliases(),
-                needs_build_marker_source: slot.needs_build_marker_source,
-                dir_clone_cache: if slot.dir_clone_cacheable { dir_clone_cache } else { None },
-                #[cfg(test)]
-                link_concurrency_probe,
-            }
-            .run::<Reporter>()
-            .map_err(|error| {
-                CreateVirtualStoreError::InstallPackageBySnapshot(
-                    InstallPackageBySnapshotError::CreateVirtualDir(error),
-                )
-            })
-        })
-    };
+    let groups = group_slots_by_dir(opts.slots, opts.layout);
+    let link_work =
+        || groups.par_iter().try_for_each(|group| link_slot_group::<Reporter>(group, &opts));
     // Driving the link pass from inside an `async fn` means the
     // `par_iter` blocks the calling tokio worker for the duration. On
     // the production multi-thread runtime, `block_in_place` migrates
@@ -1581,14 +1539,50 @@ fn link_slots_parallel<Reporter: self::Reporter>(
     tracing::info!(
         target: "pacquet::install::phase",
         phase = "link_slots",
-        batch,
-        slots = slots.len(),
+        batch = opts.batch,
+        slots = opts.slots.len(),
         unique_dirs = groups.len(),
         elapsed_ms = phase_start.elapsed().as_millis() as u64,
         "phase complete",
     );
 
     Ok(())
+}
+
+fn link_slot_group<Reporter: self::Reporter>(
+    group: &SlotDirGroup<'_>,
+    opts: &LinkSlotsParallel<'_>,
+) -> Result<(), CreateVirtualStoreError> {
+    let slot = group.representative;
+    let package_id = slot.snapshot_key.pkg_id();
+    emit_group_warm_progress::<Reporter>(group, opts.requester, opts.progress_reported);
+
+    crate::CreateVirtualDirBySnapshot {
+        layout: opts.layout,
+        cas_paths: slot.cas_paths,
+        import_method: opts.import_method,
+        logged_methods: opts.logged_methods,
+        requester: opts.requester,
+        package_id: &package_id,
+        package_key: slot.snapshot_key,
+        snapshot: slot.snapshot,
+        source_is_mutable: slot.source_is_mutable,
+        force_import: slot.force_import,
+        include_optional_dependencies: opts.include_optional_dependencies,
+        symlink: opts.symlink,
+        skipped: opts.skipped,
+        removed_aliases: group.removed_aliases(),
+        needs_build_marker_source: slot.needs_build_marker_source,
+        dir_clone_cache: if slot.dir_clone_cacheable { opts.dir_clone_cache } else { None },
+        #[cfg(test)]
+        link_concurrency_probe: opts.link_concurrency_probe,
+    }
+    .run::<Reporter>()
+    .map_err(|error| {
+        CreateVirtualStoreError::InstallPackageBySnapshot(
+            InstallPackageBySnapshotError::CreateVirtualDir(error),
+        )
+    })
 }
 
 fn emit_group_warm_progress<Reporter: self::Reporter>(

--- a/pnpm/crates/deps-restorer/src/create_virtual_store.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store.rs
@@ -352,133 +352,156 @@ pub enum CreateVirtualStoreError {
     },
 }
 
-impl CreateVirtualStore<'_> {
+impl<'a> CreateVirtualStore<'a> {
     /// Execute the subroutine. Returns the set of bundled manifests
     /// recovered from `index.db` for the warm-batch slots — the
     /// bin linker uses these to avoid re-reading `package.json` per
     /// child. See [`PackageManifests`].
     pub async fn run<Reporter: self::Reporter>(
-        self,
+        mut self,
     ) -> Result<CreateVirtualStoreOutput, CreateVirtualStoreError> {
-        let CreateVirtualStore {
-            http_client,
-            ctx,
-            entries,
-            current_entries,
-            store_index_writer,
-            store_context,
-            cas_prefetch,
-            skipped,
-            include_optional_dependencies,
-            supported_architectures,
-            dir_clone_cache,
-            progress_reported,
-            tarball_mem_cache,
-            custom_fetcher_session,
-            planned_canonical_fetches,
-            #[cfg(test)]
-            link_concurrency_probe,
-        } = self;
-        let &crate::InstallContext {
-            config,
-            requester,
-            layout,
-            node_linker,
-            allow_build_policy,
-            logged_methods,
-            ..
-        } = ctx;
-        let LockfileEntries { packages, snapshots } = entries;
-        let LockfileEntries { packages: current_packages, snapshots: current_snapshots } =
-            current_entries;
-
-        let is_hoisted = matches!(node_linker, NodeLinker::Hoisted);
-        let runtime_platform_selector = runtime_platform_selector(supported_architectures);
-
-        let Some(snapshots) = snapshots else {
-            // No snapshots to install. If the lockfile also has no project deps
-            // this is a valid no-op; if it does, pnpm would have populated
-            // `snapshots`, so bailing out here is safe enough for v9.
-            return Ok(nothing_to_materialize(is_hoisted));
+        let Some(wanted) = self.wanted()? else {
+            return Ok(nothing_to_materialize(self.is_hoisted()));
         };
-        let packages = packages.ok_or(CreateVirtualStoreError::MissingPackagesSection)?;
+        let prefetch = self.prefetch(wanted).await;
+        let marker_source = self.prepare_store().await?;
+        let mut plan = self.plan::<Reporter>(wanted, prefetch.cache_keys)?;
+        let prefetched = self.settle_prefetch(prefetch.task, wanted.packages, &mut plan).await?;
+        let mut partition = partition::partition_snapshots(
+            &plan.survivors,
+            &plan.skipped_entries,
+            &prefetched,
+            &plan.marker_rebuilds,
+            self.ctx.node_linker,
+        );
 
-        // The prefetch carries the run's store handles — the shared
-        // read-only index and the install-scoped `verifiedFilesCache`
-        // (one `Arc<DashSet>` per install, so a CAFS path verified for
-        // one snapshot is not re-stat'd for another) — plus the derived
-        // cache keys and the in-flight lookup task.
-        let CasPrefetch {
-            store_index,
-            verified_files_cache,
-            cache_keys: mut snapshot_cache_keys,
-            task: prefetch_task,
-        } = match cas_prefetch {
-            Some(cas_prefetch) => cas_prefetch,
+        // Publish the cold-batch fetch plan for the concurrent
+        // verification fan-out: every cold registry-resolved snapshot
+        // with a pinned hash is downloaded from its canonical registry
+        // URL by this run (or fails the install / is dropped as an
+        // uninstallable optional), which is the existence evidence the
+        // npm verifier's age gate may substitute for a metadata body.
+        // First fill wins; entries outside the plan keep the
+        // metadata-backed path.
+        publish_planned_canonical_fetches(
+            self.planned_canonical_fetches,
+            &partition.cold,
+            wanted.packages,
+            self.custom_fetcher_session.is_some(),
+        );
+
+        let links = self.link_plan(&plan);
+        let mut indexes =
+            CasIndexes::warm(links.shared_packages.as_ref(), &partition.warm, self.is_hoisted());
+        self.link_warm::<Reporter>(
+            wanted,
+            &partition,
+            &links,
+            marker_source.as_ref().map(tempfile::NamedTempFile::path),
+        )?;
+        let fetch_failed = self
+            .download_cold::<Reporter>(
+                ColdInputs {
+                    wanted,
+                    store: CreateVirtualStoreStoreContext {
+                        index: prefetch.store_index.as_ref(),
+                        verified_files_cache: &prefetch.verified_files_cache,
+                    },
+                    prefetched: &prefetched,
+                    marker_source: marker_source.as_ref(),
+                    links: &links,
+                },
+                &mut partition,
+                &mut indexes,
+            )
+            .await?;
+        self.apply_side_effects(wanted, &mut partition, &indexes.shared_base).await;
+
+        // The writer is owned by the caller now. They drop their
+        // sender and await the join handle after the build phase
+        // finishes, so the final batch flushes after every queued
+        // row from both the download path and the WRITE-path
+        // upload.
+
+        Ok(CreateVirtualStoreOutput {
+            package_manifests: partition.package_manifests,
+            side_effects_maps_by_snapshot: partition.side_effects_maps_by_snapshot,
+            requires_build_by_snapshot: partition.requires_build_by_snapshot,
+            materialized_snapshots: plan.materialized_keys(),
+            fetch_failed,
+            cas_paths_by_pkg_id: indexes.by_pkg_id,
+        })
+    }
+
+    fn is_hoisted(&self) -> bool {
+        matches!(self.ctx.node_linker, NodeLinker::Hoisted)
+    }
+
+    fn wanted(&self) -> Result<Option<WantedEntries<'a>>, CreateVirtualStoreError> {
+        // No snapshots to install. If the lockfile also has no project deps
+        // this is a valid no-op; if it does, pnpm would have populated
+        // `snapshots`, so bailing out here is safe enough for v9.
+        let Some(snapshots) = self.entries.snapshots else { return Ok(None) };
+        let packages =
+            self.entries.packages.ok_or(CreateVirtualStoreError::MissingPackagesSection)?;
+        Ok(Some(WantedEntries { packages, snapshots }))
+    }
+
+    async fn prefetch(&mut self, wanted: WantedEntries<'a>) -> CasPrefetch {
+        match self.cas_prefetch.take() {
+            Some(prefetch) => prefetch,
             None => {
                 CasPrefetch::start(
-                    config,
-                    LockfileEntries { packages: Some(packages), snapshots: Some(snapshots) },
-                    supported_architectures,
-                    store_context.as_ref(),
+                    self.ctx.config,
+                    LockfileEntries {
+                        packages: Some(wanted.packages),
+                        snapshots: Some(wanted.snapshots),
+                    },
+                    self.supported_architectures,
+                    self.store_context.as_ref(),
                 )
                 .await
             }
-        };
-        let store_dir: &'static _ = &config.store_dir;
+        }
+    }
 
-        // Eagerly create `files/00..ff` under the v11 store root so per-
-        // tarball CAFS writes never pay a `create_dir_all` syscall on the
-        // hot path.
-        // See [`init_store_dir_best_effort`] for the error-degradation
-        // policy shared with `install_without_lockfile.rs`. Skipped under
-        // `frozenStore`: the store is read-only and complete, so no
-        // directory creation is attempted under its root.
-        if store_context.is_none() {
+    async fn prepare_store(
+        &self,
+    ) -> Result<Option<tempfile::NamedTempFile>, CreateVirtualStoreError> {
+        let config = self.ctx.config;
+        let store_dir: &'static _ = &config.store_dir;
+        if self.store_context.is_none() {
             init_store_dir_unless_frozen(config, store_dir).await;
         }
+        create_build_marker_source(config, self.ctx.layout, store_dir)
+    }
 
-        let needs_build_marker_source = create_build_marker_source(config, layout, store_dir)?;
-
-        let store_index_ref = store_index.as_ref();
-
-        // The batched store-index writer is owned by the caller
-        // (`InstallFrozenLockfile::run`) so it survives past
-        // `CreateVirtualStore::run` and gets reused by the build
-        // phase's side-effects-cache WRITE path, which queues rows
-        // after the install path finishes.
-        //
-        // The cold-batch download path uses the same writer through
-        // `InstallPackageBySnapshot.store_index_writer`.
-        let store_index_writer_ref = Some(store_index_writer);
-
-        // The plan pass consumes the keys [`CasPrefetch::start`]
-        // derived (one per snapshot, kept as `Result`s so the
-        // strict/lenient asymmetry documented on `plan_snapshots`
-        // survives the early derivation), stashing each survivor's key
-        // alongside its `(snapshot_key, snapshot)` tuple for the
-        // warm/cold partition below. Its slot probes run while the
-        // prefetch task reads the store index.
-        let snapshot_plan::SnapshotPlan {
-            survivors: mut snapshot_entries,
-            skipped_entries,
-            marker_rebuilds,
-            has_git_hosted_survivor,
-        } = snapshot_plan::plan_snapshots::<Reporter>(snapshot_plan::SnapshotPlanInputs {
-            snapshots,
-            packages,
-            current_entries,
-            layout,
-            allow_build_policy,
-            skipped,
-            link_dependencies: !is_hoisted && config.symlink,
+    /// The plan pass consumes the keys [`CasPrefetch::start`] derived
+    /// (one per snapshot, kept as `Result`s so the strict/lenient
+    /// asymmetry documented on `plan_snapshots` survives the early
+    /// derivation), stashing each survivor's key alongside its
+    /// `(snapshot_key, snapshot)` tuple for the warm/cold partition.
+    /// Its slot probes run while the prefetch task reads the store
+    /// index.
+    fn plan<Reporter: self::Reporter>(
+        &self,
+        wanted: WantedEntries<'a>,
+        mut cache_keys: HashMap<PackageKey, Result<SnapshotCacheKey, CreateVirtualStoreError>>,
+    ) -> Result<snapshot_plan::SnapshotPlan<'a>, CreateVirtualStoreError> {
+        let config = self.ctx.config;
+        let plan = snapshot_plan::plan_snapshots::<Reporter>(snapshot_plan::SnapshotPlanInputs {
+            snapshots: wanted.snapshots,
+            packages: wanted.packages,
+            current_entries: self.current_entries,
+            layout: self.ctx.layout,
+            allow_build_policy: self.ctx.allow_build_policy,
+            skipped: self.skipped,
+            link_dependencies: !self.is_hoisted() && config.symlink,
             force: config.force,
-            is_hoisted,
-            include_optional_dependencies,
-            cache_keys: &mut snapshot_cache_keys,
+            is_hoisted: self.is_hoisted(),
+            include_optional_dependencies: self.include_optional_dependencies,
+            cache_keys: &mut cache_keys,
         })?;
-        let materialized_snapshots =
-            snapshot_entries.iter().map(|(snapshot_key, _, _)| (*snapshot_key).clone()).collect();
 
         // `pnpm:stats added` fires one event per project once the
         // orchestrator has decided how many packages will land in the
@@ -493,15 +516,23 @@ impl CreateVirtualStore<'_> {
         Reporter::emit(&LogEvent::Stats(StatsLog {
             level: LogLevel::Debug,
             message: StatsMessage::Added {
-                prefix: requester.to_owned(),
-                added: snapshot_entries.len() as u64,
+                prefix: self.ctx.requester.to_owned(),
+                added: plan.survivors.len() as u64,
             },
         }));
+        Ok(plan)
+    }
 
-        // A joined-task failure degrades to an empty result: every
-        // lookup misses and the snapshots fall through to their
-        // per-snapshot path, the same shape as a store with no index.
-        let prefetch = prefetch_task.await.unwrap_or_else(|error| {
+    /// A joined-task failure degrades to an empty result: every lookup
+    /// misses and the snapshots fall through to their per-snapshot
+    /// path, the same shape as a store with no index.
+    async fn settle_prefetch(
+        &self,
+        task: tokio::task::JoinHandle<PrefetchResult>,
+        packages: &HashMap<PackageKey, PackageMetadata>,
+        plan: &mut snapshot_plan::SnapshotPlan<'_>,
+    ) -> Result<PrefetchResult, CreateVirtualStoreError> {
+        let prefetch = task.await.unwrap_or_else(|error| {
             tracing::warn!(
                 target: "pacquet::install",
                 ?error,
@@ -510,221 +541,216 @@ impl CreateVirtualStore<'_> {
             PrefetchResult::default()
         });
         enforce_cached_git_prepare_policy(
-            &mut snapshot_entries,
+            &mut plan.survivors,
             packages,
             &prefetch,
-            allow_build_policy,
-            config.ignore_scripts,
-            has_git_hosted_survivor,
+            self.ctx.allow_build_policy,
+            self.ctx.config.ignore_scripts,
+            plan.has_git_hosted_survivor,
         )?;
-        let partition::Partition {
-            warm,
-            cold,
-            package_manifests,
-            mut side_effects_maps_by_snapshot,
-            side_effects_by_snapshot,
-            remote_side_effects_quarantine_by_snapshot,
-            store_index_keys_by_snapshot,
-            mut requires_build_by_snapshot,
-        } = partition::partition_snapshots(
-            &snapshot_entries,
-            &skipped_entries,
-            &prefetch,
-            &marker_rebuilds,
-            node_linker,
-        );
-        let shared_packages = config
-            .remote_side_effects_cache
-            .as_ref()
-            .map(|settings| settings.packages.iter().map(String::as_str).collect::<HashSet<_>>());
-        let mut shared_base_cas_paths = warm_shared_base_cas_paths(shared_packages.as_ref(), &warm);
+        Ok(prefetch)
+    }
 
-        // Publish the cold-batch fetch plan for the concurrent
-        // verification fan-out: every cold registry-resolved snapshot
-        // with a pinned hash is downloaded from its canonical registry
-        // URL by this run (or fails the install / is dropped as an
-        // uninstallable optional), which is the existence evidence the
-        // npm verifier's age gate may substitute for a metadata body.
-        // First fill wins; entries outside the plan keep the
-        // metadata-backed path.
-        publish_planned_canonical_fetches(
-            planned_canonical_fetches,
-            &cold,
-            packages,
-            custom_fetcher_session.is_some(),
-        );
-
-        // Hoisted-mode CAS index assembly. Collected here, *before*
-        // the warm-batch closure consumes `warm` under the
-        // isolated branch below, so the borrow checker doesn't
-        // need to reason across the two branches. Cold-batch
-        // entries are appended at the bottom of the function once
-        // the cold-batch fetch finishes.
-        let mut cas_paths_by_pkg_id = is_hoisted.then(|| warm_cas_paths_by_pkg_id(&warm));
-
-        // Per-slot obsolete child aliases for the link pass. Only
-        // survivors that already existed in `current_snapshots` and
-        // dropped a child contribute an entry; fresh packages and
-        // addition-only changes map to the empty slice. Computed once
-        // here so both the warm and cold `SlotLink` batches can borrow
-        // it.
-        let removed_aliases_by_key = removed_aliases_by_key(current_snapshots, &snapshot_entries);
-
-        let import_method = config.package_import_method;
-        let link_template = LinkSlotsParallel {
-            batch: "warm",
-            slots: &[],
-            layout,
-            dir_clone_cache,
-            symlink: config.symlink,
-            import_method,
-            logged_methods,
-            requester,
-            skipped,
-            include_optional_dependencies,
-            progress_reported,
-            #[cfg(test)]
-            link_concurrency_probe,
-        };
-        link_warm_batch::<Reporter>(
-            &warm,
-            &WarmLinkBatch {
-                packages,
-                current_packages,
-                is_hoisted,
-                needs_build_marker_source: needs_build_marker_source
-                    .as_ref()
-                    .map(tempfile::NamedTempFile::path),
-                removed_aliases_by_key: &removed_aliases_by_key,
-                template: &link_template,
+    fn link_plan(&self, plan: &snapshot_plan::SnapshotPlan<'_>) -> LinkPlan<'a> {
+        let config = self.ctx.config;
+        LinkPlan {
+            removed_aliases_by_key: removed_aliases_by_key(
+                self.current_entries.snapshots,
+                &plan.survivors,
+            ),
+            shared_packages: config
+                .remote_side_effects_cache
+                .as_ref()
+                .map(|settings| settings.packages.iter().map(String::as_str).collect()),
+            template: LinkSlotsParallel {
+                batch: "warm",
+                slots: &[],
+                layout: self.ctx.layout,
+                dir_clone_cache: self.dir_clone_cache,
+                symlink: config.symlink,
+                import_method: config.package_import_method,
+                logged_methods: self.ctx.logged_methods,
+                requester: self.ctx.requester,
+                skipped: self.skipped,
+                include_optional_dependencies: self.include_optional_dependencies,
+                progress_reported: self.progress_reported,
+                #[cfg(test)]
+                link_concurrency_probe: self.link_concurrency_probe,
             },
-        )?;
+        }
+    }
 
-        // Cold batch: snapshots that didn't prefetch — fall through to the
-        // existing tokio + download path.
-        //
-        // Per-snapshot result is `(Option<PackageKey>, Option<HashMap>)`:
-        // - `Some(key)` in the first slot flags a fetch/extract failure
-        //   that was silently swallowed because the snapshot is
-        //   `optional: true` — an optional snapshot whose fetch fails is
-        //   dropped rather than aborting the install.
-        //   Aggregated into `fetch_failed` for the caller to fold into
-        //   its [`crate::SkippedSnapshots`] so downstream walkers
-        //   (`build_graph`, `link_bins`, hoist) treat the snapshot
-        //   as absent.
-        // - The second slot is the per-snapshot CAS index returned by
-        //   [`InstallPackageBySnapshot::run`], threaded into
-        //   `cas_paths_by_pkg_id` under hoisted (the linker consumes
-        //   it directly). `None` for the isolated linker — its
-        //   per-slot import has already happened by the time the
-        //   future returns; under hoisted no slot was written and the
-        //   CAS index is the only output.
-        let mut fetch_failed: HashSet<PackageKey> = HashSet::new();
-        let mut cold_cas_paths: Vec<ColdCapture<'_>> = Vec::new();
+    fn link_warm<Reporter: self::Reporter>(
+        &self,
+        wanted: WantedEntries<'a>,
+        partition: &partition::Partition<'_>,
+        links: &LinkPlan<'_>,
+        marker_source: Option<&Path>,
+    ) -> Result<(), CreateVirtualStoreError> {
+        link_warm_batch::<Reporter>(
+            &partition.warm,
+            &WarmLinkBatch {
+                packages: wanted.packages,
+                current_packages: self.current_entries.packages,
+                is_hoisted: self.is_hoisted(),
+                needs_build_marker_source: marker_source,
+                removed_aliases_by_key: &links.removed_aliases_by_key,
+                template: &links.template,
+            },
+        )
+    }
+
+    /// Snapshots that did not prefetch fall through to the tokio +
+    /// download path. An optional snapshot whose fetch fails is dropped
+    /// rather than aborting the install; the returned set holds those
+    /// keys for the caller to fold into its [`crate::SkippedSnapshots`],
+    /// so downstream walkers (`build_graph`, `link_bins`, hoist) treat
+    /// the snapshot as absent. Under the hoisted linker no slot is
+    /// written and each download's CAS index is the only output, folded
+    /// into [`CasIndexes::by_pkg_id`]; the isolated linker's slot import
+    /// has already happened by the time the download future returns.
+    async fn download_cold<Reporter: self::Reporter>(
+        &self,
+        inputs: ColdInputs<'_, 'a>,
+        partition: &mut partition::Partition<'_>,
+        indexes: &mut CasIndexes,
+    ) -> Result<HashSet<PackageKey>, CreateVirtualStoreError> {
+        let runtime_platform_selector = runtime_platform_selector(self.supported_architectures);
+        let mut fetch_failed = HashSet::new();
+        let mut cold_cas_paths = Vec::new();
         run_cold_batch::<Reporter>(
             ColdBatch {
-                cold: &cold,
+                cold: &partition.cold,
                 // Install-scoped, so it is built once for the whole
                 // batch; only the snapshot varies per download.
                 installer: InstallPackageBySnapshot {
-                    ctx,
-                    http_client,
-                    store_index: store_index_ref,
-                    store_index_writer: store_index_writer_ref,
-                    prefetched_cas_paths: Some(&prefetch.cas_paths),
-                    tarball_mem_cache,
-                    progress_reported: Some(progress_reported),
-                    verified_files_cache: &verified_files_cache,
-                    skipped,
-                    include_optional_dependencies,
+                    ctx: self.ctx,
+                    http_client: self.http_client,
+                    store_index: inputs.store.index,
+                    store_index_writer: Some(self.store_index_writer),
+                    prefetched_cas_paths: Some(&inputs.prefetched.cas_paths),
+                    tarball_mem_cache: self.tarball_mem_cache,
+                    progress_reported: Some(self.progress_reported),
+                    verified_files_cache: inputs.store.verified_files_cache,
+                    skipped: self.skipped,
+                    include_optional_dependencies: self.include_optional_dependencies,
                     runtime_platform_selector: &runtime_platform_selector,
-                    custom_fetcher_session,
+                    custom_fetcher_session: self.custom_fetcher_session,
                     // The slot link is deferred to the parallel pass in
                     // `drain_cold_downloads` so it doesn't serialize
                     // inside this cooperative task.
                     defer_link: true,
                     #[cfg(test)]
-                    link_concurrency_probe,
+                    link_concurrency_probe: self.link_concurrency_probe,
                 },
-                packages,
-                current_packages,
-                marker_source: needs_build_marker_source.as_ref(),
-                removed_aliases_by_key: &removed_aliases_by_key,
-                link_template: &link_template,
-                shared_packages: shared_packages.as_ref(),
-                is_hoisted,
+                packages: inputs.wanted.packages,
+                current_packages: self.current_entries.packages,
+                marker_source: inputs.marker_source,
+                removed_aliases_by_key: &inputs.links.removed_aliases_by_key,
+                link_template: &inputs.links.template,
+                shared_packages: inputs.links.shared_packages.as_ref(),
+                is_hoisted: self.is_hoisted(),
             },
             &mut ColdBatchState {
                 fetch_failed: &mut fetch_failed,
-                requires_build_by_snapshot: &mut requires_build_by_snapshot,
-                shared_base_cas_paths: &mut shared_base_cas_paths,
+                requires_build_by_snapshot: &mut partition.requires_build_by_snapshot,
+                shared_base_cas_paths: &mut indexes.shared_base,
             },
             &mut cold_cas_paths,
         )
         .await?;
+        indexes.add_cold(cold_cas_paths);
+        Ok(fetch_failed)
+    }
 
+    async fn apply_side_effects(
+        &self,
+        wanted: WantedEntries<'a>,
+        partition: &mut partition::Partition<'_>,
+        base_cas_paths: &crate::shared_side_effects::BaseCasPaths,
+    ) {
         crate::shared_side_effects::apply_shared_side_effects(
             crate::shared_side_effects::ApplySharedSideEffectsOptions {
-                config,
-                snapshots,
-                packages,
-                requires_build_by_snapshot: &requires_build_by_snapshot,
-                allow_build_policy,
-                base_cas_paths: &shared_base_cas_paths,
-                side_effects_maps_by_snapshot: &mut side_effects_maps_by_snapshot,
-                side_effects_by_snapshot: &side_effects_by_snapshot,
-                remote_side_effects_quarantine_by_snapshot:
-                    &remote_side_effects_quarantine_by_snapshot,
-                store_index_keys_by_snapshot: &store_index_keys_by_snapshot,
-                store_index_writer,
+                config: self.ctx.config,
+                snapshots: wanted.snapshots,
+                packages: wanted.packages,
+                requires_build_by_snapshot: &partition.requires_build_by_snapshot,
+                allow_build_policy: self.ctx.allow_build_policy,
+                base_cas_paths,
+                side_effects_maps_by_snapshot: &mut partition.side_effects_maps_by_snapshot,
+                side_effects_by_snapshot: &partition.side_effects_by_snapshot,
+                remote_side_effects_quarantine_by_snapshot: &partition
+                    .remote_side_effects_quarantine_by_snapshot,
+                store_index_keys_by_snapshot: &partition.store_index_keys_by_snapshot,
+                store_index_writer: self.store_index_writer,
             },
         )
         .await;
-
-        // Build the per-pkg CAS index when the install is targeting
-        // the hoisted linker. Pacquet's fetcher and walker run
-        // independently, so the CAS index is collected here and
-        // handed to the linker in [`crate::link_hoisted_modules()`]
-        // through this output field.
-        //
-        // Key shape: [`PkgIdWithPatchHash`] mirrors the
-        // `pkg_id_with_patch_hash` field that the slice 4 walker
-        // assigns to each [`crate::DependenciesGraphNode`] (see
-        // [`crate::hoisted_dep_graph`]). Until pacquet has end-to-end
-        // patch support, the value equals the snapshot key including
-        // any peer suffix; that matches what the walker writes, so
-        // `<linker>.cas_paths_by_pkg_id.get(&node.pkg_id_with_patch_hash)`
-        // hits.
-        //
-        // Peer-variants of the same package share a single
-        // [`std::sync::Arc<HashMap>`] in the warm batch (see
-        // `package_manifests` at the loop above for the same Arc
-        // sharing pattern). The linker takes an owned
-        // `HashMap<String, PathBuf>` per package, so each variant
-        // gets a (cheap) clone of the underlying map — `PathBuf`
-        // clones are short string copies, and the per-variant
-        // duplication only matters when the lockfile has many
-        // peer-resolved variants, which is a small fraction of any
-        // real install.
-        if let Some(map) = cas_paths_by_pkg_id.as_mut() {
-            add_cold_cas_paths(map, cold_cas_paths);
-        }
-
-        // The writer is owned by the caller now. They drop their
-        // sender and await the join handle after the build phase
-        // finishes, so the final batch flushes after every queued
-        // row from both the download path and the WRITE-path
-        // upload.
-
-        Ok(CreateVirtualStoreOutput {
-            package_manifests,
-            side_effects_maps_by_snapshot,
-            requires_build_by_snapshot,
-            materialized_snapshots,
-            fetch_failed,
-            cas_paths_by_pkg_id,
-        })
     }
+}
+
+/// The wanted lockfile's two sections, once both are known to exist.
+#[derive(Clone, Copy)]
+struct WantedEntries<'a> {
+    packages: &'a HashMap<PackageKey, PackageMetadata>,
+    snapshots: &'a HashMap<PackageKey, SnapshotEntry>,
+}
+
+/// What the warm and cold link batches share beyond their slots.
+struct LinkPlan<'a> {
+    /// Per-slot obsolete child aliases. Only survivors that already
+    /// existed in the current lockfile and dropped a child contribute an
+    /// entry; fresh packages and addition-only changes map to the empty
+    /// slice.
+    removed_aliases_by_key: HashMap<PackageKey, Vec<PkgName>>,
+    template: LinkSlotsParallel<'a>,
+    /// The packages the remote side-effects cache shares, when it is
+    /// configured.
+    shared_packages: Option<HashSet<&'a str>>,
+}
+
+/// The CAS indexes the two batches fill in.
+struct CasIndexes {
+    /// Base paths of the shared side-effects packages, for the apply
+    /// pass.
+    shared_base: crate::shared_side_effects::BaseCasPaths,
+    /// Built only for the hoisted linker, which materializes
+    /// `node_modules/` straight from these paths — see
+    /// [`CreateVirtualStoreOutput::cas_paths_by_pkg_id`]. Keyed by
+    /// [`PkgIdWithPatchHash`], the key the walker assigns each
+    /// [`crate::DependenciesGraphNode`]; until pacquet has end-to-end
+    /// patch support that equals the snapshot key including any peer
+    /// suffix. Peer variants of one package share a single `Arc`ed map
+    /// in the warm batch, and each gets a cheap clone here because the
+    /// linker takes an owned map per package.
+    by_pkg_id: Option<CasPathsByPkgId>,
+}
+
+impl CasIndexes {
+    fn warm(
+        shared_packages: Option<&HashSet<&str>>,
+        warm: &[partition::WarmEntry<'_>],
+        is_hoisted: bool,
+    ) -> Self {
+        Self {
+            shared_base: warm_shared_base_cas_paths(shared_packages, warm),
+            by_pkg_id: is_hoisted.then(|| warm_cas_paths_by_pkg_id(warm)),
+        }
+    }
+
+    fn add_cold(&mut self, cold: Vec<ColdCapture<'_>>) {
+        if let Some(map) = self.by_pkg_id.as_mut() {
+            add_cold_cas_paths(map, cold);
+        }
+    }
+}
+
+struct ColdInputs<'i, 'a> {
+    wanted: WantedEntries<'a>,
+    store: CreateVirtualStoreStoreContext<'i>,
+    prefetched: &'i PrefetchResult,
+    marker_source: Option<&'i tempfile::NamedTempFile>,
+    links: &'i LinkPlan<'a>,
 }
 
 /// Look up the obsolete child aliases for a slot, defaulting to an
@@ -941,8 +967,6 @@ impl SlotDirGroup<'_> {
     }
 }
 
-/// Group `slots` by [`crate::VirtualStoreLayout::slot_dir`], preserving
-/// first-occurrence order.
 /// Eagerly create `files/00..ff` under the v11 store root so per-tarball CAFS
 /// writes never pay a `create_dir_all` syscall on the hot path. See
 /// [`init_store_dir_best_effort`] for the error-degradation policy shared with
@@ -1365,6 +1389,8 @@ fn record_cold_outcome<'a>(
     Some(captured)
 }
 
+/// Group `slots` by [`crate::VirtualStoreLayout::slot_dir`], preserving
+/// first-occurrence order.
 fn group_slots_by_dir<'a>(
     slots: &'a [SlotLink<'a>],
     layout: &crate::VirtualStoreLayout,

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/partition.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/partition.rs
@@ -58,8 +58,6 @@ pub(super) fn partition_snapshots<'a>(
     marker_rebuilds: &HashSet<PackageKey>,
     node_linker: NodeLinker,
 ) -> Partition<'a> {
-    let PrefetchResult { cas_paths: prefetched, .. } = prefetch;
-
     // The warm batch runs on rayon rather than per-snapshot tokio
     // futures. Profiled at 1352 prefetched / 0 cold on a 10-core Mac:
     // each future's sync `rayon::join` pinned a tokio worker and
@@ -77,29 +75,17 @@ pub(super) fn partition_snapshots<'a>(
     // the shape the bin linker looks up by.
     let mut rows = IndexRows::with_capacity_for(prefetch);
 
-    for (snapshot_key, _snapshot, cache_key) in skipped_entries {
-        rows.absorb(snapshot_key, cache_key.as_deref(), prefetch, marker_rebuilds);
+    for entry in skipped_entries {
+        rows.absorb(entry, prefetch, marker_rebuilds);
     }
 
     // Second pass: survivors, which additionally take the warm/cold
     // partition that decides which snapshots run the link work.
-    for (snapshot_key, snapshot, cache_key) in snapshot_entries {
-        rows.absorb(snapshot_key, cache_key.as_deref(), prefetch, marker_rebuilds);
-        // Carry the cache key alongside the warm entry so the
-        // reporter can skip a duplicate package-status event when
-        // a resolve-time prefetch already emitted it.
-        match cache_key.as_deref().and_then(|key| prefetched.get(key).map(|paths| (key, paths))) {
-            Some((key, cas_paths)) => warm.push((
-                *snapshot_key,
-                *snapshot,
-                cas_paths,
-                key,
-                snapshot_needs_build_marker(
-                    snapshot_key,
-                    rows.requires_build_by_snapshot.get(*snapshot_key).copied().unwrap_or(false),
-                ),
-            )),
-            None => cold.push((*snapshot_key, *snapshot)),
+    for entry in snapshot_entries {
+        rows.absorb(entry, prefetch, marker_rebuilds);
+        match rows.warm_entry(entry, prefetch) {
+            Some(warm_entry) => warm.push(warm_entry),
+            None => cold.push((entry.0, entry.1)),
         }
     }
     tracing::info!(
@@ -112,24 +98,7 @@ pub(super) fn partition_snapshots<'a>(
         node_linker = ?node_linker,
         "phase complete",
     );
-    let IndexRows {
-        package_manifests,
-        side_effects_maps_by_snapshot,
-        side_effects_by_snapshot,
-        remote_side_effects_quarantine_by_snapshot,
-        store_index_keys_by_snapshot,
-        requires_build_by_snapshot,
-    } = rows;
-    Partition {
-        warm,
-        cold,
-        package_manifests,
-        side_effects_maps_by_snapshot,
-        side_effects_by_snapshot,
-        remote_side_effects_quarantine_by_snapshot,
-        store_index_keys_by_snapshot,
-        requires_build_by_snapshot,
-    }
+    rows.into_partition(warm, cold)
 }
 
 /// The store-index rows the build and bin phases read, accumulated
@@ -163,12 +132,12 @@ impl IndexRows {
     /// never diverge in what they contribute.
     fn absorb(
         &mut self,
-        snapshot_key: &PackageKey,
-        cache_key: Option<&str>,
+        entry: &SnapshotWithCacheKey<'_>,
         prefetch: &PrefetchResult,
         marker_rebuilds: &HashSet<PackageKey>,
     ) {
-        let Some(cache_key) = cache_key else { return };
+        let snapshot_key = entry.0;
+        let Some(cache_key) = entry.2.as_deref() else { return };
         self.store_index_keys_by_snapshot.insert(snapshot_key.clone(), cache_key.to_string());
         if let Some(manifest) = prefetch.manifests.get(cache_key) {
             self.package_manifests
@@ -193,6 +162,47 @@ impl IndexRows {
         }
         if let Some(&requires_build) = prefetch.requires_build.get(cache_key) {
             self.requires_build_by_snapshot.insert(snapshot_key.clone(), requires_build);
+        }
+    }
+
+    /// The warm entry of a survivor whose cache key the prefetch found.
+    /// The key rides along so the reporter can skip a duplicate
+    /// package-status event when a resolve-time prefetch already emitted
+    /// it.
+    fn warm_entry<'a>(
+        &self,
+        entry: &'a SnapshotWithCacheKey<'a>,
+        prefetch: &'a PrefetchResult,
+    ) -> Option<WarmEntry<'a>> {
+        let (snapshot_key, snapshot, cache_key) = entry;
+        let key = cache_key.as_deref()?;
+        let cas_paths = prefetch.cas_paths.get(key)?;
+        let requires_build =
+            self.requires_build_by_snapshot.get(*snapshot_key).copied().unwrap_or(false);
+        Some((
+            *snapshot_key,
+            *snapshot,
+            cas_paths,
+            key,
+            snapshot_needs_build_marker(snapshot_key, requires_build),
+        ))
+    }
+
+    fn into_partition<'a>(
+        self,
+        warm: Vec<WarmEntry<'a>>,
+        cold: Vec<(&'a PackageKey, &'a SnapshotEntry)>,
+    ) -> Partition<'a> {
+        Partition {
+            warm,
+            cold,
+            package_manifests: self.package_manifests,
+            side_effects_maps_by_snapshot: self.side_effects_maps_by_snapshot,
+            side_effects_by_snapshot: self.side_effects_by_snapshot,
+            remote_side_effects_quarantine_by_snapshot: self
+                .remote_side_effects_quarantine_by_snapshot,
+            store_index_keys_by_snapshot: self.store_index_keys_by_snapshot,
+            requires_build_by_snapshot: self.requires_build_by_snapshot,
         }
     }
 }

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
@@ -76,49 +76,41 @@ impl SnapshotPlan<'_> {
 pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
     inputs: SnapshotPlanInputs<'a, '_>,
 ) -> Result<SnapshotPlan<'a>, CreateVirtualStoreError> {
-    let SnapshotPlanInputs {
-        snapshots,
-        packages,
-        current_entries,
-        layout,
-        allow_build_policy,
-        skipped,
-        link_dependencies,
-        force,
-        is_hoisted,
-        include_optional_dependencies,
-        cache_keys,
-    } = inputs;
-
-    // The slot probe goes through `layout.slot_dir` because under GVS
-    // the slot lives at `<global_virtual_store_dir>/...`, and probing
-    // `<virtual_store_dir>/<flat-name>` would find nothing and report
-    // every warm slot as broken. See pnpm/pacquet#442 for why the
-    // current-lockfile skip keeps its store-index rows.
+    let probe = WarmSlotProbe::of(&inputs);
+    let SnapshotPlanInputs { snapshots, cache_keys, .. } = inputs;
     let mut markers = MarkerProbes::default();
+    let (survivors, has_git_hosted_survivor) =
+        survivors::<Reporter>(snapshots, &probe, &mut markers, cache_keys)?;
+    let marker_rebuilds = marker_rebuilds(markers, &survivors, &probe);
+    let skipped_entries = skipped_entries(snapshots, &survivors, probe.skipped, cache_keys);
+    Ok(SnapshotPlan { survivors, skipped_entries, marker_rebuilds, has_git_hosted_survivor })
+}
+
+/// The snapshots this install materializes, and whether any of them is
+/// git-hosted.
+///
+/// The slot probe goes through `layout.slot_dir` because under GVS the
+/// slot lives at `<global_virtual_store_dir>/...`, and probing
+/// `<virtual_store_dir>/<flat-name>` would find nothing and report
+/// every warm slot as broken.
+fn survivors<'a, Reporter: self::Reporter>(
+    snapshots: &'a HashMap<PackageKey, SnapshotEntry>,
+    probe: &WarmSlotProbe<'a, '_>,
+    markers: &mut MarkerProbes,
+    cache_keys: &mut HashMap<PackageKey, Result<SnapshotCacheKey, CreateVirtualStoreError>>,
+) -> Result<(Vec<SnapshotWithCacheKey<'a>>, bool), CreateVirtualStoreError> {
     let mut has_git_hosted_survivor = false;
-    let probe = WarmSlotProbe {
-        packages,
-        current_entries,
-        layout,
-        allow_build_policy,
-        skipped,
-        link_dependencies,
-        force,
-        is_hoisted,
-        include_optional_dependencies,
-    };
-    let snapshot_entries = snapshots
+    let entries = snapshots
         .iter()
         // Reason 1: installability skip. Drop entirely.
-        .filter(|(snapshot_key, _)| !skipped.contains(snapshot_key))
+        .filter(|(snapshot_key, _)| !probe.skipped.contains(snapshot_key))
         // Reason 2: warm-slot skip. Drop survivors that already match
         // the previous install, or whose content-addressed global-
         // virtual-store slot already exists. This is a fallible fold
         // because a warm-slot lstat error must abort the install rather
         // than quietly converting the slot into a rebuild on every run.
         .try_fold(Vec::new(), |mut entries, (snapshot_key, snapshot)| {
-            if !warm_slot_is_current::<Reporter>(&probe, snapshot_key, snapshot, &mut markers)? {
+            if !warm_slot_is_current::<Reporter>(probe, snapshot_key, snapshot, markers)? {
                 let cache_key = cache_keys
                     .remove(snapshot_key)
                     .expect("CasPrefetch::start derived a cache key for every lockfile snapshot")?;
@@ -127,33 +119,48 @@ pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
             }
             Ok::<_, CreateVirtualStoreError>(entries)
         })?;
-    let MarkerProbes { keys: marker_probe_keys, rebuilds: mut marker_rebuilds } = markers;
-    if !is_hoisted {
-        marker_rebuilds.extend(
-            snapshot_entries
+    Ok((entries, has_git_hosted_survivor))
+}
+
+/// The probe's own rebuilds, joined by the survivors it never reached
+/// whose global-virtual-store build marker forces one anyway.
+fn marker_rebuilds(
+    markers: MarkerProbes,
+    survivors: &[SnapshotWithCacheKey<'_>],
+    probe: &WarmSlotProbe<'_, '_>,
+) -> HashSet<PackageKey> {
+    let MarkerProbes { keys: probed, mut rebuilds } = markers;
+    if !probe.is_hoisted {
+        rebuilds.extend(
+            survivors
                 .iter()
-                .filter(|(snapshot_key, _, _)| !marker_probe_keys.contains(*snapshot_key))
+                .filter(|(snapshot_key, _, _)| !probed.contains(*snapshot_key))
                 .filter(|(snapshot_key, _, _)| {
-                    gvs_slot_needs_rebuild(layout, allow_build_policy, snapshot_key)
+                    gvs_slot_needs_rebuild(probe.layout, probe.allow_build_policy, snapshot_key)
                 })
                 .map(|(snapshot_key, _, _)| (*snapshot_key).clone()),
         );
     }
+    rebuilds
+}
 
+/// The snapshots the warm-slot probe left alone, with the lenient
+/// cache-key pass. Installability-skipped snapshots are excluded: they
+/// were never installed, so there is no store-index row to keep warm
+/// for the build-cache lookup.
+fn skipped_entries<'a>(
+    snapshots: &'a HashMap<PackageKey, SnapshotEntry>,
+    survivors: &[SnapshotWithCacheKey<'_>],
+    skipped: &SkippedSnapshots,
+    cache_keys: &mut HashMap<PackageKey, Result<SnapshotCacheKey, CreateVirtualStoreError>>,
+) -> Vec<SnapshotWithCacheKey<'a>> {
     // A parallel `Vec` rather than a filter later: the partition's
     // manifest and side-effects loop has to see the full snapshot set,
     // not just survivors.
-    let survivor_keys: std::collections::HashSet<&PackageKey> =
-        snapshot_entries.iter().map(|(k, _, _)| *k).collect();
-    let skipped_entries: Vec<SnapshotWithCacheKey<'_>> = snapshots
+    let survivor_keys: HashSet<&PackageKey> = survivors.iter().map(|(key, _, _)| *key).collect();
+    snapshots
         .iter()
         .filter(|(snapshot_key, _)| !survivor_keys.contains(snapshot_key))
-        // Installability-skipped snapshots are excluded from
-        // `skipped_entries` too — they were never installed, so
-        // there's no store-index row to keep warm for the
-        // build-cache lookup. Only the current-lockfile-skip
-        // path (`snapshot_entries` filtered above) should contribute
-        // here.
         .filter(|(snapshot_key, _)| !skipped.contains(snapshot_key))
         .map(|(snapshot_key, snapshot)| {
             let cache_key = cache_keys
@@ -162,13 +169,7 @@ pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
                 .and_then(|cache_key| cache_key.value);
             (snapshot_key, snapshot, cache_key)
         })
-        .collect();
-    Ok(SnapshotPlan {
-        survivors: snapshot_entries,
-        skipped_entries,
-        marker_rebuilds,
-        has_git_hosted_survivor,
-    })
+        .collect()
 }
 
 /// The lockfile-independent inputs of the warm-slot probe: everything
@@ -184,6 +185,22 @@ struct WarmSlotProbe<'a, 'b> {
     force: bool,
     is_hoisted: bool,
     include_optional_dependencies: bool,
+}
+
+impl<'a, 'b> WarmSlotProbe<'a, 'b> {
+    fn of(inputs: &SnapshotPlanInputs<'a, 'b>) -> Self {
+        Self {
+            packages: inputs.packages,
+            current_entries: inputs.current_entries,
+            layout: inputs.layout,
+            allow_build_policy: inputs.allow_build_policy,
+            skipped: inputs.skipped,
+            link_dependencies: inputs.link_dependencies,
+            force: inputs.force,
+            is_hoisted: inputs.is_hoisted,
+            include_optional_dependencies: inputs.include_optional_dependencies,
+        }
+    }
 }
 
 /// Slots the warm-slot probe reached a verdict on, split by what the

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
@@ -58,6 +58,12 @@ pub(super) struct SnapshotPlan<'a> {
     pub has_git_hosted_survivor: bool,
 }
 
+impl SnapshotPlan<'_> {
+    pub(super) fn materialized_keys(&self) -> Vec<PackageKey> {
+        self.survivors.iter().map(|(snapshot_key, _, _)| (*snapshot_key).clone()).collect()
+    }
+}
+
 /// Partition the lockfile's snapshots into what this install must do
 /// and what it may leave alone.
 ///

--- a/pnpm/crates/deps-restorer/src/current_lockfile.rs
+++ b/pnpm/crates/deps-restorer/src/current_lockfile.rs
@@ -178,15 +178,7 @@ pub fn merge_filtered_wanted_lockfile(
         previous_wanted.and_then(|lockfile| lockfile.snapshots.as_ref()),
         fresh_snapshots,
     );
-    let final_importer_ids = freshly_resolved.importers.keys().cloned().collect();
-    Ok(materialization_closure(
-        &freshly_resolved,
-        workspace_root,
-        &final_importer_ids,
-        all_dependencies(),
-        &SkippedSnapshots::new(),
-    )
-    .lockfile)
+    Ok(full_closure(&freshly_resolved, workspace_root))
 }
 
 #[must_use]
@@ -208,10 +200,28 @@ pub fn merge_filtered_current_lockfile(
     let Some(previous_current) = previous_current else {
         return selected.lockfile;
     };
+    let retained = retained_closure(previous_current, &selected.importer_ids, workspace_root);
+    let selected_packages = selected.lockfile.packages.clone();
+    let merged = overlay_lockfiles(wanted, previous_current, retained, selected.lockfile);
+    let mut final_lockfile = full_closure(&merged, workspace_root);
+    if let Some(selected_packages) = selected_packages {
+        final_lockfile.packages.get_or_insert_default().extend(selected_packages);
+    }
+    restore_skipped_package_metadata(&mut final_lockfile, &merged, skipped);
+    final_lockfile
+}
+
+/// The closure of the previous install's importers this install left
+/// alone, so their entries survive the merge.
+fn retained_closure(
+    previous_current: &Lockfile,
+    selected_importer_ids: &HashSet<String>,
+    workspace_root: &Path,
+) -> Lockfile {
     let retained_importers = previous_current
         .importers
         .iter()
-        .filter(|(importer_id, _)| !selected.importer_ids.contains(*importer_id))
+        .filter(|(importer_id, _)| !selected_importer_ids.contains(*importer_id))
         .map(|(importer_id, importer)| (importer_id.clone(), importer.clone()))
         .collect::<HashMap<_, _>>();
     let retained_importer_ids = retained_importers.keys().cloned().collect();
@@ -221,35 +231,42 @@ pub fn merge_filtered_current_lockfile(
         previous_current.packages.clone(),
         previous_current.snapshots.clone(),
     );
-    let retained = materialization_closure(
+    materialization_closure(
         &retained_source,
         workspace_root,
         &retained_importer_ids,
         all_dependencies(),
         &SkippedSnapshots::new(),
-    );
-    let mut importers = retained.lockfile.importers;
-    importers.extend(selected.lockfile.importers);
-    let selected_packages = selected.lockfile.packages;
-    let packages =
-        overlay_package_maps(previous_current.packages.as_ref(), selected_packages.clone());
-    let snapshots =
-        overlay_package_maps(retained.lockfile.snapshots.as_ref(), selected.lockfile.snapshots);
-    let merged = lockfile_with_graph(wanted, importers, packages, snapshots);
-    let final_importer_ids = merged.importers.keys().cloned().collect();
-    let mut final_lockfile = materialization_closure(
-        &merged,
+    )
+    .lockfile
+}
+
+/// The retained importers and graph under the selected ones, over the
+/// previous install's package metadata.
+fn overlay_lockfiles(
+    wanted: &Lockfile,
+    previous_current: &Lockfile,
+    retained: Lockfile,
+    selected: Lockfile,
+) -> Lockfile {
+    let mut importers = retained.importers;
+    importers.extend(selected.importers);
+    let packages = overlay_package_maps(previous_current.packages.as_ref(), selected.packages);
+    let snapshots = overlay_package_maps(retained.snapshots.as_ref(), selected.snapshots);
+    lockfile_with_graph(wanted, importers, packages, snapshots)
+}
+
+/// The closure over every importer and dependency group of `lockfile`.
+fn full_closure(lockfile: &Lockfile, workspace_root: &Path) -> Lockfile {
+    let importer_ids = lockfile.importers.keys().cloned().collect();
+    materialization_closure(
+        lockfile,
         workspace_root,
-        &final_importer_ids,
+        &importer_ids,
         all_dependencies(),
         &SkippedSnapshots::new(),
     )
-    .lockfile;
-    if let Some(selected_packages) = selected_packages {
-        final_lockfile.packages.get_or_insert_default().extend(selected_packages);
-    }
-    restore_skipped_package_metadata(&mut final_lockfile, &merged, skipped);
-    final_lockfile
+    .lockfile
 }
 
 /// Put back the `packages` rows of snapshots the install skipped. The

--- a/pnpm/crates/deps-restorer/src/custom_fetcher.rs
+++ b/pnpm/crates/deps-restorer/src/custom_fetcher.rs
@@ -319,18 +319,7 @@ async fn run_callback<Reporter: self::Reporter>(
         FetcherMethod::CafsInfo => {
             return Ok(serde_json::json!({ "storeDir": download.store_dir.root() }));
         }
-        FetcherMethod::TempDir => {
-            let root = download.store_dir.tmp();
-            tokio::fs::create_dir_all(&root)
-                .await
-                .map_err(|error| callback_error(error.to_string(), "ERR_PNPM_FETCHER_TEMP_DIR"))?;
-            let directory = tempfile::Builder::new()
-                .prefix("fetcher-")
-                .tempdir_in(root)
-                .map_err(|error| callback_error(error.to_string(), "ERR_PNPM_FETCHER_TEMP_DIR"))?
-                .keep();
-            return Ok(serde_json::json!(directory));
-        }
+        FetcherMethod::TempDir => return temp_dir(download).await,
         FetcherMethod::LocalTarball => true,
         FetcherMethod::RemoteTarball => false,
     };
@@ -342,30 +331,7 @@ async fn run_callback<Reporter: self::Reporter>(
             ));
         }
     }
-    let mut location = callback.resolution.clone();
-    if let Some(integrity) = download.package_integrity
-        && let Some(object) = location.as_object_mut()
-    {
-        object.insert("integrity".to_owned(), serde_json::json!(integrity.to_string()));
-    }
-    let location: TarballLocation = serde_json::from_value(location).map_err(|error| {
-        callback_error(error.to_string(), "ERR_PNPM_INVALID_FETCHER_RESOLUTION")
-    })?;
-    // Each callback answers for one transport, so the URL has to name that
-    // transport and no other. Without the positive test on the remote side, a
-    // scheme neither fetcher handles — `ftp:`, `data:`, a bare path — counts as
-    // remote and fails deep in the HTTP client instead of here.
-    let scheme_matches_callback = if expects_local_archive {
-        location.tarball.starts_with("file:")
-    } else {
-        location.tarball.starts_with("https:") || location.tarball.starts_with("http:")
-    };
-    if !scheme_matches_callback {
-        return Err(callback_error(
-            "native tarball callback received an incompatible URL",
-            "ERR_PNPM_INVALID_FETCHER_RESOLUTION",
-        ));
-    }
+    let location = callback_location(callback, download, expects_local_archive)?;
     let lockfile_dir =
         callback.options.get("lockfileDir").and_then(Value::as_str).map_or(lockfile_dir, Path::new);
     let tarball = fetch_location::<Reporter>(download, location, lockfile_dir)
@@ -379,4 +345,54 @@ async fn run_callback<Reporter: self::Reporter>(
     });
     verified.push(tarball);
     Ok(result)
+}
+
+/// A fresh directory under the store's temp root, kept for the fetcher.
+async fn temp_dir(download: &IngestTarballToStore<'_>) -> Result<Value, FetchErrorDetails> {
+    let root = download.store_dir.tmp();
+    tokio::fs::create_dir_all(&root)
+        .await
+        .map_err(|error| callback_error(error.to_string(), "ERR_PNPM_FETCHER_TEMP_DIR"))?;
+    let directory = tempfile::Builder::new()
+        .prefix("fetcher-")
+        .tempdir_in(root)
+        .map_err(|error| callback_error(error.to_string(), "ERR_PNPM_FETCHER_TEMP_DIR"))?
+        .keep();
+    Ok(serde_json::json!(directory))
+}
+
+/// The callback's resolution as a tarball location, carrying the
+/// download's integrity when the callback named none.
+///
+/// Each callback answers for one transport, so the URL has to name that
+/// transport and no other. Without the positive test on the remote
+/// side, a scheme neither fetcher handles — `ftp:`, `data:`, a bare
+/// path — counts as remote and fails deep in the HTTP client instead of
+/// here.
+fn callback_location(
+    callback: &FetcherCallback,
+    download: &IngestTarballToStore<'_>,
+    expects_local_archive: bool,
+) -> Result<TarballLocation, FetchErrorDetails> {
+    let mut location = callback.resolution.clone();
+    if let Some(integrity) = download.package_integrity
+        && let Some(object) = location.as_object_mut()
+    {
+        object.insert("integrity".to_owned(), serde_json::json!(integrity.to_string()));
+    }
+    let location: TarballLocation = serde_json::from_value(location).map_err(|error| {
+        callback_error(error.to_string(), "ERR_PNPM_INVALID_FETCHER_RESOLUTION")
+    })?;
+    let scheme_matches_callback = if expects_local_archive {
+        location.tarball.starts_with("file:")
+    } else {
+        location.tarball.starts_with("https:") || location.tarball.starts_with("http:")
+    };
+    if !scheme_matches_callback {
+        return Err(callback_error(
+            "native tarball callback received an incompatible URL",
+            "ERR_PNPM_INVALID_FETCHER_RESOLUTION",
+        ));
+    }
+    Ok(location)
 }

--- a/pnpm/crates/deps-restorer/src/hoisted_dep_graph.rs
+++ b/pnpm/crates/deps-restorer/src/hoisted_dep_graph.rs
@@ -372,67 +372,67 @@ fn build_dep_graph(
     let root_deps = hoister_result.dependencies.borrow();
     let root_hierarchy = walk_deps(&mut state, &modules_dir, &root_deps)?;
     drop(root_deps);
+    state.into_result(root_hierarchy)
+}
 
-    // Pass 2 — fill in each node's `children` map from the
-    // now-complete `pkg_locations_by_pkg_id`.
-    //
-    // The walk above intentionally leaves `children` empty: every
-    // sibling and descendant of a node must have its directory
-    // recorded in `pkg_locations_by_pkg_id` before any node
-    // resolves its children, so the location index is complete by
-    // the time children are computed. The simplest way to preserve
-    // that invariant is to insert everything first and resolve
-    // children second.
-    let WalkState {
-        graph,
-        pkg_locations_by_pkg_id,
-        hoisted_locations,
-        injection_targets_by_dep_path,
-        skipped,
-        lockfile,
-        per_importer_hierarchies,
-        per_importer_direct_deps,
-        ..
-    } = state;
-    let mut graph = graph;
-    fill_children(&mut graph, &pkg_locations_by_pkg_id, lockfile)?;
+impl WalkState<'_> {
+    /// Pass 2 — fill in each node's `children` map from the
+    /// now-complete `pkg_locations_by_pkg_id`, then assemble the result.
+    ///
+    /// The walk intentionally leaves `children` empty: every sibling and
+    /// descendant of a node must have its directory recorded in
+    /// `pkg_locations_by_pkg_id` before any node resolves its children,
+    /// so the location index is complete by the time children are
+    /// computed. The simplest way to preserve that invariant is to
+    /// insert everything first and resolve children second.
+    fn into_result(
+        mut self,
+        root_hierarchy: DepHierarchy,
+    ) -> Result<LockfileToDepGraphResult, HoistedDepGraphError> {
+        fill_children(&mut self.graph, &self.pkg_locations_by_pkg_id, self.lockfile)?;
 
-    // The hoister produced a children order; the directory keys in
-    // `root_hierarchy` follow it, and
-    // `direct_dependencies_by_importer_id["."]` is built from that
-    // order.
-    let mut direct_dependencies_by_importer_id: DirectDependenciesByImporterId = BTreeMap::new();
-    direct_dependencies_by_importer_id
-        .insert(Lockfile::ROOT_IMPORTER_KEY.to_string(), root_direct_deps(&root_hierarchy, &graph));
+        // The hoister produced a children order; the directory keys in
+        // `root_hierarchy` follow it, and
+        // `direct_dependencies_by_importer_id["."]` is built from that
+        // order.
+        let mut direct_dependencies_by_importer_id: DirectDependenciesByImporterId =
+            BTreeMap::new();
+        direct_dependencies_by_importer_id.insert(
+            Lockfile::ROOT_IMPORTER_KEY.to_string(),
+            root_direct_deps(&root_hierarchy, &self.graph),
+        );
 
-    // `link:` entries are skipped — they don't enter the hoist tree
-    // and have no `pkg_locations` entry. The install pipeline handles
-    // them via [`crate::SymlinkDirectDependencies`]'s `link_only` pass
-    // after the hoisted linker runs.
-    for importer_id in per_importer_direct_deps.keys() {
-        let Some(importer) = lockfile.importers.get(importer_id) else { continue };
-        direct_dependencies_by_importer_id
-            .insert(importer_id.clone(), importer_direct_deps(importer, &pkg_locations_by_pkg_id));
+        // `link:` entries are skipped — they don't enter the hoist tree
+        // and have no `pkg_locations` entry. The install pipeline handles
+        // them via [`crate::SymlinkDirectDependencies`]'s `link_only` pass
+        // after the hoisted linker runs.
+        for importer_id in self.per_importer_direct_deps.keys() {
+            let Some(importer) = self.lockfile.importers.get(importer_id) else { continue };
+            direct_dependencies_by_importer_id.insert(
+                importer_id.clone(),
+                importer_direct_deps(importer, &self.pkg_locations_by_pkg_id),
+            );
+        }
+
+        // Hierarchy: one entry per importer root. Root importer gets
+        // `lockfile_dir`; non-root workspace importers get
+        // `<lockfile_dir>/<importer_id>` — the linker walks each
+        // importer's subtree under its own root.
+        let mut hierarchy = BTreeMap::new();
+        hierarchy.insert(self.opts.lockfile_dir.clone(), root_hierarchy);
+        hierarchy.extend(self.per_importer_hierarchies);
+
+        Ok(LockfileToDepGraphResult {
+            graph: self.graph,
+            direct_dependencies_by_importer_id,
+            hierarchy,
+            hoisted_locations: self.hoisted_locations,
+            symlinked_direct_dependencies_by_importer_id: DirectDependenciesByImporterId::new(),
+            prev_graph: None,
+            injection_targets_by_dep_path: self.injection_targets_by_dep_path,
+            skipped: self.skipped,
+        })
     }
-
-    // Hierarchy: one entry per importer root. Root importer gets
-    // `lockfile_dir`; non-root workspace importers get
-    // `<lockfile_dir>/<importer_id>` — the linker walks each
-    // importer's subtree under its own root.
-    let mut hierarchy = BTreeMap::new();
-    hierarchy.insert(opts.lockfile_dir.clone(), root_hierarchy);
-    hierarchy.extend(per_importer_hierarchies);
-
-    Ok(LockfileToDepGraphResult {
-        graph,
-        direct_dependencies_by_importer_id,
-        hierarchy,
-        hoisted_locations,
-        symlinked_direct_dependencies_by_importer_id: DirectDependenciesByImporterId::new(),
-        prev_graph: None,
-        injection_targets_by_dep_path,
-        skipped,
-    })
 }
 
 /// The root importer's direct dependencies, in the children order the
@@ -585,49 +585,17 @@ fn walk_dep(
         return Ok(None);
     }
 
-    // Workspace-kind hoister children are non-root workspace importers.
-    // Recurse into their (post-hoist, often-empty) dependencies under
-    // `<lockfile_dir>/<importer_id>/node_modules` to capture any deps
-    // the hoister couldn't move up — those become nested entries in the
-    // per-importer hierarchy. The workspace node itself is *not* added
-    // to the graph or to the parent's hierarchy: it has no package
-    // contents to import. Per-importer
-    // `direct_dependencies_by_importer_id` is computed in
-    // [`build_dep_graph`] from the lockfile (not from the hoister tree)
-    // because hoisted siblings don't appear in the workspace node's
-    // children.
     if let Some(importer_id) = reference.strip_prefix("workspace:") {
-        let importer_id = importer_id.to_string();
-        let importer_root = state.lockfile_dir.join(&importer_id);
-        let importer_modules = importer_root.join("node_modules");
-        let child_deps = dep.0.dependencies.borrow();
-        let importer_hierarchy = walk_deps(state, &importer_modules, &child_deps)?;
-        drop(child_deps);
-        state.per_importer_hierarchies.insert(importer_root, importer_hierarchy);
-        // Reserve the importer's slot so [`build_dep_graph`]'s post-walk
-        // loop knows the importer was visited, even when it ends up with
-        // zero direct deps.
-        state.per_importer_direct_deps.entry(importer_id).or_default();
+        walk_workspace_importer(state, dep, importer_id)?;
         return Ok(None);
     }
 
-    let pkg_key: PackageKey = match reference.parse() {
-        Ok(key) => key,
-        Err(source) => {
-            return Err(HoistedDepGraphError::BadReference { reference, source });
-        }
-    };
-
-    // `packages[key]` is the metadata source; absent → this is a link /
-    // external placeholder that the wrapper strips, so the walker skips
-    // it.
-    let Some(metadata) = lookup_package_metadata(state.lockfile, &pkg_key) else {
+    let Some(resolved) = resolve_reference(state, &reference)? else {
         return Ok(None);
     };
-    let snapshot = state.lockfile.snapshots.as_ref().and_then(|snapshots| snapshots.get(&pkg_key));
-    let optional = snapshot.is_some_and(|snapshot| snapshot.optional);
+    let optional = resolved.snapshot.is_some_and(|snapshot| snapshot.optional);
 
-    if installability_skip(state, &pkg_key, metadata, optional)? {
+    if installability_skip(state, &resolved.pkg_key, resolved.metadata, optional)? {
         state.skipped.insert(reference);
         return Ok(None);
     }
@@ -639,55 +607,119 @@ fn walk_dep(
     // recurse) so every node's location is recorded ahead of any child
     // that needs to resolve to it. `children` is filled in by
     // `fill_children` after the whole walk is done.
-    let node = DependenciesGraphNode {
-        alias: Some(dep.0.name.clone()),
-        dep_path: DepPath::from(reference.clone()),
-        // `pkgIdWithPatchHash` strips peer-graph hashes but keeps
-        // `(patch_hash=...)`.
-        pkg_id_with_patch_hash: PkgIdWithPatchHash::from(
-            get_pkg_id_with_patch_hash(&pkg_key.to_string()).to_string(),
-        ),
-        dir: dir.clone(),
-        modules: modules.to_path_buf(),
-        children: BTreeMap::new(),
-        name: pkg_key.name.to_string(),
-        version: pkg_key.suffix.version().to_string(),
-        optional,
-        optional_dependencies: snapshot
-            .and_then(|snap| snap.optional_dependencies.as_ref())
-            .map(|map| map.keys().map(std::string::ToString::to_string).collect())
-            .unwrap_or_default(),
-        has_bin: metadata.has_bin.unwrap_or(false),
-        has_bundled_dependencies: metadata.bundled_dependencies.is_some(),
-        patch: None,
-        resolution: metadata.resolution.clone(),
-    };
-
-    state.graph.insert(dir.clone(), node);
+    state
+        .graph
+        .insert(dir.clone(), graph_node(dep, &reference, &resolved, optional, &dir, modules));
     state
         .pkg_locations_by_pkg_id
-        .entry(pnpm_real_hoist::pkg_id(&pkg_key))
+        .entry(pnpm_real_hoist::pkg_id(&resolved.pkg_key))
         .or_default()
         .push(dir.clone());
 
     // Directory resolutions are injected workspace packages. Record
     // every dir an injected dep lands in for the post-install re-mirror
     // step, so a future re-mirror pass has the input it needs.
-    if let LockfileResolution::Directory(_) = &metadata.resolution {
+    if let LockfileResolution::Directory(_) = &resolved.metadata.resolution {
         state.injection_targets_by_dep_path.entry(reference.clone()).or_default().push(dir.clone());
     }
 
-    let inner_modules = dir.join("node_modules");
-    let child_deps = dep.0.dependencies.borrow();
-    let inner_hierarchy = walk_deps(state, &inner_modules, &child_deps)?;
-    drop(child_deps);
+    let hierarchy = walk_deps(state, &dir.join("node_modules"), &dep.0.dependencies.borrow())?;
 
     // `hoistedLocations` is pushed AFTER the recursion. The
     // pre-recursion sites that mutate state are for graph/index
     // identity; this one is the user-visible location list that the
     // linker consumes.
     state.hoisted_locations.entry(reference).or_default().push(dep_location);
-    Ok(Some((dir, inner_hierarchy)))
+    Ok(Some((dir, hierarchy)))
+}
+
+/// Workspace-kind hoister children are non-root workspace importers.
+/// Recurse into their (post-hoist, often-empty) dependencies under
+/// `<lockfile_dir>/<importer_id>/node_modules` to capture any deps the
+/// hoister couldn't move up — those become nested entries in the
+/// per-importer hierarchy. The workspace node itself is *not* added to
+/// the graph or to the parent's hierarchy: it has no package contents
+/// to import. Per-importer `direct_dependencies_by_importer_id` is
+/// computed in [`WalkState::into_result`] from the lockfile (not from
+/// the hoister tree) because hoisted siblings don't appear in the
+/// workspace node's children.
+fn walk_workspace_importer(
+    state: &mut WalkState<'_>,
+    dep: &RcByPtr<HoisterResult>,
+    importer_id: &str,
+) -> Result<(), HoistedDepGraphError> {
+    let importer_root = state.lockfile_dir.join(importer_id);
+    let importer_hierarchy =
+        walk_deps(state, &importer_root.join("node_modules"), &dep.0.dependencies.borrow())?;
+    state.per_importer_hierarchies.insert(importer_root, importer_hierarchy);
+    // Reserve the importer's slot so [`WalkState::into_result`]'s
+    // post-walk loop knows the importer was visited, even when it ends
+    // up with zero direct deps.
+    state.per_importer_direct_deps.entry(importer_id.to_string()).or_default();
+    Ok(())
+}
+
+/// The lockfile's metadata and snapshot for a hoister reference. `None`
+/// for a link / external placeholder the wrapper strips, which the
+/// walker skips.
+struct ResolvedReference<'l> {
+    pkg_key: PackageKey,
+    metadata: &'l pnpm_lockfile::PackageMetadata,
+    snapshot: Option<&'l pnpm_lockfile::SnapshotEntry>,
+}
+
+fn resolve_reference<'l>(
+    state: &WalkState<'l>,
+    reference: &str,
+) -> Result<Option<ResolvedReference<'l>>, HoistedDepGraphError> {
+    let pkg_key: PackageKey = match reference.parse() {
+        Ok(key) => key,
+        Err(source) => {
+            return Err(HoistedDepGraphError::BadReference {
+                reference: reference.to_string(),
+                source,
+            });
+        }
+    };
+    let Some(metadata) = lookup_package_metadata(state.lockfile, &pkg_key) else {
+        return Ok(None);
+    };
+    let snapshot = state.lockfile.snapshots.as_ref().and_then(|snapshots| snapshots.get(&pkg_key));
+    Ok(Some(ResolvedReference { pkg_key, metadata, snapshot }))
+}
+
+fn graph_node(
+    dep: &RcByPtr<HoisterResult>,
+    reference: &str,
+    resolved: &ResolvedReference<'_>,
+    optional: bool,
+    dir: &Path,
+    modules: &Path,
+) -> DependenciesGraphNode {
+    DependenciesGraphNode {
+        alias: Some(dep.0.name.clone()),
+        dep_path: DepPath::from(reference.to_string()),
+        // `pkgIdWithPatchHash` strips peer-graph hashes but keeps
+        // `(patch_hash=...)`.
+        pkg_id_with_patch_hash: PkgIdWithPatchHash::from(
+            get_pkg_id_with_patch_hash(&resolved.pkg_key.to_string()).to_string(),
+        ),
+        dir: dir.to_path_buf(),
+        modules: modules.to_path_buf(),
+        children: BTreeMap::new(),
+        name: resolved.pkg_key.name.to_string(),
+        version: resolved.pkg_key.suffix.version().to_string(),
+        optional,
+        optional_dependencies: resolved
+            .snapshot
+            .and_then(|snap| snap.optional_dependencies.as_ref())
+            .map(|map| map.keys().map(std::string::ToString::to_string).collect())
+            .unwrap_or_default(),
+        has_bin: resolved.metadata.has_bin.unwrap_or(false),
+        has_bundled_dependencies: resolved.metadata.bundled_dependencies.is_some(),
+        patch: None,
+        resolution: resolved.metadata.resolution.clone(),
+    }
 }
 
 /// Whether the installability filter rules this package out on this

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
@@ -26,7 +26,6 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pnpm_cmd_shim::{LinkBinsError, LinkBinsOptions};
 use pnpm_config::{Config, NodeLinker, matcher::create_matcher};
-use pnpm_executor::ScriptsPrependNodePath as ExecScriptsPrependNodePath;
 use pnpm_lockfile::{
     Lockfile, LockfileEntries, PackageKey, PackageMetadata, Prefix, ProjectSnapshot, SnapshotEntry,
 };

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase.rs
@@ -2,9 +2,9 @@
 
 use super::{
     AllowBuildPolicy, Arc, AtomicU8, BuildModules, BuildModulesError, Config, DependencyGroup,
-    Diagnostic, Display, Error, ExecScriptsPrependNodePath, ExtendedPatchInfo, HashMap,
-    IgnoredScriptsLog, LinkBinsError, LinkBinsOptions, Lockfile, LogEvent, LogLevel, OsStr,
-    PackageKey, PackageMetadata, PatchKeyConflictError, Path, PathBuf, ProjectSnapshot, Reporter,
+    Diagnostic, Display, Error, ExtendedPatchInfo, HashMap, IgnoredScriptsLog, LinkBinsError,
+    LinkBinsOptions, Lockfile, LogEvent, LogLevel, OsStr, PackageKey, PackageMetadata,
+    PatchKeyConflictError, Path, PathBuf, ProjectSnapshot, Reporter,
     ResolvePatchedDependenciesError, SkippedSnapshots, SnapshotEntry, StoreIndexWriter,
     VirtualStoreLayout, direct_dep_names_for_importer, get_patch_info, importer_root_dir,
     link_top_level_bins,
@@ -158,43 +158,11 @@ pub struct BuildPhaseInputs<'a> {
 pub fn run_build_phase<Reporter: self::Reporter>(
     inputs: &BuildPhaseInputs,
 ) -> Result<crate::BuildModulesOutput, BuildPhaseError> {
-    // Every field is a `Copy` reference / scalar, so destructuring
-    // through the shared borrow copies them out without a move.
-    let &BuildPhaseInputs {
-        config,
-        workspace_root,
-        layout,
-        snapshots,
-        packages,
-        importers,
-        patch_groups,
-        allow_build_policy,
-        side_effects_maps_by_snapshot,
-        requires_build_by_snapshot,
-        materialized_snapshots,
-        engine_name,
-        extra_env,
-        store_index_writer,
-        skipped,
-        hoisted_pkg_roots_by_key,
-        is_hoisted,
-        logged_methods,
-        rebuild,
-        ..
-    } = inputs;
-
-    let patches = resolve_snapshot_patches(config, patch_groups, snapshots, packages)?;
+    let config = inputs.config;
+    let patches =
+        resolve_snapshot_patches(config, inputs.patch_groups, inputs.snapshots, inputs.packages)?;
     let shared_side_effects_publisher =
-        crate::shared_side_effects::shared_side_effects_publisher(config, snapshots);
-
-    // Convert `pnpm-config`'s mirror enum to the executor's
-    // canonical type. Config's enum carries the yaml-deserialize impl;
-    // the executor's stays free of serde wiring.
-    let scripts_prepend_node_path = match config.scripts_prepend_node_path {
-        pnpm_config::ScriptsPrependNodePath::Always => ExecScriptsPrependNodePath::Always,
-        pnpm_config::ScriptsPrependNodePath::Never => ExecScriptsPrependNodePath::Never,
-        pnpm_config::ScriptsPrependNodePath::WarnOnly => ExecScriptsPrependNodePath::WarnOnly,
-    };
+        crate::shared_side_effects::shared_side_effects_publisher(config, inputs.snapshots);
 
     // BuildModules walks per-snapshot package directories and runs
     // `preinstall` / `install` / `postinstall` lifecycle scripts.
@@ -202,14 +170,17 @@ pub fn run_build_phase<Reporter: self::Reporter>(
     // layout; under hoisted, they live at the project-tree paths the
     // walker assigned — threaded in via `pkg_roots_by_key`.
     let can_defer_without_build_modules = config.ignore_scripts
-        && rebuild.is_none()
+        && inputs.rebuild.is_none()
         && patches.as_ref().is_none_or(HashMap::is_empty)
-        && (!config.side_effects_cache_read() || side_effects_maps_by_snapshot.is_empty());
+        && (!config.side_effects_cache_read() || inputs.side_effects_maps_by_snapshot.is_empty());
     let build_output = if can_defer_without_build_modules {
-        let newly_deferred = materialized_snapshots
+        let newly_deferred = inputs
+            .materialized_snapshots
             .iter()
-            .filter(|snapshot_key| !skipped.contains(snapshot_key))
-            .filter_map(|snapshot_key| requires_build_by_snapshot.get_key_value(snapshot_key));
+            .filter(|snapshot_key| !inputs.skipped.contains(snapshot_key))
+            .filter_map(|snapshot_key| {
+                inputs.requires_build_by_snapshot.get_key_value(snapshot_key)
+            });
         crate::BuildModulesOutput {
             ignored_builds: Vec::new(),
             deferred_builds: crate::build_modules::deferred_builds(newly_deferred, true),
@@ -217,38 +188,38 @@ pub fn run_build_phase<Reporter: self::Reporter>(
         }
     } else {
         BuildModules {
-            layout,
+            layout: inputs.layout,
             modules_dir: &config.modules_dir,
-            lockfile_dir: workspace_root,
-            snapshots,
-            packages,
-            importers,
-            allow_build_policy,
-            side_effects_maps_by_snapshot: Some(side_effects_maps_by_snapshot),
-            requires_build_by_snapshot: Some(requires_build_by_snapshot),
-            engine_name,
+            lockfile_dir: inputs.workspace_root,
+            snapshots: inputs.snapshots,
+            packages: inputs.packages,
+            importers: inputs.importers,
+            allow_build_policy: inputs.allow_build_policy,
+            side_effects_maps_by_snapshot: Some(inputs.side_effects_maps_by_snapshot),
+            requires_build_by_snapshot: Some(inputs.requires_build_by_snapshot),
+            engine_name: inputs.engine_name,
             side_effects_cache: config.side_effects_cache_read()
                 || config.remote_side_effects_cache.is_some(),
             side_effects_cache_write: config.side_effects_cache_write(),
             shared_side_effects_publisher: shared_side_effects_publisher.as_ref(),
             store_dir: Some(&config.store_dir),
-            store_index_writer: Some(store_index_writer),
+            store_index_writer: Some(inputs.store_index_writer),
             patches: patches.as_ref(),
-            scripts_prepend_node_path,
+            scripts_prepend_node_path: crate::build_modules::exec_scripts_prepend_node_path(config),
             script_shell: config.script_shell.as_deref().map(Path::new),
             shell_emulator: config.shell_emulator,
-            extra_env,
+            extra_env: inputs.extra_env,
             user_agent: &config.user_agent,
             unsafe_perm: config.unsafe_perm,
             child_concurrency: config.child_concurrency,
-            skipped,
-            pkg_roots_by_key: hoisted_pkg_roots_by_key,
-            gather_ancestor_bin_paths: is_hoisted,
+            skipped: inputs.skipped,
+            pkg_roots_by_key: inputs.hoisted_pkg_roots_by_key,
+            gather_ancestor_bin_paths: inputs.is_hoisted,
             frozen_store: config.frozen_store,
             ignore_scripts: config.ignore_scripts,
             import_method: config.package_import_method,
-            logged_methods,
-            rebuild,
+            logged_methods: inputs.logged_methods,
+            rebuild: inputs.rebuild,
         }
         .run::<Reporter>()
         .map_err(BuildPhaseError::BuildModules)?
@@ -283,7 +254,7 @@ pub fn run_build_phase<Reporter: self::Reporter>(
     // time. Idempotent for unchanged shims. Runs after `buildModules`.
     let modules_dir_basename: &OsStr =
         config.modules_dir.file_name().unwrap_or_else(|| OsStr::new("node_modules"));
-    for (importer_id, importer_snapshot) in importers {
+    for (importer_id, importer_snapshot) in inputs.importers {
         link_importer_top_level_bins(
             inputs,
             build_output.mutated_slots,

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile/hoisted.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile/hoisted.rs
@@ -111,52 +111,60 @@ pub fn run_hoisted_linker<Reporter: self::Reporter>(
     inputs: HoistedLinkerInputs<'_>,
     skipped: &mut SkippedSnapshots,
 ) -> Result<HoistedLinkerOutput, HoistedLinkerError> {
-    let HoistedLinkerInputs {
-        config,
-        lockfile,
-        current_lockfile,
-        layout,
-        importers,
-        dependency_groups,
-        project_manifests,
-        package_map_project_manifests,
-        walker_lockfile_dir,
-        symlink_workspace_root,
-        host_node,
-        supported_architectures,
-        cas_paths_by_pkg_id,
-        logged_methods,
-        requester,
-    } = inputs;
+    let lockfile = included_lockfile(&inputs);
+    let walked = walk_hoisted_graph(&inputs, &lockfile, skipped)?;
+    link_hoisted::<Reporter>(inputs, &lockfile, &walked, skipped)?;
+    Ok(HoistedLinkerOutput {
+        hoisted_pkg_roots_by_key: Some(pkg_roots_by_key(walked.graph.values())),
+        hoisted_locations: walked.hoisted_locations,
+    })
+}
 
-    // The hoist tree seeds from every importer dep map, so groups the
-    // user excluded (`--prod`, `--dev`, `--no-optional`) must be cleared
-    // from the lockfile before the walk — otherwise their whole subgraph
-    // materializes as real directories. Mirrors pnpm, which hands its
-    // hoisted walker an include-filtered lockfile.
+/// The hoist tree seeds from every importer dep map, so groups the user
+/// excluded (`--prod`, `--dev`, `--no-optional`) must be cleared from
+/// the lockfile before the walk — otherwise their whole subgraph
+/// materializes as real directories. Mirrors pnpm, which hands its
+/// hoisted walker an include-filtered lockfile.
+fn included_lockfile<'l>(inputs: &HoistedLinkerInputs<'l>) -> std::borrow::Cow<'l, Lockfile> {
     let included = IncludedDependencies {
-        dependencies: dependency_groups.contains(&DependencyGroup::Prod),
-        dev_dependencies: dependency_groups.contains(&DependencyGroup::Dev),
-        optional_dependencies: dependency_groups.contains(&DependencyGroup::Optional),
+        dependencies: inputs.dependency_groups.contains(&DependencyGroup::Prod),
+        dev_dependencies: inputs.dependency_groups.contains(&DependencyGroup::Dev),
+        optional_dependencies: inputs.dependency_groups.contains(&DependencyGroup::Optional),
     };
-    let filtered_lockfile;
-    let lockfile =
-        if included.dependencies && included.dev_dependencies && included.optional_dependencies {
-            lockfile
-        } else {
-            filtered_lockfile = exclude_importer_groups(lockfile, included);
-            &filtered_lockfile
-        };
+    if included.dependencies && included.dev_dependencies && included.optional_dependencies {
+        std::borrow::Cow::Borrowed(inputs.lockfile)
+    } else {
+        std::borrow::Cow::Owned(exclude_importer_groups(inputs.lockfile, included))
+    }
+}
 
-    // Walker installability inputs come straight from the optional
-    // `host_node` the caller built for the `compute_skipped_snapshots`
-    // pass. When `host_node` is `None` no per-snapshot constraint
-    // exists, so the host triple values pass through as defaults the
-    // walker won't actually consult.
+/// Walker installability inputs come straight from the optional
+/// `host_node` the caller built for the `compute_skipped_snapshots`
+/// pass. When `host_node` is `None` no per-snapshot constraint exists,
+/// so the host triple values pass through as defaults the walker won't
+/// actually consult.
+///
+/// Augments the live skip set with the walker's *new* skips only —
+/// entries already in the input `SkippedSnapshots` each live in their
+/// proper subset (installability / fetch-failed / optional-excluded).
+/// Re-inserting them as installability would promote transient
+/// `fetch_failed` / `optional_excluded` entries into the
+/// persisted-on-disk `.modules.yaml.skipped` set, which would survive
+/// into the next install — exactly the contract those subsets exist to
+/// prevent. Diffing against the input set keeps the persistence
+/// boundary intact: only walker-discovered installability skips
+/// (optional + unsupported platform) flow into
+/// [`SkippedSnapshots::insert_installability`].
+fn walk_hoisted_graph(
+    inputs: &HoistedLinkerInputs<'_>,
+    lockfile: &Lockfile,
+    skipped: &mut SkippedSnapshots,
+) -> Result<crate::hoisted_dep_graph::LockfileToDepGraphResult, HoistedLinkerError> {
+    let config = inputs.config;
     let walker_skipped: BTreeSet<String> =
         skipped.iter().map(std::string::ToString::to_string).collect();
     let walker_opts = LockfileToHoistedDepGraphOptions {
-        lockfile_dir: walker_lockfile_dir.to_path_buf(),
+        lockfile_dir: inputs.walker_lockfile_dir.to_path_buf(),
         auto_install_peers: config.auto_install_peers,
         skipped: walker_skipped.clone(),
         force: config.force,
@@ -165,65 +173,64 @@ pub fn run_hoisted_linker<Reporter: self::Reporter>(
         // mismatch on a required package is a hard error under strict,
         // otherwise a skip-optional / warning.
         engine_strict: config.engine_strict,
-        current_node_version: host_node.map(|host| host.version.clone()).unwrap_or_default(),
+        current_node_version: inputs.host_node.map(|host| host.version.clone()).unwrap_or_default(),
         current_os: pnpm_graph_hasher::host_platform().to_string(),
         current_cpu: pnpm_graph_hasher::host_arch().to_string(),
         current_libc: pnpm_graph_hasher::host_libc().to_string(),
-        supported_architectures: supported_architectures.cloned(),
+        supported_architectures: inputs.supported_architectures.cloned(),
         hoist_workspace_packages: config.hoist_workspace_packages,
         hoisting_limits: crate::get_hoisting_limits(&lockfile.importers, config.hoisting_limits),
         external_dependencies: config.external_dependencies.clone(),
     };
-    let walker_result = lockfile_to_hoisted_dep_graph(lockfile, current_lockfile, &walker_opts)
+    let walked = lockfile_to_hoisted_dep_graph(lockfile, inputs.current_lockfile, &walker_opts)
         .map_err(HoistedLinkerError::HoistedDepGraph)?;
-    // Augment the live skip set with the walker's *new* skips only —
-    // entries already in `walker_skipped` came from the input
-    // `SkippedSnapshots`, where each one already lives in its proper
-    // subset (installability / fetch-failed / optional-excluded).
-    // Re-inserting them as installability would promote transient
-    // `fetch_failed` / `optional_excluded` entries into the
-    // persisted-on-disk `.modules.yaml.skipped` set, which would
-    // survive into the next install — exactly the contract those
-    // subsets exist to prevent. Diffing against the input set keeps
-    // the persistence boundary intact: only walker-discovered
-    // installability skips (optional + unsupported platform) flow
-    // into [`SkippedSnapshots::insert_installability`].
-    for skipped_dep_path in walker_result.skipped.difference(&walker_skipped) {
+    for skipped_dep_path in walked.skipped.difference(&walker_skipped) {
         if let Ok(key) = skipped_dep_path.parse::<PackageKey>() {
             skipped.insert_installability(key);
         }
     }
+    Ok(walked)
+}
+
+fn link_hoisted<Reporter: self::Reporter>(
+    inputs: HoistedLinkerInputs<'_>,
+    lockfile: &Lockfile,
+    walked: &crate::hoisted_dep_graph::LockfileToDepGraphResult,
+    skipped: &SkippedSnapshots,
+) -> Result<(), HoistedLinkerError> {
+    let config = inputs.config;
     // Empty CAS index → linker would refuse every non-optional node.
     // Only happens when the install has no snapshots, in which case
     // the linker is a no-op.
-    let cas_index = cas_paths_by_pkg_id.expect("hoisted CreateVirtualStore populates cas_paths");
+    let cas_index =
+        inputs.cas_paths_by_pkg_id.expect("hoisted CreateVirtualStore populates cas_paths");
     let link_options = crate::shim_link_options(config, NodeLinker::Hoisted);
-    let link_opts = LinkHoistedModulesOpts {
-        graph: &walker_result.graph,
-        prev_graph: walker_result.prev_graph.as_ref(),
-        hierarchy: &walker_result.hierarchy,
+    link_hoisted_modules::<Reporter>(&LinkHoistedModulesOpts {
+        graph: &walked.graph,
+        prev_graph: walked.prev_graph.as_ref(),
+        hierarchy: &walked.hierarchy,
         cas_paths_by_pkg_id: &cas_index,
         import_method: config.package_import_method,
-        logged_methods,
-        requester,
-        confine_root: walker_lockfile_dir,
+        logged_methods: inputs.logged_methods,
+        requester: inputs.requester,
+        confine_root: inputs.walker_lockfile_dir,
         link_options: &link_options,
-    };
-    link_hoisted_modules::<Reporter>(&link_opts).map_err(HoistedLinkerError::LinkHoistedModules)?;
+    })
+    .map_err(HoistedLinkerError::LinkHoistedModules)?;
     link_selected_hoisted_direct_dependencies(
         config,
-        walker_lockfile_dir,
-        project_manifests,
-        &walker_result.direct_dependencies_by_importer_id,
+        inputs.walker_lockfile_dir,
+        inputs.project_manifests,
+        &walked.direct_dependencies_by_importer_id,
     )?;
     crate::package_map::write_hoisted_package_map(
         lockfile,
-        &walker_result,
+        walked,
         &crate::package_map::HoistedPackageMapOptions {
-            lockfile_dir: walker_lockfile_dir,
+            lockfile_dir: inputs.walker_lockfile_dir,
             modules_dir: &config.modules_dir,
             package_map_type: config.node_package_map_type,
-            project_manifests: package_map_project_manifests,
+            project_manifests: inputs.package_map_project_manifests,
         },
     )
     .map_err(HoistedLinkerError::WritePackageMap)?;
@@ -240,20 +247,21 @@ pub fn run_hoisted_linker<Reporter: self::Reporter>(
     // allowed outside the lockfile dir (see the isolated-path use).
     // Ids are lockfile-dir-relative, so derive them against
     // `walker_lockfile_dir`.
-    let trusted_importer_ids: std::collections::HashSet<String> = project_manifests
+    let trusted_importer_ids: std::collections::HashSet<String> = inputs
+        .project_manifests
         .iter()
         .map(|(project_dir, _)| {
-            pnpm_workspace::importer_id_from_root_dir(walker_lockfile_dir, project_dir)
+            pnpm_workspace::importer_id_from_root_dir(inputs.walker_lockfile_dir, project_dir)
         })
         .collect();
     SymlinkDirectDependencies {
         config,
-        layout,
-        importers,
+        layout: inputs.layout,
+        importers: inputs.importers,
         packages: lockfile.packages.as_ref(),
-        dependency_groups: dependency_groups.iter().copied(),
-        workspace_root: symlink_workspace_root,
-        skipped: &*skipped,
+        dependency_groups: inputs.dependency_groups.iter().copied(),
+        workspace_root: inputs.symlink_workspace_root,
+        skipped,
         link_only: true,
         // Hoisted-linker path has no public-hoist virtual store to
         // dedupe against; the real-directory tree is the hoist layout.
@@ -268,24 +276,26 @@ pub fn run_hoisted_linker<Reporter: self::Reporter>(
         requires_build_by_snapshot: None,
     }
     .run::<Reporter>()
-    .map_err(HoistedLinkerError::SymlinkDirectDependencies)?;
-    // Map snapshot key → every recorded directory, in walker order. The
-    // walker emits multiple [`crate::DependenciesGraphNode`]s with the
-    // same `dep_path` when the package nests under a sibling (version
-    // conflict). Postinstall scripts and the side-effects-cache key both
-    // depend only on the package contents (identical across locations),
-    // so `BuildModules` runs those once at the head of the list; patch
-    // application and cache-overlay re-imports walk the whole list.
-    let mut pkg_roots_by_key: HashMap<PackageKey, Vec<std::path::PathBuf>> = HashMap::new();
-    for node in walker_result.graph.values() {
+    .map_err(HoistedLinkerError::SymlinkDirectDependencies)
+}
+
+/// Map snapshot key → every recorded directory, in walker order. The
+/// walker emits multiple [`crate::DependenciesGraphNode`]s with the
+/// same `dep_path` when the package nests under a sibling (version
+/// conflict). Postinstall scripts and the side-effects-cache key both
+/// depend only on the package contents (identical across locations),
+/// so `BuildModules` runs those once at the head of the list; patch
+/// application and cache-overlay re-imports walk the whole list.
+fn pkg_roots_by_key<'n>(
+    nodes: impl Iterator<Item = &'n crate::DependenciesGraphNode>,
+) -> HashMap<PackageKey, Vec<std::path::PathBuf>> {
+    let mut roots: HashMap<PackageKey, Vec<std::path::PathBuf>> = HashMap::new();
+    for node in nodes {
         if let Ok(key) = node.dep_path.as_str().parse::<PackageKey>() {
-            pkg_roots_by_key.entry(key).or_default().push(node.dir.clone());
+            roots.entry(key).or_default().push(node.dir.clone());
         }
     }
-    Ok(HoistedLinkerOutput {
-        hoisted_locations: walker_result.hoisted_locations,
-        hoisted_pkg_roots_by_key: Some(pkg_roots_by_key),
-    })
+    roots
 }
 
 pub(crate) fn link_selected_hoisted_direct_dependencies(

--- a/pnpm/crates/deps-restorer/src/install_package_by_snapshot.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_by_snapshot.rs
@@ -1,6 +1,7 @@
 use crate::{
     CreateVirtualDirBySnapshot, CreateVirtualDirError, CustomFetcherSession,
-    custom_fetcher::CustomFetchOutcome, retry_config::retry_opts_from_config,
+    build_modules::exec_scripts_prepend_node_path, custom_fetcher::CustomFetchOutcome,
+    retry_config::retry_opts_from_config,
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;
@@ -284,128 +285,126 @@ impl InstallPackageBySnapshot<'_> {
         metadata: &PackageMetadata,
         snapshot: &SnapshotEntry,
     ) -> Result<InstalledPackage, InstallPackageBySnapshotError> {
-        let InstallPackageBySnapshot {
-            ctx,
-            http_client,
-            store_index,
-            store_index_writer,
-            prefetched_cas_paths,
-            progress_reported,
-            verified_files_cache,
-            skipped,
-            include_optional_dependencies,
-            runtime_platform_selector,
-            custom_fetcher_session,
-            defer_link,
-            #[cfg(test)]
-            link_concurrency_probe,
-            ..
-        } = *self;
-        let &crate::InstallContext {
-            config,
-            workspace_root,
-            requester,
-            layout,
-            node_linker,
-            allow_build_policy,
-            logged_methods,
-            ..
-        } = ctx;
-
         // TODO: skip when already exists in store?
         let package_id = package_key.pkg_id();
-        emit_progress_resolved::<Reporter>(&package_id, requester);
+        emit_progress_resolved::<Reporter>(&package_id, self.ctx.requester);
 
-        // Adapter shared between the `Git` arm below and the
-        // `gitHosted: true` post-pass on tarballs. Named local so
-        // both fetchers can borrow it across their `.await` without
-        // depending on temporary-lifetime extension.
-        //
-        // `AllowBuildPolicy::check` returns `None` when the package
-        // is neither allow-listed nor deny-listed. The default is deny
-        // (`None → false`): build scripts have to be explicitly opted
-        // in to run.
-        let allow_build_closure =
-            |dep_path: &str| allow_build_policy.check(dep_path).unwrap_or(false);
-        let scripts_prepend_node_path = match config.scripts_prepend_node_path {
-            pnpm_config::ScriptsPrependNodePath::Always => ExecScriptsPrependNodePath::Always,
-            pnpm_config::ScriptsPrependNodePath::Never => ExecScriptsPrependNodePath::Never,
-            pnpm_config::ScriptsPrependNodePath::WarnOnly => ExecScriptsPrependNodePath::WarnOnly,
-        };
-
-        let download = IngestTarballToStore {
-            http_client,
-            store_dir: &config.store_dir,
-            store_index: store_index.cloned(),
-            store_index_writer: store_index_writer.cloned(),
-            verify_store_integrity: config.verify_store_integrity,
-            strict_store_pkg_content_check: config.strict_store_pkg_content_check,
-            verified_files_cache: Arc::clone(verified_files_cache),
-            package_integrity: metadata.resolution.checkable_integrity(),
-            package_unpacked_size: None,
-            package_file_count: None,
-            package_url: "",
-            package_id: &package_id,
-            requester,
-            prefetched_cas_paths,
-            retry_opts: retry_opts_from_config(config),
-            auth_headers: &config.auth_headers,
-            ignore_file_pattern: None,
-            offline: config.offline,
-            progress_reported: progress_reported.cloned(),
-            store_projection: pnpm_tarball::ArchiveStoreProjection::Package {
-                append_manifest: None,
-            },
-        };
-        let custom_fetch = if let Some(session) = custom_fetcher_session {
-            let opts = serde_json::json!({
-                "pkg": {
-                    "name": package_key.name.to_string(),
-                    "version": metadata.version.clone()
-                        .unwrap_or_else(|| package_key.suffix.version().to_string()),
-                },
-                "lockfileDir": workspace_root,
-                "readManifest": true,
-                "filesIndexFile": pnpm_store_dir::pick_store_index_key(
-                    metadata.resolution.checkable_integrity().map(ToString::to_string).as_deref(),
-                    false, &package_id, !config.ignore_scripts,
-                ),
-            });
-            Some(session.fetch::<Reporter>(download.clone(), &metadata.resolution, opts).await?)
-        } else {
-            None
-        };
-        let (effective_resolution, custom_cas_paths) = match custom_fetch {
-            Some(
-                CustomFetchOutcome::Declined(resolution)
-                | CustomFetchOutcome::Delegate { delegate: resolution, .. },
-            ) => (Some(resolution), None),
-            Some(CustomFetchOutcome::Fetched { tarball, .. }) => {
-                (None, Some(tarball.files_map.clone()))
-            }
-            None => (None, None),
-        };
-        let resolution = effective_resolution.as_ref().unwrap_or(&metadata.resolution);
+        let download = self.ingest(metadata, &package_id);
+        let custom =
+            self.custom_fetch::<Reporter>(package_key, metadata, &package_id, &download).await?;
+        let resolution = custom.resolution.as_ref().unwrap_or(&metadata.resolution);
         // Derived from the effective resolution, not the lockfile's: a
         // custom fetcher's `delegate` can resolve to a directory, and
         // then the file map points at mutable source even though the
         // lockfile entry says otherwise.
         let source_is_mutable = matches!(resolution, LockfileResolution::Directory(_));
-
-        let cas_paths = match (custom_cas_paths, resolution) {
-            (Some(paths), _) => paths,
-            (None, LockfileResolution::Tarball(_) | LockfileResolution::Registry(_)) => {
-                self.tarball_cas_paths::<Reporter>(TarballFetch {
-                    download: &download,
-                    resolution,
+        let cas_paths = match custom.cas_paths {
+            Some(paths) => paths,
+            None => {
+                self.fetch_cas_paths::<Reporter>(SnapshotFetch {
                     package_key,
                     package_id: &package_id,
-                    allow_build: &allow_build_closure,
-                    scripts_prepend_node_path,
+                    resolution,
+                    download: &download,
                 })
                 .await?
             }
-            (None, LockfileResolution::Directory(dir_resolution)) => {
+        };
+        self.link_slot::<Reporter>(
+            SlotLink { package_key, snapshot, package_id: &package_id, source_is_mutable },
+            &cas_paths,
+        )?;
+        Ok(InstalledPackage { cas_paths, source_is_mutable })
+    }
+
+    fn ingest<'d>(
+        &'d self,
+        metadata: &'d PackageMetadata,
+        package_id: &'d str,
+    ) -> IngestTarballToStore<'d> {
+        let config = self.ctx.config;
+        IngestTarballToStore {
+            http_client: self.http_client,
+            store_dir: &config.store_dir,
+            store_index: self.store_index.cloned(),
+            store_index_writer: self.store_index_writer.cloned(),
+            verify_store_integrity: config.verify_store_integrity,
+            strict_store_pkg_content_check: config.strict_store_pkg_content_check,
+            verified_files_cache: Arc::clone(self.verified_files_cache),
+            package_integrity: metadata.resolution.checkable_integrity(),
+            package_unpacked_size: None,
+            package_file_count: None,
+            package_url: "",
+            package_id,
+            requester: self.ctx.requester,
+            prefetched_cas_paths: self.prefetched_cas_paths,
+            retry_opts: retry_opts_from_config(config),
+            auth_headers: &config.auth_headers,
+            ignore_file_pattern: None,
+            offline: config.offline,
+            progress_reported: self.progress_reported.cloned(),
+            store_projection: pnpm_tarball::ArchiveStoreProjection::Package {
+                append_manifest: None,
+            },
+        }
+    }
+
+    async fn custom_fetch<Reporter: self::Reporter>(
+        &self,
+        package_key: &PackageKey,
+        metadata: &PackageMetadata,
+        package_id: &str,
+        download: &IngestTarballToStore<'_>,
+    ) -> Result<CustomFetched, InstallPackageBySnapshotError> {
+        let Some(session) = self.custom_fetcher_session else {
+            return Ok(CustomFetched { resolution: None, cas_paths: None });
+        };
+        let config = self.ctx.config;
+        let opts = serde_json::json!({
+            "pkg": {
+                "name": package_key.name.to_string(),
+                "version": metadata.version.clone()
+                    .unwrap_or_else(|| package_key.suffix.version().to_string()),
+            },
+            "lockfileDir": self.ctx.workspace_root,
+            "readManifest": true,
+            "filesIndexFile": pnpm_store_dir::pick_store_index_key(
+                metadata.resolution.checkable_integrity().map(ToString::to_string).as_deref(),
+                false, package_id, !config.ignore_scripts,
+            ),
+        });
+        Ok(match session.fetch::<Reporter>(download.clone(), &metadata.resolution, opts).await? {
+            CustomFetchOutcome::Declined(resolution)
+            | CustomFetchOutcome::Delegate { delegate: resolution, .. } => {
+                CustomFetched { resolution: Some(resolution), cas_paths: None }
+            }
+            CustomFetchOutcome::Fetched { tarball, .. } => {
+                CustomFetched { resolution: None, cas_paths: Some(tarball.files_map.clone()) }
+            }
+        })
+    }
+
+    async fn fetch_cas_paths<Reporter: self::Reporter>(
+        &self,
+        fetch: SnapshotFetch<'_>,
+    ) -> Result<HashMap<String, PathBuf>, InstallPackageBySnapshotError> {
+        let config = self.ctx.config;
+        // Named local so both git fetchers can borrow it across their
+        // `.await` without depending on temporary-lifetime extension.
+        let allow_build = self.allow_build();
+        match fetch.resolution {
+            LockfileResolution::Tarball(_) | LockfileResolution::Registry(_) => {
+                self.tarball_cas_paths::<Reporter>(TarballFetch {
+                    download: fetch.download,
+                    resolution: fetch.resolution,
+                    package_key: fetch.package_key,
+                    package_id: fetch.package_id,
+                    allow_build: &allow_build,
+                    scripts_prepend_node_path: exec_scripts_prepend_node_path(config),
+                })
+                .await
+            }
+            LockfileResolution::Directory(dir_resolution) => {
                 // Injected workspace dep (`file:./local-pkg` with
                 // `dependenciesMeta[*].injected = true`). The source
                 // dir resolves as
@@ -418,12 +417,11 @@ impl InstallPackageBySnapshot<'_> {
                 // `import_indexed_dir` hardlink-or-copy from those
                 // source paths into the slot / hoisted directory just
                 // like they would from a CAS-resident entry.
-                //
                 fetch_directory_resolution(
-                    workspace_root,
+                    self.ctx.workspace_root,
                     dir_resolution,
                     !config.deploy_all_files,
-                )?
+                )
             }
             // Runtime artifacts (Node.js / Bun / Deno) — `Binary`
             // and `Variations` carry a `BinaryResolution` describing
@@ -431,123 +429,179 @@ impl InstallPackageBySnapshot<'_> {
             // platform wrapper: pick the variant whose `targets`
             // includes the host triple, then route through the same
             // `BinaryResolution` extractor.
-            (None, LockfileResolution::Binary(binary)) => {
-                fetch_binary_resolution_to_cas::<Reporter>(
-                    binary,
-                    http_client,
-                    config,
-                    store_index,
-                    store_index_writer,
-                    verified_files_cache,
-                    prefetched_cas_paths,
-                    package_key,
-                    requester,
-                    archive_filter_for(package_key),
-                )
-                .await?
+            LockfileResolution::Binary(binary) => {
+                self.fetch_binary::<Reporter>(binary, fetch.package_key).await
             }
-            (None, LockfileResolution::Variations(variations)) => {
-                fetch_binary_resolution_to_cas::<Reporter>(
-                    binary_variant_for_host(variations, package_key, runtime_platform_selector)?,
-                    http_client,
-                    config,
-                    store_index,
-                    store_index_writer,
-                    verified_files_cache,
-                    prefetched_cas_paths,
-                    package_key,
-                    requester,
-                    archive_filter_for(package_key),
+            LockfileResolution::Variations(variations) => {
+                self.fetch_binary::<Reporter>(
+                    binary_variant_for_host(
+                        variations,
+                        fetch.package_key,
+                        self.runtime_platform_selector,
+                    )?,
+                    fetch.package_key,
                 )
-                .await?
-            }
-            (None, LockfileResolution::Git(git_resolution)) => {
-                // Same `built = !ignore_scripts` rationale as the
-                // git-hosted tarball branch above — key shape stays in
-                // lock-step with `snapshot_cache_key`.
-                let built = !config.ignore_scripts;
-                let files_index_file = git_hosted_store_index_key(&package_id, built);
-                let package_name = package_key.name.to_string();
-                let GitFetchOutput { cas_paths, built: _built } = GitFetcher {
-                    repo: &git_resolution.repo,
-                    commit: &git_resolution.commit,
-                    path: git_resolution.path.as_deref(),
-                    git_shallow_hosts: &config.git_shallow_hosts,
-                    allow_build: &allow_build_closure,
-                    ignore_scripts: config.ignore_scripts,
-                    unsafe_perm: config.unsafe_perm,
-                    user_agent: Some(&config.user_agent),
-                    scripts_prepend_node_path,
-                    script_shell: None,
-                    node_execpath: None,
-                    npm_execpath: None,
-                    pnpm_execpath: PNPM_EXECPATH.as_deref(),
-                    store_dir: &config.store_dir,
-                    package_id: &package_id,
-                    package_name: &package_name,
-                    requester,
-                    store_index_writer,
-                    files_index_file: &files_index_file,
-                    git_bin: None,
-                }
-                .run::<Reporter>()
                 .await
-                .map_err(InstallPackageBySnapshotError::GitFetch)?;
-                cas_paths
+            }
+            LockfileResolution::Git(git_resolution) => {
+                self.fetch_git::<Reporter>(&fetch, git_resolution, &allow_build).await
             }
             // A custom-typed resolution cannot be materialized without
             // a custom fetcher that claims it.
-            (None, LockfileResolution::Custom(custom)) => {
-                return Err(InstallPackageBySnapshotError::UnsupportedResolutionType {
+            LockfileResolution::Custom(custom) => {
+                Err(InstallPackageBySnapshotError::UnsupportedResolutionType {
                     resolution_type: custom.resolution_type.to_string(),
-                });
+                })
             }
-        };
-
-        // Under hoisted, the virtual-store slot would be unused —
-        // [`crate::link_hoisted_modules()`] consumes the CAS paths
-        // directly to materialize project-tree `node_modules/`
-        // directories, so any slot we'd write here would only waste
-        // disk. Hoisted skips both `linkAllModules` (slot symlinks)
-        // and `linkAllPkgs` (slot file imports), and runs
-        // `linkHoistedModules` over the CAS paths instead.
-        if !defer_link && matches!(node_linker, NodeLinker::Isolated | NodeLinker::Pnp) {
-            CreateVirtualDirBySnapshot {
-                layout,
-                cas_paths: &cas_paths,
-                import_method: config.package_import_method,
-                logged_methods,
-                requester,
-                package_id: &package_id,
-                package_key,
-                snapshot,
-                source_is_mutable,
-                force_import: false,
-                include_optional_dependencies,
-                symlink: config.symlink,
-                skipped,
-                // The non-deferred slot link runs only on the fresh
-                // single-package path (no previous install to diff
-                // against), so there are never obsolete children here.
-                removed_aliases: &[],
-                needs_build_marker_source: None,
-                // The fresh single-package path materializes one slot;
-                // there is no per-install batch to amortize a cache
-                // layout over.
-                dir_clone_cache: None,
-                #[cfg(test)]
-                link_concurrency_probe,
-            }
-            .run::<Reporter>()
-            .map_err(InstallPackageBySnapshotError::CreateVirtualDir)?;
         }
+    }
 
-        Ok(InstalledPackage { cas_paths, source_is_mutable })
+    /// `AllowBuildPolicy::check` returns `None` when the package is
+    /// neither allow-listed nor deny-listed. The default is deny
+    /// (`None → false`): build scripts have to be explicitly opted in to
+    /// run.
+    fn allow_build(&self) -> impl Fn(&str) -> bool + Send + Sync {
+        let policy = self.ctx.allow_build_policy;
+        move |dep_path: &str| policy.check(dep_path).unwrap_or(false)
+    }
+
+    async fn fetch_binary<Reporter: self::Reporter>(
+        &self,
+        binary: &BinaryResolution,
+        package_key: &PackageKey,
+    ) -> Result<HashMap<String, PathBuf>, InstallPackageBySnapshotError> {
+        fetch_binary_resolution_to_cas::<Reporter>(
+            binary,
+            self.http_client,
+            self.ctx.config,
+            self.store_index,
+            self.store_index_writer,
+            self.verified_files_cache,
+            self.prefetched_cas_paths,
+            package_key,
+            self.ctx.requester,
+            archive_filter_for(package_key),
+        )
+        .await
+    }
+
+    async fn fetch_git<Reporter: self::Reporter>(
+        &self,
+        fetch: &SnapshotFetch<'_>,
+        git_resolution: &pnpm_lockfile::GitResolution,
+        allow_build: &(impl Fn(&str) -> bool + Send + Sync),
+    ) -> Result<HashMap<String, PathBuf>, InstallPackageBySnapshotError> {
+        let config = self.ctx.config;
+        // Same `built = !ignore_scripts` rationale as the git-hosted
+        // tarball branch — key shape stays in lock-step with
+        // `snapshot_cache_key`.
+        let built = !config.ignore_scripts;
+        let files_index_file = git_hosted_store_index_key(fetch.package_id, built);
+        let package_name = fetch.package_key.name.to_string();
+        let GitFetchOutput { cas_paths, built: _built } = GitFetcher {
+            repo: &git_resolution.repo,
+            commit: &git_resolution.commit,
+            path: git_resolution.path.as_deref(),
+            git_shallow_hosts: &config.git_shallow_hosts,
+            allow_build,
+            ignore_scripts: config.ignore_scripts,
+            unsafe_perm: config.unsafe_perm,
+            user_agent: Some(&config.user_agent),
+            scripts_prepend_node_path: exec_scripts_prepend_node_path(config),
+            script_shell: None,
+            node_execpath: None,
+            npm_execpath: None,
+            pnpm_execpath: PNPM_EXECPATH.as_deref(),
+            store_dir: &config.store_dir,
+            package_id: fetch.package_id,
+            package_name: &package_name,
+            requester: self.ctx.requester,
+            store_index_writer: self.store_index_writer,
+            files_index_file: &files_index_file,
+            git_bin: None,
+        }
+        .run::<Reporter>()
+        .await
+        .map_err(InstallPackageBySnapshotError::GitFetch)?;
+        Ok(cas_paths)
+    }
+
+    /// Under hoisted, the virtual-store slot would be unused —
+    /// [`crate::link_hoisted_modules()`] consumes the CAS paths
+    /// directly to materialize project-tree `node_modules/`
+    /// directories, so any slot written here would only waste disk.
+    /// Hoisted skips both `linkAllModules` (slot symlinks) and
+    /// `linkAllPkgs` (slot file imports), and runs `linkHoistedModules`
+    /// over the CAS paths instead.
+    fn link_slot<Reporter: self::Reporter>(
+        &self,
+        slot: SlotLink<'_>,
+        cas_paths: &HashMap<String, PathBuf>,
+    ) -> Result<(), InstallPackageBySnapshotError> {
+        let config = self.ctx.config;
+        if self.defer_link
+            || !matches!(self.ctx.node_linker, NodeLinker::Isolated | NodeLinker::Pnp)
+        {
+            return Ok(());
+        }
+        CreateVirtualDirBySnapshot {
+            layout: self.ctx.layout,
+            cas_paths,
+            import_method: config.package_import_method,
+            logged_methods: self.ctx.logged_methods,
+            requester: self.ctx.requester,
+            package_id: slot.package_id,
+            package_key: slot.package_key,
+            snapshot: slot.snapshot,
+            source_is_mutable: slot.source_is_mutable,
+            force_import: false,
+            include_optional_dependencies: self.include_optional_dependencies,
+            symlink: config.symlink,
+            skipped: self.skipped,
+            // The non-deferred slot link runs only on the fresh
+            // single-package path (no previous install to diff
+            // against), so there are never obsolete children here.
+            removed_aliases: &[],
+            needs_build_marker_source: None,
+            // The fresh single-package path materializes one slot;
+            // there is no per-install batch to amortize a cache
+            // layout over.
+            dir_clone_cache: None,
+            #[cfg(test)]
+            link_concurrency_probe: self.link_concurrency_probe,
+        }
+        .run::<Reporter>()
+        .map_err(InstallPackageBySnapshotError::CreateVirtualDir)
     }
 }
 
 /// The per-call inputs of [`InstallPackageBySnapshot::tarball_cas_paths`],
 /// alongside the install-scoped ones it reads off `self`.
+/// What a custom fetcher made of the lockfile's resolution: a
+/// replacement resolution when it declined or delegated, the files when
+/// it fetched, neither when no fetcher is configured.
+struct CustomFetched {
+    resolution: Option<LockfileResolution>,
+    cas_paths: Option<HashMap<String, PathBuf>>,
+}
+
+struct SnapshotFetch<'f> {
+    package_key: &'f PackageKey,
+    package_id: &'f str,
+    /// The effective resolution, which a custom fetcher's `delegate`
+    /// may have replaced.
+    resolution: &'f LockfileResolution,
+    download: &'f IngestTarballToStore<'f>,
+}
+
+#[derive(Clone, Copy)]
+struct SlotLink<'s> {
+    package_key: &'s PackageKey,
+    snapshot: &'s SnapshotEntry,
+    package_id: &'s str,
+    source_is_mutable: bool,
+}
+
 struct TarballFetch<'a, AllowBuild> {
     download: &'a IngestTarballToStore<'a>,
     /// The effective resolution, which a custom fetcher's `delegate`
@@ -566,69 +620,69 @@ impl InstallPackageBySnapshot<'_> {
         &self,
         fetch: TarballFetch<'_, impl Fn(&str) -> bool + Send + Sync>,
     ) -> Result<HashMap<String, PathBuf>, InstallPackageBySnapshotError> {
-        let TarballFetch {
-            download,
-            resolution,
-            package_key,
-            package_id,
-            allow_build,
-            scripts_prepend_node_path,
-        } = fetch;
         let config = self.ctx.config;
-        let revision_addressed = match resolution {
+        let revision_addressed = match fetch.resolution {
             LockfileResolution::Tarball(tarball) => tarball.revision.is_some(),
             LockfileResolution::Registry(registry) => registry.revision.is_some(),
             _ => false,
         };
-        let (tarball_url, integrity) = tarball_url_and_integrity(resolution, package_key, config)?;
+        let (tarball_url, integrity) =
+            tarball_url_and_integrity(fetch.resolution, fetch.package_key, config)?;
         let tarball_url = local_file_tarball_install_url(tarball_url, self.ctx.workspace_root);
         let download = IngestTarballToStore {
             package_url: &tarball_url,
             package_integrity: integrity,
-            ..download.clone()
+            ..fetch.download.clone()
         };
         let raw_cas_paths = download_tarball::<Reporter>(
             download,
             self.tarball_mem_cache
-                .filter(|_| matches!(resolution, LockfileResolution::Registry(_)))
+                .filter(|_| matches!(fetch.resolution, LockfileResolution::Registry(_)))
                 .map(std::convert::AsRef::as_ref),
             revision_addressed,
         )
         .await
         .map_err(InstallPackageBySnapshotError::DownloadTarball)?;
-
-        // Run the git-hosted prepare+packlist pass for tarballs sourced
-        // from a git host: a `gitHosted: true` tarball routes through
-        // `gitHostedTarballFetcher` rather than the plain
-        // `remoteTarballFetcher`, because the host's archive endpoint
-        // doesn't run `prepare`/`prepublish*` and the file set typically
-        // needs packlist filtering.
-        let LockfileResolution::Tarball(tarball) = resolution else {
-            return Ok(raw_cas_paths);
-        };
-        if !tarball.is_git_hosted() {
-            return Ok(raw_cas_paths);
+        match fetch.resolution {
+            LockfileResolution::Tarball(tarball) if tarball.is_git_hosted() => {
+                self.prepare_git_hosted::<Reporter>(&fetch, tarball, raw_cas_paths).await
+            }
+            _ => Ok(raw_cas_paths),
         }
+    }
+
+    /// The git-hosted prepare+packlist pass: a `gitHosted: true` tarball
+    /// routes through `gitHostedTarballFetcher` rather than the plain
+    /// `remoteTarballFetcher`, because the host's archive endpoint
+    /// doesn't run `prepare`/`prepublish*` and the file set typically
+    /// needs packlist filtering.
+    async fn prepare_git_hosted<Reporter: self::Reporter>(
+        &self,
+        fetch: &TarballFetch<'_, impl Fn(&str) -> bool + Send + Sync>,
+        tarball: &pnpm_lockfile::TarballResolution,
+        cas_paths: HashMap<String, PathBuf>,
+    ) -> Result<HashMap<String, PathBuf>, InstallPackageBySnapshotError> {
+        let config = self.ctx.config;
         // `built` tracks `!ignore_scripts`, in lock-step with the key
         // shape `snapshot_cache_key` produces — otherwise the prefetch
         // and the write would address different slots. Under
         // `--ignore-scripts` the git-hosted `prepare` is suppressed too,
         // matching pnpm's `ignoreScripts`.
-        let files_index_file = git_hosted_store_index_key(package_id, !config.ignore_scripts);
+        let files_index_file = git_hosted_store_index_key(fetch.package_id, !config.ignore_scripts);
         let GitFetchOutput { cas_paths, built: _built } = GitHostedTarballFetcher {
-            cas_paths: raw_cas_paths,
+            cas_paths,
             path: tarball.path.as_deref(),
-            allow_build,
+            allow_build: fetch.allow_build,
             ignore_scripts: config.ignore_scripts,
             unsafe_perm: config.unsafe_perm,
             user_agent: Some(&config.user_agent),
-            scripts_prepend_node_path,
+            scripts_prepend_node_path: fetch.scripts_prepend_node_path,
             script_shell: None,
             node_execpath: None,
             npm_execpath: None,
             pnpm_execpath: PNPM_EXECPATH.as_deref(),
             store_dir: &config.store_dir,
-            package_id,
+            package_id: fetch.package_id,
             requester: self.ctx.requester,
             store_index_writer: self.store_index_writer,
             files_index_file: &files_index_file,

--- a/pnpm/crates/deps-restorer/src/install_package_from_registry.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_from_registry.rs
@@ -116,29 +116,13 @@ impl InstallPackageFromRegistry<'_> {
     pub async fn run<Reporter: self::Reporter>(
         self,
     ) -> Result<(), InstallPackageFromRegistryError> {
-        let InstallPackageFromRegistry {
-            tarball_mem_cache,
-            http_client,
-            config,
-            store_index,
-            store_index_writer,
-            verified_files_cache,
-            prefetched_cas_paths,
-            logged_methods,
-            requester,
-            node_modules_dir,
-            slot_dir,
-            alias,
-            resolution,
-            first_visit,
-        } = self;
-
-        let (real_name, version) = real_name_version(resolution).ok_or_else(|| {
+        let (real_name, version) = real_name_version(self.resolution).ok_or_else(|| {
             InstallPackageFromRegistryError::UnsupportedResolution {
                 detail: format!(
                     "resolver {resolved_via} produced a resolution without a structured \
                      name@version and no manifest name/version to fall back to (alias={alias})",
-                    resolved_via = resolution.resolved_via,
+                    resolved_via = self.resolution.resolved_via,
+                    alias = self.alias,
                 ),
             }
         })?;
@@ -151,92 +135,98 @@ impl InstallPackageFromRegistry<'_> {
         // `real_name` is untrusted for tarball/git/file deps (read from
         // the fetched manifest), so the join is guarded against a
         // traversal-shaped name escaping `node_modules`.
-        let save_path = safe_join_modules_dir(&slot_dir.join("node_modules"), &real_name)
+        let save_path = safe_join_modules_dir(&self.slot_dir.join("node_modules"), &real_name)
             .map_err(InstallPackageFromRegistryError::InvalidAlias)?;
 
-        let symlink_path = node_modules_dir.join(alias);
-
-        if first_visit {
-            let revision_addressed = matches!(
-                &resolution.resolution,
-                LockfileResolution::Tarball(tarball) if tarball.revision.is_some(),
-            );
-            let (tarball_url, integrity) = extract_tarball(&resolution.resolution)?;
-            let unpacked_size = manifest_unpacked_size(resolution.manifest.as_deref());
-            let file_count = manifest_file_count(resolution.manifest.as_deref());
-
-            Reporter::emit(&LogEvent::Progress(ProgressLog {
-                level: LogLevel::Debug,
-                message: ProgressMessage::Resolved {
-                    package_id: package_id.clone(),
-                    requester: requester.to_owned(),
-                },
-            }));
-
-            // TODO: skip when it already exists in store?
-            let download = IngestTarballToStore {
-                http_client,
-                store_dir: &config.store_dir,
-                store_index: store_index.cloned(),
-                store_index_writer: store_index_writer.cloned(),
-                verify_store_integrity: config.verify_store_integrity,
-                strict_store_pkg_content_check: config.strict_store_pkg_content_check,
-                verified_files_cache: SharedVerifiedFilesCache::clone(verified_files_cache),
-                package_integrity: Some(&integrity),
-                package_unpacked_size: unpacked_size,
-                package_file_count: file_count,
-                package_url: tarball_url,
-                package_id: &package_id,
-                requester,
-                prefetched_cas_paths,
-                retry_opts: retry_opts_from_config(config),
-                auth_headers: &config.auth_headers,
-                ignore_file_pattern: None,
-                offline: config.offline,
-                // This recursive install path owns its package-status
-                // progress directly; no resolve-time prefetch shares a
-                // dedupe set with it.
-                progress_reported: None,
-                store_projection: pnpm_tarball::ArchiveStoreProjection::Package {
-                    append_manifest: None,
-                },
-            };
-            let cas_paths = if revision_addressed {
-                download.run_revision_addressed_with_mem_cache::<Reporter>(tarball_mem_cache).await
-            } else {
-                download.run_with_mem_cache::<Reporter>(tarball_mem_cache).await
-            }
-            .map_err(InstallPackageFromRegistryError::IngestTarballToStore)?;
-
-            tracing::info!(target: "pacquet::import", ?save_path, ?symlink_path, "Import package");
-
-            import_indexed_dir::<Reporter>(
-                logged_methods,
-                config.package_import_method,
-                &save_path,
-                &cas_paths,
-                ImportIndexedDirOpts::default(),
-            )
-            .map_err(InstallPackageFromRegistryError::ImportIndexedDir)?;
-
-            // `pnpm:progress imported` — see the matching emit in
-            // `create_virtual_dir_by_snapshot::run` for the rationale
-            // on the optimistic `method` value. `to` is the per-
-            // package virtual-store directory the symlink under
-            // `node_modules/{alias}` resolves to.
-            Reporter::emit(&LogEvent::Progress(ProgressLog {
-                level: LogLevel::Debug,
-                message: ProgressMessage::Imported {
-                    method: crate::optimistic_wire_method(config.package_import_method),
-                    requester: requester.to_owned(),
-                    to: save_path.to_string_lossy().into_owned(),
-                },
-            }));
+        if self.first_visit {
+            self.ingest_and_import::<Reporter>(&package_id, &save_path).await?;
         }
 
-        symlink_package(&save_path, &symlink_path)
+        symlink_package(&save_path, &self.node_modules_dir.join(self.alias))
             .map_err(InstallPackageFromRegistryError::SymlinkPackage)?;
 
+        Ok(())
+    }
+
+    async fn ingest_and_import<Reporter: self::Reporter>(
+        &self,
+        package_id: &str,
+        save_path: &Path,
+    ) -> Result<(), InstallPackageFromRegistryError> {
+        let config = self.config;
+        let revision_addressed = matches!(
+            &self.resolution.resolution,
+            LockfileResolution::Tarball(tarball) if tarball.revision.is_some(),
+        );
+        let (tarball_url, integrity) = extract_tarball(&self.resolution.resolution)?;
+
+        Reporter::emit(&LogEvent::Progress(ProgressLog {
+            level: LogLevel::Debug,
+            message: ProgressMessage::Resolved {
+                package_id: package_id.to_owned(),
+                requester: self.requester.to_owned(),
+            },
+        }));
+
+        // TODO: skip when it already exists in store?
+        let download = IngestTarballToStore {
+            http_client: self.http_client,
+            store_dir: &config.store_dir,
+            store_index: self.store_index.cloned(),
+            store_index_writer: self.store_index_writer.cloned(),
+            verify_store_integrity: config.verify_store_integrity,
+            strict_store_pkg_content_check: config.strict_store_pkg_content_check,
+            verified_files_cache: SharedVerifiedFilesCache::clone(self.verified_files_cache),
+            package_integrity: Some(&integrity),
+            package_unpacked_size: manifest_unpacked_size(self.resolution.manifest.as_deref()),
+            package_file_count: manifest_file_count(self.resolution.manifest.as_deref()),
+            package_url: tarball_url,
+            package_id,
+            requester: self.requester,
+            prefetched_cas_paths: self.prefetched_cas_paths,
+            retry_opts: retry_opts_from_config(config),
+            auth_headers: &config.auth_headers,
+            ignore_file_pattern: None,
+            offline: config.offline,
+            // This recursive install path owns its package-status
+            // progress directly; no resolve-time prefetch shares a
+            // dedupe set with it.
+            progress_reported: None,
+            store_projection: pnpm_tarball::ArchiveStoreProjection::Package {
+                append_manifest: None,
+            },
+        };
+        let cas_paths = if revision_addressed {
+            download.run_revision_addressed_with_mem_cache::<Reporter>(self.tarball_mem_cache).await
+        } else {
+            download.run_with_mem_cache::<Reporter>(self.tarball_mem_cache).await
+        }
+        .map_err(InstallPackageFromRegistryError::IngestTarballToStore)?;
+
+        tracing::info!(target: "pacquet::import", ?save_path, "Import package");
+
+        import_indexed_dir::<Reporter>(
+            self.logged_methods,
+            config.package_import_method,
+            save_path,
+            &cas_paths,
+            ImportIndexedDirOpts::default(),
+        )
+        .map_err(InstallPackageFromRegistryError::ImportIndexedDir)?;
+
+        // `pnpm:progress imported` — see the matching emit in
+        // `create_virtual_dir_by_snapshot::run` for the rationale
+        // on the optimistic `method` value. `to` is the per-
+        // package virtual-store directory the symlink under
+        // `node_modules/{alias}` resolves to.
+        Reporter::emit(&LogEvent::Progress(ProgressLog {
+            level: LogLevel::Debug,
+            message: ProgressMessage::Imported {
+                method: crate::optimistic_wire_method(config.package_import_method),
+                requester: self.requester.to_owned(),
+                to: save_path.to_string_lossy().into_owned(),
+            },
+        }));
         Ok(())
     }
 }

--- a/pnpm/crates/deps-restorer/src/link_bins.rs
+++ b/pnpm/crates/deps-restorer/src/link_bins.rs
@@ -745,35 +745,21 @@ where
         + FsSetExecutable
         + FsEnsureExecutableBits,
 {
-    let &SlotBinContext { layout, sets, package_manifests, link_options } = context;
-    let with_bin = children_with_bins(snapshot, sets.has_bin);
+    let with_bin = children_with_bins(snapshot, context.sets.has_bin);
     let self_metadata_key = slot_key.without_peer();
-    let self_has_bin = declares_bin(sets.has_bin, &self_metadata_key);
-    let self_bundles = sets.bundling.contains(&self_metadata_key);
+    let self_has_bin = declares_bin(context.sets.has_bin, &self_metadata_key);
+    let self_bundles = context.sets.bundling.contains(&self_metadata_key);
     if with_bin.is_empty() && !self_has_bin && !self_bundles {
         return Ok(());
     }
 
-    let slot_dir = layout.slot_dir(slot_key);
-    let modules_dir = slot_dir.join("node_modules");
+    let modules_dir = context.layout.slot_dir(slot_key).join("node_modules");
     let self_pkg_dir = slot_own_pkg_dir(&modules_dir, slot_key);
     let bins_dir = self_pkg_dir.join("node_modules/.bin");
 
     let mut bin_sources: Vec<PackageBinSource> =
         Vec::with_capacity(with_bin.len() + usize::from(self_has_bin));
-    for (alias, child_key, metadata_key) in with_bin {
-        push_bin_source::<Sys>(
-            &mut bin_sources,
-            package_manifests,
-            &metadata_key,
-            pkg_dir_under(&modules_dir, alias),
-            // The child location reaches the child through the slot's
-            // alias symlink; the layout knows the symlink's destination
-            // without touching the filesystem, so the shim `NODE_PATH`
-            // derivation never has to `realpath`.
-            pkg_dir_under(&layout.slot_dir(&child_key).join("node_modules"), &child_key.name),
-        )?;
-    }
+    push_child_bin_sources::<Sys>(&mut bin_sources, context, &modules_dir, with_bin)?;
 
     // Packages the tarball ships in its own `node_modules` are not
     // lockfile children, so nothing above sees them; their bins are
@@ -791,7 +777,7 @@ where
     if self_has_bin {
         push_bin_source::<Sys>(
             &mut bin_sources,
-            package_manifests,
+            context.package_manifests,
             &self_metadata_key,
             self_pkg_dir.clone(),
             self_pkg_dir,
@@ -801,8 +787,33 @@ where
     if bin_sources.is_empty() {
         return Ok(());
     }
-    link_bins_of_packages::<Sys>(&bin_sources, &bins_dir, link_options)
+    link_bins_of_packages::<Sys>(&bin_sources, &bins_dir, context.link_options)
         .map_err(LinkVirtualStoreBinsError::LinkBins)
+}
+
+fn push_child_bin_sources<Sys: FsReadFile>(
+    bin_sources: &mut Vec<PackageBinSource>,
+    context: &SlotBinContext<'_>,
+    modules_dir: &Path,
+    with_bin: Vec<(&PkgName, PackageKey, PackageKey)>,
+) -> Result<(), LinkVirtualStoreBinsError> {
+    for (alias, child_key, metadata_key) in with_bin {
+        push_bin_source::<Sys>(
+            bin_sources,
+            context.package_manifests,
+            &metadata_key,
+            pkg_dir_under(modules_dir, alias),
+            // The child location reaches the child through the slot's
+            // alias symlink; the layout knows the symlink's destination
+            // without touching the filesystem, so the shim `NODE_PATH`
+            // derivation never has to `realpath`.
+            pkg_dir_under(
+                &context.layout.slot_dir(&child_key).join("node_modules"),
+                &child_key.name,
+            ),
+        )?;
+    }
+    Ok(())
 }
 
 /// Whether the lockfile says this package declares a bin. No

--- a/pnpm/crates/deps-restorer/src/linking.rs
+++ b/pnpm/crates/deps-restorer/src/linking.rs
@@ -11,9 +11,8 @@ use crate::{
     CasPathsByPkgId, LinkVirtualStoreBins, PackageManifests, SkippedSnapshots,
     SymlinkDirectDependencies, VirtualStoreLayout,
     install_frozen_lockfile::{
-        HoistPlan, HoistedLinkerError, HoistedLinkerInputs, HoistedLinkerOutput,
-        collect_public_hoist_targets, compute_hoist_plan, run_hoisted_linker,
-        workspace_packages_for_hoist,
+        HoistPlan, HoistedLinkerError, HoistedLinkerInputs, collect_public_hoist_targets,
+        compute_hoist_plan, run_hoisted_linker, workspace_packages_for_hoist,
     },
     link_direct_dep_bins_resolved, link_root_component_members, symlink_hoisted_dependencies,
 };
@@ -190,175 +189,180 @@ pub fn run_link_phase<Reporter: self::Reporter>(
     inputs: LinkPhaseInputs<'_>,
     skipped: &mut SkippedSnapshots,
 ) -> Result<LinkPhaseOutput, LinkPhaseError> {
-    let LinkPhaseInputs {
-        ctx,
-        symlink_root,
-        trusted_importer_ids,
-        root_component_importers,
-        sidecar_lockfile,
-        lockfile,
-        current_lockfile,
-        materialized_snapshots,
-        project_manifests,
-        package_map_project_manifests,
-        dependency_groups,
-        package_manifests,
-        requires_build_by_snapshot,
-        cas_paths_by_pkg_id,
-        prune_orphans,
-        prior_hoisted_dependencies,
-        host_node,
-        supported_architectures,
-    } = inputs;
-    let &crate::InstallContext {
-        config,
-        workspace_root,
-        requester,
-        layout,
-        node_linker,
-        link_options,
-        logged_methods,
-        ..
-    } = ctx;
-    let is_hoisted = ctx.is_hoisted();
-    let Lockfile { importers, packages, snapshots, .. } = lockfile;
-    let (packages, snapshots) = (packages.as_ref(), snapshots.as_ref());
-
-    // `hoistWorkspacePackages`: named non-root projects become hoist
-    // candidates whose links point at the project dirs.
-    let hoisted_workspace_packages = config
-        .hoist_workspace_packages
-        .then(|| workspace_packages_for_hoist(workspace_root, project_manifests));
-    // Planned before the links are written, not with them: an importer's
-    // dep that public-hoist lands at root has to be in
-    // `SymlinkDirectDependencies`'s dedupe map, and `write_hoist_links`
-    // reuses the plan rather than walking a second time.
-    let phase_start = std::time::Instant::now();
-    let pre_hoist = compute_hoist_plan(
-        config,
-        snapshots,
-        packages,
-        importers,
-        dependency_groups,
-        skipped,
-        is_hoisted,
-        hoisted_workspace_packages.as_ref(),
-    );
-    let public_hoist_targets: Option<BTreeMap<String, PathBuf>> = pre_hoist
-        .as_ref()
-        .map(|plan| collect_public_hoist_targets(&plan.result, &plan.graph, layout, &plan.skipped));
-    tracing::info!(target: "pacquet::install::phase", phase = "link.hoist_plan", elapsed_ms = phase_start.elapsed().as_millis() as u64, "phase complete");
+    let hoist = plan_hoist(&inputs, skipped);
 
     // `nodeLinker: hoisted` writes no virtual store — `CreateVirtualStore`
     // skipped the slots — so there is nothing to link into or out of.
-    let has_virtual_store = !is_hoisted;
-    let links_importer_tree = has_virtual_store && !config.virtual_store_only;
-
-    // Reconcile first, so stale direct-dep and orphaned hoist links
-    // vacate the slots the relink + rehoist below claim. The hoisted
-    // linker reconciles and emits this `removed` event itself (see
-    // [`crate::link_hoisted_modules()`]), keeping it one per install —
-    // the pair of the `added` emitted in `CreateVirtualStore`.
-    if links_importer_tree {
-        let removed_count = current_lockfile
-            .map(|current| {
-                crate::PruneStaleModules {
-                    config,
-                    workspace_root: symlink_root,
-                    wanted_lockfile: lockfile,
-                    current_lockfile: current,
-                    prior_hoisted_dependencies,
-                    included_groups: dependency_groups,
-                    prune_orphans,
-                }
-                .run::<Reporter>()
-                .map_err(LinkPhaseError::PruneStaleModules)
-            })
-            .transpose()?
-            .unwrap_or(0);
-        Reporter::emit(&LogEvent::Stats(StatsLog {
-            level: LogLevel::Debug,
-            message: StatsMessage::Removed { prefix: requester.to_owned(), removed: removed_count },
-        }));
-
-        let phase_start = std::time::Instant::now();
-        SymlinkDirectDependencies {
-            config,
-            layout,
-            importers,
-            packages,
-            dependency_groups: dependency_groups.iter().copied(),
-            workspace_root: symlink_root,
-            skipped,
-            link_only: false,
-            public_hoist_targets: public_hoist_targets.as_ref(),
-            trusted_importer_ids: Some(trusted_importer_ids),
-            link_options,
-            package_manifests: Some(package_manifests),
-            requires_build_by_snapshot,
-        }
-        .run::<Reporter>()
-        .map_err(LinkPhaseError::SymlinkDirectDependencies)?;
-        tracing::info!(target: "pacquet::install::phase", phase = "link.symlink_direct_deps", elapsed_ms = phase_start.elapsed().as_millis() as u64, "phase complete");
-
-        // Bit "root components" — a no-op unless an importer declared
-        // `installConfig.hoistingLimits: "workspaces"`.
-        link_root_component_members(
-            layout,
-            importers,
-            snapshots,
-            root_component_importers,
-            dependency_groups,
-            skipped,
-        )
-        .map_err(LinkPhaseError::LinkRootComponentMembers)?;
+    let has_virtual_store = !inputs.ctx.is_hoisted();
+    if has_virtual_store && !inputs.ctx.config.virtual_store_only {
+        relink_importer_tree::<Reporter>(&inputs, skipped, hoist.public_targets.as_ref())?;
     }
-
     if has_virtual_store {
-        // Unlike every other pass here this one also runs under
-        // `virtual_store_only`: the links it writes live inside the
-        // virtual store, and the build phase — which `pnpm fetch` still
-        // runs — resolves a dependency's sibling bin through them.
-        let phase_start = std::time::Instant::now();
-        LinkVirtualStoreBins {
-            layout,
-            snapshots,
-            selected_snapshots: materialized_snapshots,
-            packages,
-            package_manifests,
-            skipped,
-            link_options,
-        }
-        .run()
-        .map_err(LinkPhaseError::LinkVirtualStoreBins)?;
-        tracing::info!(target: "pacquet::install::phase", phase = "link.virtual_store_bins", elapsed_ms = phase_start.elapsed().as_millis() as u64, "phase complete");
+        link_virtual_store_bins(&inputs, skipped)?;
     }
 
     // Everything below writes into the project that `virtual_store_only`
     // exists to leave alone.
-    if config.virtual_store_only {
+    if inputs.ctx.config.virtual_store_only {
         return Ok(LinkPhaseOutput::empty());
     }
+    write_project_links::<Reporter>(inputs, skipped, hoist.plan)
+}
 
-    let HoistedLinkerOutput { hoisted_locations, hoisted_pkg_roots_by_key } = is_hoisted
+/// Planned before the links are written, not with them: an importer's
+/// dep that public-hoist lands at root has to be in
+/// `SymlinkDirectDependencies`'s dedupe map, and `write_hoist_links`
+/// reuses the plan rather than walking a second time.
+struct PlannedHoist {
+    plan: Option<HoistPlan>,
+    public_targets: Option<BTreeMap<String, PathBuf>>,
+}
+
+fn plan_hoist(inputs: &LinkPhaseInputs<'_>, skipped: &SkippedSnapshots) -> PlannedHoist {
+    let config = inputs.ctx.config;
+    // `hoistWorkspacePackages`: named non-root projects become hoist
+    // candidates whose links point at the project dirs.
+    let hoisted_workspace_packages = config
+        .hoist_workspace_packages
+        .then(|| workspace_packages_for_hoist(inputs.ctx.workspace_root, inputs.project_manifests));
+    let phase_start = std::time::Instant::now();
+    let plan = compute_hoist_plan(
+        config,
+        inputs.lockfile.snapshots.as_ref(),
+        inputs.lockfile.packages.as_ref(),
+        &inputs.lockfile.importers,
+        inputs.dependency_groups,
+        skipped,
+        inputs.ctx.is_hoisted(),
+        hoisted_workspace_packages.as_ref(),
+    );
+    let public_targets = plan.as_ref().map(|plan| {
+        collect_public_hoist_targets(&plan.result, &plan.graph, inputs.ctx.layout, &plan.skipped)
+    });
+    tracing::info!(target: "pacquet::install::phase", phase = "link.hoist_plan", elapsed_ms = phase_start.elapsed().as_millis() as u64, "phase complete");
+    PlannedHoist { plan, public_targets }
+}
+
+/// Reconcile first, so stale direct-dep and orphaned hoist links vacate
+/// the slots the relink + rehoist claim. The hoisted linker reconciles
+/// and emits this `removed` event itself (see
+/// [`crate::link_hoisted_modules()`]), keeping it one per install — the
+/// pair of the `added` emitted in `CreateVirtualStore`.
+fn relink_importer_tree<Reporter: self::Reporter>(
+    inputs: &LinkPhaseInputs<'_>,
+    skipped: &SkippedSnapshots,
+    public_hoist_targets: Option<&BTreeMap<String, PathBuf>>,
+) -> Result<(), LinkPhaseError> {
+    let config = inputs.ctx.config;
+    let removed_count = inputs
+        .current_lockfile
+        .map(|current| {
+            crate::PruneStaleModules {
+                config,
+                workspace_root: inputs.symlink_root,
+                wanted_lockfile: inputs.lockfile,
+                current_lockfile: current,
+                prior_hoisted_dependencies: inputs.prior_hoisted_dependencies,
+                included_groups: inputs.dependency_groups,
+                prune_orphans: inputs.prune_orphans,
+            }
+            .run::<Reporter>()
+            .map_err(LinkPhaseError::PruneStaleModules)
+        })
+        .transpose()?
+        .unwrap_or(0);
+    Reporter::emit(&LogEvent::Stats(StatsLog {
+        level: LogLevel::Debug,
+        message: StatsMessage::Removed {
+            prefix: inputs.ctx.requester.to_owned(),
+            removed: removed_count,
+        },
+    }));
+
+    let phase_start = std::time::Instant::now();
+    SymlinkDirectDependencies {
+        config,
+        layout: inputs.ctx.layout,
+        importers: &inputs.lockfile.importers,
+        packages: inputs.lockfile.packages.as_ref(),
+        dependency_groups: inputs.dependency_groups.iter().copied(),
+        workspace_root: inputs.symlink_root,
+        skipped,
+        link_only: false,
+        public_hoist_targets,
+        trusted_importer_ids: Some(inputs.trusted_importer_ids),
+        link_options: inputs.ctx.link_options,
+        package_manifests: Some(inputs.package_manifests),
+        requires_build_by_snapshot: inputs.requires_build_by_snapshot,
+    }
+    .run::<Reporter>()
+    .map_err(LinkPhaseError::SymlinkDirectDependencies)?;
+    tracing::info!(target: "pacquet::install::phase", phase = "link.symlink_direct_deps", elapsed_ms = phase_start.elapsed().as_millis() as u64, "phase complete");
+
+    // Bit "root components" — a no-op unless an importer declared
+    // `installConfig.hoistingLimits: "workspaces"`.
+    link_root_component_members(
+        inputs.ctx.layout,
+        &inputs.lockfile.importers,
+        inputs.lockfile.snapshots.as_ref(),
+        inputs.root_component_importers,
+        inputs.dependency_groups,
+        skipped,
+    )
+    .map_err(LinkPhaseError::LinkRootComponentMembers)
+}
+
+/// Unlike every other link pass this one also runs under
+/// `virtual_store_only`: the links it writes live inside the virtual
+/// store, and the build phase — which `pnpm fetch` still runs — resolves
+/// a dependency's sibling bin through them.
+fn link_virtual_store_bins(
+    inputs: &LinkPhaseInputs<'_>,
+    skipped: &SkippedSnapshots,
+) -> Result<(), LinkPhaseError> {
+    let phase_start = std::time::Instant::now();
+    LinkVirtualStoreBins {
+        layout: inputs.ctx.layout,
+        snapshots: inputs.lockfile.snapshots.as_ref(),
+        selected_snapshots: inputs.materialized_snapshots,
+        packages: inputs.lockfile.packages.as_ref(),
+        package_manifests: inputs.package_manifests,
+        skipped,
+        link_options: inputs.ctx.link_options,
+    }
+    .run()
+    .map_err(LinkPhaseError::LinkVirtualStoreBins)?;
+    tracing::info!(target: "pacquet::install::phase", phase = "link.virtual_store_bins", elapsed_ms = phase_start.elapsed().as_millis() as u64, "phase complete");
+    Ok(())
+}
+
+fn write_project_links<Reporter: self::Reporter>(
+    inputs: LinkPhaseInputs<'_>,
+    skipped: &mut SkippedSnapshots,
+    pre_hoist: Option<HoistPlan>,
+) -> Result<LinkPhaseOutput, LinkPhaseError> {
+    let config = inputs.ctx.config;
+    let hoisted = inputs
+        .ctx
+        .is_hoisted()
         .then(|| {
             run_hoisted_linker::<Reporter>(
                 HoistedLinkerInputs {
                     config,
-                    lockfile,
-                    current_lockfile,
-                    layout,
-                    importers,
-                    dependency_groups,
-                    project_manifests,
-                    package_map_project_manifests,
-                    walker_lockfile_dir: workspace_root,
-                    symlink_workspace_root: symlink_root,
-                    host_node,
-                    supported_architectures,
-                    cas_paths_by_pkg_id,
-                    logged_methods,
-                    requester,
+                    lockfile: inputs.lockfile,
+                    current_lockfile: inputs.current_lockfile,
+                    layout: inputs.ctx.layout,
+                    importers: &inputs.lockfile.importers,
+                    dependency_groups: inputs.dependency_groups,
+                    project_manifests: inputs.project_manifests,
+                    package_map_project_manifests: inputs.package_map_project_manifests,
+                    walker_lockfile_dir: inputs.ctx.workspace_root,
+                    symlink_workspace_root: inputs.symlink_root,
+                    host_node: inputs.host_node,
+                    supported_architectures: inputs.supported_architectures,
+                    cas_paths_by_pkg_id: inputs.cas_paths_by_pkg_id,
+                    logged_methods: inputs.ctx.logged_methods,
+                    requester: inputs.ctx.requester,
                 },
                 skipped,
             )
@@ -367,65 +371,68 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         .transpose()?
         .unwrap_or_default();
 
-    // Publicly hoisted *workspace* packages are the one source of root
-    // bins nothing else shims: every importer's direct-dep bins were
-    // written by `SymlinkDirectDependencies`, and publicly hoisted
-    // regular packages go through the post-build top-level pass
-    // (`publicly_hoisted_for_post_build`) — but that pass resolves bins
-    // out of virtual-store slots, which a workspace project doesn't
-    // have. Collected before `write_hoist_links` consumes the plan;
-    // shimmed after the hoist symlinks land.
-    let public_workspace_bin_deps: Vec<(String, PathBuf)> = pre_hoist
-        .as_ref()
-        .map(|plan| {
-            plan.result
-                .hoisted_workspace_aliases
-                .iter()
-                .filter(|(_, kind, _)| matches!(kind, pnpm_modules_yaml::HoistKind::Public))
-                .map(|(alias, _, project_dir)| (alias.clone(), project_dir.clone()))
-                .collect()
-        })
-        .unwrap_or_default();
-
+    let bin_deps = public_workspace_bin_deps(pre_hoist.as_ref());
     let phase_start = std::time::Instant::now();
-    let HoistLinks { hoisted_dependencies, publicly_hoisted_with_bins } = pre_hoist
-        .map(|plan| write_hoist_links(plan, config, layout, link_options))
+    let links = pre_hoist
+        .map(|plan| write_hoist_links(plan, config, inputs.ctx.layout, inputs.ctx.link_options))
         .transpose()?
         .unwrap_or_else(HoistLinks::none);
     tracing::info!(target: "pacquet::install::phase", phase = "link.write_hoist_links", elapsed_ms = phase_start.elapsed().as_millis() as u64, "phase complete");
 
-    if crate::should_write_package_map(config, node_linker) {
+    if crate::should_write_package_map(config, inputs.ctx.node_linker) {
         crate::package_map::write_package_map(
-            sidecar_lockfile,
+            inputs.sidecar_lockfile,
             &crate::package_map::PackageMapOptions {
-                lockfile_dir: workspace_root,
+                lockfile_dir: inputs.ctx.workspace_root,
                 modules_dir: &config.modules_dir,
                 package_map_type: config.node_package_map_type,
-                layout,
-                project_manifests,
+                layout: inputs.ctx.layout,
+                project_manifests: inputs.project_manifests,
             },
         )
         .map_err(LinkPhaseError::WritePackageMap)?;
     }
-    if matches!(node_linker, NodeLinker::Pnp) {
-        crate::write_pnp_file(sidecar_lockfile, workspace_root, config, layout, project_manifests)
-            .map_err(LinkPhaseError::WritePnpFile)?;
-    }
-    if !public_workspace_bin_deps.is_empty() {
-        link_direct_dep_bins_resolved(
-            &config.modules_dir,
-            &public_workspace_bin_deps,
-            link_options,
+    if matches!(inputs.ctx.node_linker, NodeLinker::Pnp) {
+        crate::write_pnp_file(
+            inputs.sidecar_lockfile,
+            inputs.ctx.workspace_root,
+            config,
+            inputs.ctx.layout,
+            inputs.project_manifests,
         )
-        .map_err(LinkPhaseError::LinkBins)?;
+        .map_err(LinkPhaseError::WritePnpFile)?;
+    }
+    if !bin_deps.is_empty() {
+        link_direct_dep_bins_resolved(&config.modules_dir, &bin_deps, inputs.ctx.link_options)
+            .map_err(LinkPhaseError::LinkBins)?;
     }
 
     Ok(LinkPhaseOutput {
-        hoisted_dependencies,
-        hoisted_locations,
-        hoisted_pkg_roots_by_key,
-        publicly_hoisted_for_post_build: publicly_hoisted_with_bins,
+        hoisted_dependencies: links.hoisted_dependencies,
+        hoisted_locations: hoisted.hoisted_locations,
+        hoisted_pkg_roots_by_key: hoisted.hoisted_pkg_roots_by_key,
+        publicly_hoisted_for_post_build: links.publicly_hoisted_with_bins,
     })
+}
+
+/// Publicly hoisted *workspace* packages are the one source of root
+/// bins nothing else shims: every importer's direct-dep bins were
+/// written by `SymlinkDirectDependencies`, and publicly hoisted regular
+/// packages go through the post-build top-level pass
+/// (`publicly_hoisted_for_post_build`) — but that pass resolves bins out
+/// of virtual-store slots, which a workspace project doesn't have.
+/// Collected before `write_hoist_links` consumes the plan; shimmed after
+/// the hoist symlinks land.
+fn public_workspace_bin_deps(plan: Option<&HoistPlan>) -> Vec<(String, PathBuf)> {
+    plan.map(|plan| {
+        plan.result
+            .hoisted_workspace_aliases
+            .iter()
+            .filter(|(_, kind, _)| matches!(kind, pnpm_modules_yaml::HoistKind::Public))
+            .map(|(alias, _, project_dir)| (alias.clone(), project_dir.clone()))
+            .collect()
+    })
+    .unwrap_or_default()
 }
 
 /// Symlink the hoist plan's aliases into the private

--- a/pnpm/crates/deps-restorer/src/linking.rs
+++ b/pnpm/crates/deps-restorer/src/linking.rs
@@ -211,7 +211,7 @@ pub fn run_link_phase<Reporter: self::Reporter>(
 
 /// Planned before the links are written, not with them: an importer's
 /// dep that public-hoist lands at root has to be in
-/// `SymlinkDirectDependencies`'s dedupe map, and `write_hoist_links`
+/// `SymlinkDirectDependencies`'s dedupe map, and [`write_hoist_links`]
 /// reuses the plan rather than walking a second time.
 struct PlannedHoist {
     plan: Option<HoistPlan>,
@@ -421,7 +421,7 @@ fn write_project_links<Reporter: self::Reporter>(
 /// packages go through the post-build top-level pass
 /// (`publicly_hoisted_for_post_build`) — but that pass resolves bins out
 /// of virtual-store slots, which a workspace project doesn't have.
-/// Collected before `write_hoist_links` consumes the plan; shimmed after
+/// Collected before [`write_hoist_links`] consumes the plan; shimmed after
 /// the hoist symlinks land.
 fn public_workspace_bin_deps(plan: Option<&HoistPlan>) -> Vec<(String, PathBuf)> {
     plan.map(|plan| {

--- a/pnpm/crates/deps-restorer/src/materialization_plan.rs
+++ b/pnpm/crates/deps-restorer/src/materialization_plan.rs
@@ -215,29 +215,19 @@ pub struct SkipSetInputs<'a> {
 pub fn compute_skip_set<Reporter: pnpm_reporter::Reporter>(
     inputs: SkipSetInputs<'_>,
 ) -> Result<SkippedSnapshots, Box<InstallabilityError>> {
-    let SkipSetInputs {
-        requester,
-        importers,
-        snapshots,
-        packages,
-        installability_host,
-        seed,
-        exclude_optional,
-        skip_runtimes,
-        closure_lockfile,
-        closure_root,
-        closure_importer_ids,
-        included,
-    } = inputs;
-
-    let mut skipped = match (snapshots, packages, installability_host) {
+    let mut skipped = match (inputs.snapshots, inputs.packages, inputs.installability_host) {
         (Some(snapshots), Some(packages), Some(host)) => compute_skipped_snapshots::<Reporter>(
-            importers, snapshots, packages, host, requester, seed,
+            inputs.importers,
+            snapshots,
+            packages,
+            host,
+            inputs.requester,
+            inputs.seed,
         )?,
         // Constraint-free lockfile: keep the seed verbatim, so a
         // snapshot recorded as skipped previously survives the
         // constraint having since been removed from the lockfile.
-        _ => seed,
+        _ => inputs.seed,
     };
 
     // The lockfile's `optional` flag is set only when a snapshot is
@@ -246,7 +236,9 @@ pub fn compute_skip_set<Reporter: pnpm_reporter::Reporter>(
     // These land in the transient `optional_excluded` subset: excluded
     // from materialization, but kept out of `.modules.yaml.skipped` so a
     // later install without the flag brings them back.
-    if exclude_optional && let Some(snapshots) = snapshots {
+    if inputs.exclude_optional
+        && let Some(snapshots) = inputs.snapshots
+    {
         for (key, snapshot) in snapshots {
             if snapshot.optional {
                 skipped.add_optional_excluded(key.clone());
@@ -254,16 +246,18 @@ pub fn compute_skip_set<Reporter: pnpm_reporter::Reporter>(
         }
     }
 
-    if skip_runtimes && let Some(packages) = packages {
-        add_direct_runtime_skips(&mut skipped, importers, packages);
+    if inputs.skip_runtimes
+        && let Some(packages) = inputs.packages
+    {
+        add_direct_runtime_skips(&mut skipped, inputs.importers, packages);
     }
 
     extend_skipped_with_dependency_closure(
         &mut skipped,
-        closure_lockfile,
-        closure_root,
-        closure_importer_ids,
-        included,
+        inputs.closure_lockfile,
+        inputs.closure_root,
+        inputs.closure_importer_ids,
+        inputs.included,
     );
 
     Ok(skipped)

--- a/pnpm/crates/deps-restorer/src/package_map.rs
+++ b/pnpm/crates/deps-restorer/src/package_map.rs
@@ -230,128 +230,151 @@ pub fn dependencies_graph_to_package_map(
     graph: &LockfileToDepGraphResult,
     opts: &HoistedPackageMapOptions<'_>,
 ) -> PackageMap {
-    let is_loose = opts.package_map_type == NodePackageMapType::Loose;
-    let mut packages = BTreeMap::new();
-    let mut package_ids_by_graph_key = BTreeMap::new();
-    let mut package_ids_by_pkg_id = BTreeMap::new();
-    let mut package_dirs = is_loose.then(BTreeMap::new);
-    let mut loose_index = is_loose.then(PhysicalPackageIndex::default);
+    let mut builder = HoistedMapBuilder::new(graph, opts);
     let importer_names = importer_names(opts.lockfile_dir, opts.project_manifests);
-
-    index_graph_nodes(
-        graph,
-        opts.modules_dir,
-        &mut loose_index,
-        &mut package_ids_by_graph_key,
-        &mut package_ids_by_pkg_id,
-    );
-
     for (importer_id, importer) in &lockfile.importers {
-        let importer_dir = lexical_normalize(&opts.lockfile_dir.join(importer_id));
-        let importer_id_for_map = graph_package_id(&importer_dir, opts.modules_dir);
+        builder.add_importer(
+            importer_id,
+            importer,
+            importer_names.get(importer_id).and_then(Option::as_deref),
+        );
+    }
+    for (graph_key, node) in &graph.graph {
+        builder.add_graph_node(lockfile, graph_key, node);
+    }
+    builder.finish()
+}
+
+/// The hoisted package map under construction: the packages so far, the
+/// ids graph nodes and pkg ids resolve to, and the loose-mode physical
+/// index and directories.
+struct HoistedMapBuilder<'b> {
+    opts: &'b HoistedPackageMapOptions<'b>,
+    is_loose: bool,
+    packages: BTreeMap<String, PackageMapPackage>,
+    package_ids_by_graph_key: BTreeMap<PathBuf, String>,
+    package_ids_by_pkg_id: BTreeMap<String, String>,
+    package_dirs: Option<BTreeMap<String, PathBuf>>,
+    loose_index: Option<PhysicalPackageIndex>,
+}
+
+impl<'b> HoistedMapBuilder<'b> {
+    fn new(graph: &LockfileToDepGraphResult, opts: &'b HoistedPackageMapOptions<'b>) -> Self {
+        let is_loose = opts.package_map_type == NodePackageMapType::Loose;
+        let mut builder = Self {
+            opts,
+            is_loose,
+            packages: BTreeMap::new(),
+            package_ids_by_graph_key: BTreeMap::new(),
+            package_ids_by_pkg_id: BTreeMap::new(),
+            package_dirs: is_loose.then(BTreeMap::new),
+            loose_index: is_loose.then(PhysicalPackageIndex::default),
+        };
+        index_graph_nodes(
+            graph,
+            opts.modules_dir,
+            &mut builder.loose_index,
+            &mut builder.package_ids_by_graph_key,
+            &mut builder.package_ids_by_pkg_id,
+        );
+        builder
+    }
+
+    fn add_importer(
+        &mut self,
+        importer_id: &str,
+        importer: &pnpm_lockfile::ProjectSnapshot,
+        name: Option<&str>,
+    ) {
+        let importer_dir = lexical_normalize(&self.opts.lockfile_dir.join(importer_id));
+        let importer_id_for_map = graph_package_id(&importer_dir, self.opts.modules_dir);
         let mut dependencies = BTreeMap::new();
-        if let Some(Some(name)) = importer_names.get(importer_id) {
-            dependencies.insert(name.clone(), importer_id_for_map.clone());
+        if let Some(name) = name {
+            dependencies.insert(name.to_string(), importer_id_for_map.clone());
         }
-        add_hoisted_importer_dependencies(
-            &mut dependencies,
+        for deps in [
             importer.dependencies.as_ref(),
-            &package_ids_by_pkg_id,
-        );
-        add_hoisted_importer_dependencies(
-            &mut dependencies,
             importer.optional_dependencies.as_ref(),
-            &package_ids_by_pkg_id,
-        );
-        add_hoisted_importer_dependencies(
-            &mut dependencies,
             importer.dev_dependencies.as_ref(),
-            &package_ids_by_pkg_id,
-        );
-        let importer_modules_dir = is_loose.then(|| importer_dir.join("node_modules"));
-        add_hoisted_linked_dependencies(
-            &mut packages,
-            &mut dependencies,
-            &mut loose_index,
-            opts,
+        ] {
+            add_hoisted_importer_dependencies(&mut dependencies, deps, &self.package_ids_by_pkg_id);
+        }
+        let importer_modules_dir = self.is_loose.then(|| importer_dir.join("node_modules"));
+        for deps in [
             importer.dependencies.as_ref(),
-            Some(importer_id),
-            importer_modules_dir.as_deref(),
-        );
-        add_hoisted_linked_dependencies(
-            &mut packages,
-            &mut dependencies,
-            &mut loose_index,
-            opts,
             importer.optional_dependencies.as_ref(),
-            Some(importer_id),
-            importer_modules_dir.as_deref(),
-        );
-        add_hoisted_linked_dependencies(
-            &mut packages,
-            &mut dependencies,
-            &mut loose_index,
-            opts,
             importer.dev_dependencies.as_ref(),
-            Some(importer_id),
-            importer_modules_dir.as_deref(),
-        );
+        ] {
+            add_hoisted_linked_dependencies(
+                &mut self.packages,
+                &mut dependencies,
+                &mut self.loose_index,
+                self.opts,
+                deps,
+                Some(importer_id),
+                importer_modules_dir.as_deref(),
+            );
+        }
         add_package(
-            &mut packages,
+            &mut self.packages,
             importer_id_for_map,
-            &mut package_dirs,
+            &mut self.package_dirs,
             &importer_dir,
             dependencies,
-            opts.modules_dir,
+            self.opts.modules_dir,
         );
     }
 
-    for (graph_key, node) in &graph.graph {
-        let id = package_ids_by_graph_key[graph_key].clone();
+    fn add_graph_node(
+        &mut self,
+        lockfile: &Lockfile,
+        graph_key: &Path,
+        node: &crate::DependenciesGraphNode,
+    ) {
+        let id = self.package_ids_by_graph_key[graph_key].clone();
         let mut dependencies = BTreeMap::from([(node.name.clone(), id.clone())]);
         add_hoisted_graph_dependencies(
             &mut dependencies,
             &node.children,
-            &package_ids_by_graph_key,
+            &self.package_ids_by_graph_key,
         );
 
         if let Some(snapshot) = lockfile.snapshots.as_ref().and_then(|snapshots| {
             node.dep_path.as_str().parse::<PackageKey>().ok().and_then(|key| snapshots.get(&key))
         }) {
-            let package_modules_dir = is_loose.then(|| node.dir.join("node_modules"));
-            add_hoisted_linked_dependencies(
-                &mut packages,
-                &mut dependencies,
-                &mut loose_index,
-                opts,
-                snapshot.dependencies.as_ref(),
-                None,
-                package_modules_dir.as_deref(),
-            );
-            add_hoisted_linked_dependencies(
-                &mut packages,
-                &mut dependencies,
-                &mut loose_index,
-                opts,
-                snapshot.optional_dependencies.as_ref(),
-                None,
-                package_modules_dir.as_deref(),
-            );
+            let package_modules_dir = self.is_loose.then(|| node.dir.join("node_modules"));
+            for deps in [snapshot.dependencies.as_ref(), snapshot.optional_dependencies.as_ref()] {
+                add_hoisted_linked_dependencies(
+                    &mut self.packages,
+                    &mut dependencies,
+                    &mut self.loose_index,
+                    self.opts,
+                    deps,
+                    None,
+                    package_modules_dir.as_deref(),
+                );
+            }
         }
 
         add_package(
-            &mut packages,
+            &mut self.packages,
             id,
-            &mut package_dirs,
+            &mut self.package_dirs,
             &node.dir,
             dependencies,
-            opts.modules_dir,
+            self.opts.modules_dir,
         );
     }
 
-    add_loose_dependencies(&mut packages, package_dirs.as_ref(), loose_index.as_ref());
-
-    PackageMap { packages }
+    fn finish(self) -> PackageMap {
+        let mut packages = self.packages;
+        add_loose_dependencies(
+            &mut packages,
+            self.package_dirs.as_ref(),
+            self.loose_index.as_ref(),
+        );
+        PackageMap { packages }
+    }
 }
 
 /// Assign a package-map id to every hoisted graph node, indexed both by

--- a/pnpm/crates/deps-restorer/src/prune_stale_modules.rs
+++ b/pnpm/crates/deps-restorer/src/prune_stale_modules.rs
@@ -68,57 +68,33 @@ pub struct PruneStaleModules<'a> {
 const RECORDED_GROUPS: [DependencyGroup; 3] =
     [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional];
 
-impl PruneStaleModules<'_> {
+impl<'a> PruneStaleModules<'a> {
     /// Returns the count of unique orphan *packages* (dep-paths
     /// deduped down to `name@version`, matching pnpm's
     /// `orphanPkgIds`), for the caller's single `pnpm:stats`
     /// `removed` emission. `0` when the orphan diff is skipped.
     pub fn run<Reporter: self::Reporter>(self) -> Result<u64, PruneDirectDepsError> {
-        let PruneStaleModules {
-            config,
-            workspace_root,
-            wanted_lockfile,
-            current_lockfile,
-            prior_hoisted_dependencies,
-            included_groups,
-            prune_orphans,
-        } = self;
-
         let modules_dir_name: &OsStr =
-            config.modules_dir.file_name().unwrap_or_else(|| OsStr::new("node_modules"));
+            self.config.modules_dir.file_name().unwrap_or_else(|| OsStr::new("node_modules"));
+        let wanted_root_deps = self.wanted_root_deps();
 
-        // `dedupeDirectDeps`'s removal half. The link pass only decides
-        // which links to *create*, so a sibling's link that an earlier
-        // install legitimately created has to be retired here once the
-        // root starts providing the same resolution — otherwise the
-        // layout would depend on install history rather than on the
-        // manifests. Pnpm folds the same condition into this diff.
-        let wanted_root_deps: Option<HashMap<&PkgName, &ImporterDepVersion>> =
-            config.dedupe_direct_deps.then(|| wanted_lockfile.importers.get(".")).flatten().map(
-                |root_snapshot| {
-                    direct_deps_of(root_snapshot, included_groups)
-                        .into_iter()
-                        .map(|(alias, spec, _)| (alias, &spec.version))
-                        .collect()
-                },
-            );
-
-        for (importer_id, current_snapshot) in &current_lockfile.importers {
+        for (importer_id, current_snapshot) in &self.current_lockfile.importers {
             // An importer the wanted lockfile doesn't cover was not
             // re-materialized; leave its links alone (the partial
             // install guard).
-            let Some(wanted_snapshot) = wanted_lockfile.importers.get(importer_id) else {
+            let Some(wanted_snapshot) = self.wanted_lockfile.importers.get(importer_id) else {
                 continue;
             };
             if validate_importer_id(importer_id).is_err() {
                 continue;
             }
-            let importer_dir = importer_root_dir(workspace_root, importer_id);
-            let modules_dir = importer_dir.join(modules_dir_name);
-            let Some(modules_dir) = confined_modules_dir(&modules_dir, workspace_root) else {
+            let importer_dir = importer_root_dir(self.workspace_root, importer_id);
+            let Some(modules_dir) =
+                confined_modules_dir(&importer_dir.join(modules_dir_name), self.workspace_root)
+            else {
                 continue;
             };
-            let wanted_specs = direct_deps_of(wanted_snapshot, included_groups);
+            let wanted_specs = direct_deps_of(wanted_snapshot, self.included_groups);
             // Root is what the others dedupe *against*; it keeps every
             // link the wanted lockfile still records.
             let dedupe_against_root =
@@ -132,15 +108,32 @@ impl PruneStaleModules<'_> {
             )?;
         }
 
-        if !prune_orphans {
+        if !self.prune_orphans {
             return Ok(0);
         }
         prune_orphan_snapshots(
-            config,
-            workspace_root,
-            wanted_lockfile,
-            current_lockfile,
-            prior_hoisted_dependencies,
+            self.config,
+            self.workspace_root,
+            self.wanted_lockfile,
+            self.current_lockfile,
+            self.prior_hoisted_dependencies,
+        )
+    }
+
+    /// `dedupeDirectDeps`'s removal half. The link pass only decides
+    /// which links to *create*, so a sibling's link that an earlier
+    /// install legitimately created has to be retired once the root
+    /// starts providing the same resolution — otherwise the layout would
+    /// depend on install history rather than on the manifests. Pnpm
+    /// folds the same condition into this diff.
+    fn wanted_root_deps(&self) -> Option<HashMap<&'a PkgName, &'a ImporterDepVersion>> {
+        let root_snapshot =
+            self.config.dedupe_direct_deps.then(|| self.wanted_lockfile.importers.get("."))??;
+        Some(
+            direct_deps_of(root_snapshot, self.included_groups)
+                .into_iter()
+                .map(|(alias, spec, _)| (alias, &spec.version))
+                .collect(),
         )
     }
 }

--- a/pnpm/crates/deps-restorer/src/shared_side_effects.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects.rs
@@ -96,32 +96,21 @@ pub(crate) struct ApplySharedSideEffectsOptions<'a> {
     pub store_index_writer: &'a Arc<StoreIndexWriter>,
 }
 
-pub(crate) async fn apply_shared_side_effects(options: ApplySharedSideEffectsOptions<'_>) {
-    let ApplySharedSideEffectsOptions {
-        config,
-        snapshots,
-        packages,
-        requires_build_by_snapshot,
-        allow_build_policy,
-        base_cas_paths,
-        side_effects_maps_by_snapshot,
-        side_effects_by_snapshot,
-        remote_side_effects_quarantine_by_snapshot,
-        store_index_keys_by_snapshot,
-        store_index_writer,
-    } = options;
-    let persisted_remote =
-        take_persisted_remote_side_effects(side_effects_maps_by_snapshot, side_effects_by_snapshot);
-    if !config.side_effects_cache_read() {
-        side_effects_maps_by_snapshot.clear();
+pub(crate) async fn apply_shared_side_effects(mut options: ApplySharedSideEffectsOptions<'_>) {
+    let persisted_remote = take_persisted_remote_side_effects(
+        options.side_effects_maps_by_snapshot,
+        options.side_effects_by_snapshot,
+    );
+    if !options.config.side_effects_cache_read() {
+        options.side_effects_maps_by_snapshot.clear();
     }
-    let Some(setup) = remote_cache_setup(config, snapshots) else { return };
+    let Some(setup) = remote_cache_setup(options.config, options.snapshots) else { return };
 
     let roots = eligible_roots(
-        snapshots,
-        requires_build_by_snapshot,
-        allow_build_policy,
-        base_cas_paths,
+        options.snapshots,
+        options.requires_build_by_snapshot,
+        options.allow_build_policy,
+        options.base_cas_paths,
         &setup.eligible_packages,
     );
     tracing::debug!(
@@ -135,30 +124,40 @@ pub(crate) async fn apply_shared_side_effects(options: ApplySharedSideEffectsOpt
 
     let groups = plan_candidate_groups(
         &CandidatePlan {
-            config,
-            snapshots,
-            packages,
+            config: options.config,
+            snapshots: options.snapshots,
+            packages: options.packages,
             setup: &setup,
-            side_effects_by_snapshot,
-            store_index_keys_by_snapshot,
+            side_effects_by_snapshot: options.side_effects_by_snapshot,
+            store_index_keys_by_snapshot: options.store_index_keys_by_snapshot,
         },
         roots,
         persisted_remote,
-        side_effects_maps_by_snapshot,
+        options.side_effects_maps_by_snapshot,
     )
     .await;
-    if groups.is_empty() || config.frozen_store {
+    if groups.is_empty() || options.config.frozen_store {
         return;
     }
-    let Some(server) = config.pnpr_server.as_deref() else { return };
+    fetch_remote_artifacts(&mut options, &setup, &groups).await;
+}
 
+/// Resolve the groups' artifacts on the configured pnpr server,
+/// quarantine the rejected ones and overlay the rest.
+async fn fetch_remote_artifacts(
+    options: &mut ApplySharedSideEffectsOptions<'_>,
+    setup: &RemoteCacheSetup,
+    groups: &BTreeMap<String, CandidateGroup>,
+) {
+    let config = options.config;
+    let Some(server) = config.pnpr_server.as_deref() else { return };
     let client = PnprClient::new(server);
     let authorization = config.auth_headers.for_url(server);
     let Some((resolved, rejected_artifacts)) = resolve_remote_artifacts(
         &client,
-        &setup,
-        &groups,
-        remote_side_effects_quarantine_by_snapshot,
+        setup,
+        groups,
+        options.remote_side_effects_quarantine_by_snapshot,
         server,
         authorization.as_deref(),
     )
@@ -167,7 +166,7 @@ pub(crate) async fn apply_shared_side_effects(options: ApplySharedSideEffectsOpt
         return;
     };
     for rejected in rejected_artifacts {
-        quarantine_remote_side_effects(&rejected, &groups, server, store_index_writer);
+        quarantine_remote_side_effects(&rejected, groups, server, options.store_index_writer);
     }
 
     for (input_key, artifact) in resolved {
@@ -177,13 +176,13 @@ pub(crate) async fn apply_shared_side_effects(options: ApplySharedSideEffectsOpt
                 client: &client,
                 server,
                 authorization: authorization.as_deref(),
-                groups: &groups,
-                base_cas_paths,
-                store_index_writer,
+                groups,
+                base_cas_paths: options.base_cas_paths,
+                store_index_writer: options.store_index_writer,
             },
             &input_key,
             &artifact,
-            side_effects_maps_by_snapshot,
+            options.side_effects_maps_by_snapshot,
         )
         .await;
     }
@@ -271,61 +270,27 @@ async fn plan_candidate_groups(
     mut persisted_remote: HashMap<(PackageKey, String), HashMap<String, PathBuf>>,
     side_effects_maps_by_snapshot: &mut SideEffectsMapsBySnapshot,
 ) -> BTreeMap<String, CandidateGroup> {
-    let graph = build_deps_subgraph(plan.snapshots, plan.packages, roots.clone());
-    let mut deps_state_cache = pnpm_graph_hasher::DepsStateCache::new();
-    pnpm_graph_hasher::warm_deps_state_cache(
-        &graph,
-        &mut deps_state_cache,
-        in_lockfile_order(&graph).into_iter().map(|(key, _)| key),
-    );
-    let engine_name = pnpm_graph_hasher::engine_name(plan.setup.node_major, None, None);
+    let mut hasher = DepStateHasher::new(plan, &roots);
     let mut groups = BTreeMap::<String, CandidateGroup>::new();
     let mut collisions = HashSet::new();
     for snapshot_key in roots {
         let patch_hash = patch_hash(&snapshot_key);
-        let input_key = pnpm_graph_hasher::calc_dep_state_input_key(
-            &graph,
-            &snapshot_key,
-            patch_hash.as_deref(),
-        );
+        let input_key = hasher.input_key(&snapshot_key, patch_hash.as_deref());
         if collisions.contains(&input_key) {
             continue;
         }
-        let Some(candidate) =
-            artifact_candidate(plan, &snapshot_key, &input_key, plan.setup.owner.clone())
-        else {
-            continue;
-        };
-        let local_cache_key = pnpm_graph_hasher::calc_dep_state(
-            &graph,
-            &mut deps_state_cache,
-            &snapshot_key,
-            &pnpm_graph_hasher::CalcDepStateOptions {
-                engine_name: &engine_name,
-                patch_file_hash: patch_hash.as_deref(),
-                include_dep_graph_hash: true,
-            },
-        );
-        if reuse_persisted_overlay(
+        let Some(planned) = plan_root(
             plan,
-            &candidate,
-            &snapshot_key,
-            &local_cache_key,
+            &mut hasher,
+            RootKeys {
+                snapshot_key: &snapshot_key,
+                input_key: &input_key,
+                patch_hash: patch_hash.as_deref(),
+            },
             &mut persisted_remote,
             side_effects_maps_by_snapshot,
         )
         .await
-        {
-            continue;
-        }
-        if plan.config.side_effects_cache_read()
-            && side_effects_maps_by_snapshot
-                .get(&snapshot_key)
-                .is_some_and(|maps| maps.contains_key(&local_cache_key))
-        {
-            continue;
-        }
-        let Some(store_index_key) = plan.store_index_keys_by_snapshot.get(&snapshot_key).cloned()
         else {
             continue;
         };
@@ -333,11 +298,100 @@ async fn plan_candidate_groups(
             &mut groups,
             &mut collisions,
             input_key,
-            candidate,
-            (snapshot_key, local_cache_key, store_index_key),
+            planned.candidate,
+            (snapshot_key, planned.local_cache_key, planned.store_index_key),
         );
     }
     groups
+}
+
+/// The dep graph the eligible roots hash over, with its memo and the
+/// install's engine string.
+struct DepStateHasher {
+    graph: HashMap<PackageKey, pnpm_graph_hasher::DepsGraphNode<PackageKey>>,
+    cache: pnpm_graph_hasher::DepsStateCache<PackageKey>,
+    engine_name: String,
+}
+
+impl DepStateHasher {
+    fn new(plan: &CandidatePlan<'_>, roots: &[PackageKey]) -> Self {
+        let graph = build_deps_subgraph(plan.snapshots, plan.packages, roots.iter().cloned());
+        let mut cache = pnpm_graph_hasher::DepsStateCache::new();
+        pnpm_graph_hasher::warm_deps_state_cache(
+            &graph,
+            &mut cache,
+            in_lockfile_order(&graph).into_iter().map(|(key, _)| key),
+        );
+        Self {
+            graph,
+            cache,
+            engine_name: pnpm_graph_hasher::engine_name(plan.setup.node_major, None, None),
+        }
+    }
+
+    fn input_key(&self, snapshot_key: &PackageKey, patch_hash: Option<&str>) -> String {
+        pnpm_graph_hasher::calc_dep_state_input_key(&self.graph, snapshot_key, patch_hash)
+    }
+
+    fn local_cache_key(&mut self, snapshot_key: &PackageKey, patch_hash: Option<&str>) -> String {
+        pnpm_graph_hasher::calc_dep_state(
+            &self.graph,
+            &mut self.cache,
+            snapshot_key,
+            &pnpm_graph_hasher::CalcDepStateOptions {
+                engine_name: &self.engine_name,
+                patch_file_hash: patch_hash,
+                include_dep_graph_hash: true,
+            },
+        )
+    }
+}
+
+struct RootKeys<'r> {
+    snapshot_key: &'r PackageKey,
+    input_key: &'r str,
+    patch_hash: Option<&'r str>,
+}
+
+struct PlannedRoot {
+    candidate: ArtifactCandidate,
+    local_cache_key: String,
+    store_index_key: String,
+}
+
+/// `None` when a persisted or locally cached overlay already covers the
+/// root, or the store index holds no row for it.
+async fn plan_root(
+    plan: &CandidatePlan<'_>,
+    hasher: &mut DepStateHasher,
+    root: RootKeys<'_>,
+    persisted_remote: &mut HashMap<(PackageKey, String), HashMap<String, PathBuf>>,
+    side_effects_maps_by_snapshot: &mut SideEffectsMapsBySnapshot,
+) -> Option<PlannedRoot> {
+    let candidate =
+        artifact_candidate(plan, root.snapshot_key, root.input_key, plan.setup.owner.clone())?;
+    let local_cache_key = hasher.local_cache_key(root.snapshot_key, root.patch_hash);
+    if reuse_persisted_overlay(
+        plan,
+        &candidate,
+        root.snapshot_key,
+        &local_cache_key,
+        persisted_remote,
+        side_effects_maps_by_snapshot,
+    )
+    .await
+    {
+        return None;
+    }
+    if plan.config.side_effects_cache_read()
+        && side_effects_maps_by_snapshot
+            .get(root.snapshot_key)
+            .is_some_and(|maps| maps.contains_key(&local_cache_key))
+    {
+        return None;
+    }
+    let store_index_key = plan.store_index_keys_by_snapshot.get(root.snapshot_key).cloned()?;
+    Some(PlannedRoot { candidate, local_cache_key, store_index_key })
 }
 
 /// The artifact one snapshot would look up. `None` when the package has
@@ -535,6 +589,29 @@ async fn apply_resolved_artifact(
     let Some(group) = context.groups.get(input_key) else { return };
     let Some((first_snapshot, _, _)) = group.snapshots.first() else { return };
     let Some(base) = context.base_cas_paths.get(first_snapshot) else { return };
+    let staged = match stage_artifact(context, artifact, base).await {
+        Ok(staged) => staged,
+        Err((error, quarantine)) => {
+            report_rejected_artifact(context, input_key, artifact, group, &error, quarantine);
+            return;
+        }
+    };
+    let diff = remote_diff(context, artifact, staged.added);
+    record_group(context, group, &staged.overlay, &diff, side_effects_maps_by_snapshot);
+}
+
+/// The artifact's file map over the group's base, with every added
+/// file staged in the CAFS.
+struct StagedArtifact {
+    overlay: HashMap<String, PathBuf>,
+    added: HashMap<String, CafsFileInfo>,
+}
+
+async fn stage_artifact(
+    context: &ResolvedArtifactContext<'_>,
+    artifact: &pnpm_pnpr_client::VerifiedArtifact,
+    base: &HashMap<String, PathBuf>,
+) -> Result<StagedArtifact, (String, bool)> {
     let mut overlay = base.clone();
     let mut downloaded = HashMap::<String, Vec<u8>>::new();
     let mut stored = HashMap::<(String, u32), PathBuf>::new();
@@ -542,24 +619,21 @@ async fn apply_resolved_artifact(
     for deleted in &artifact.payload.manifest.deleted {
         overlay.remove(deleted);
     }
-    let mut rejected = None;
     for file in &artifact.payload.manifest.added {
-        match stage_artifact_blob(context, artifact, file, &mut stored, &mut downloaded).await {
-            Ok((path, info)) => {
-                overlay.insert(file.path.clone(), path);
-                added.insert(file.path.clone(), info);
-            }
-            Err((error, quarantine)) => {
-                rejected = Some((error, quarantine));
-                break;
-            }
-        }
+        let (path, info) =
+            stage_artifact_blob(context, artifact, file, &mut stored, &mut downloaded).await?;
+        overlay.insert(file.path.clone(), path);
+        added.insert(file.path.clone(), info);
     }
-    if let Some((error, quarantine)) = rejected {
-        report_rejected_artifact(context, input_key, artifact, group, &error, quarantine);
-        return;
-    }
-    let diff = SideEffectsDiff {
+    Ok(StagedArtifact { overlay, added })
+}
+
+fn remote_diff(
+    context: &ResolvedArtifactContext<'_>,
+    artifact: &pnpm_pnpr_client::VerifiedArtifact,
+    added: HashMap<String, CafsFileInfo>,
+) -> SideEffectsDiff {
+    SideEffectsDiff {
         added: Some(added),
         deleted: Some(artifact.payload.manifest.deleted.clone()),
         remote_origin: Some(RemoteSideEffectsOrigin {
@@ -570,7 +644,18 @@ async fn apply_resolved_artifact(
             envelope: artifact.envelope.clone(),
             verification: "verified".to_string(),
         }),
-    };
+    }
+}
+
+/// Record the overlay for every snapshot in the group, locally and in
+/// the store index.
+fn record_group(
+    context: &ResolvedArtifactContext<'_>,
+    group: &CandidateGroup,
+    overlay: &HashMap<String, PathBuf>,
+    diff: &SideEffectsDiff,
+    side_effects_maps_by_snapshot: &mut SideEffectsMapsBySnapshot,
+) {
     for (snapshot_key, local_cache_key, store_index_key) in &group.snapshots {
         insert_side_effects_map(
             side_effects_maps_by_snapshot,
@@ -990,47 +1075,15 @@ impl SharedSideEffectsPublisher {
         diff: pnpm_store_dir::SideEffectsDiff,
         store: &pnpm_store_dir::StoreDir,
     ) -> Result<(), String> {
-        let metadata_key = snapshot_key.without_peer();
-        let package_name = metadata_key.name.to_string();
-        if !self.packages.contains(&package_name) {
-            return Ok(());
-        }
-        let Some(source_integrity) =
-            metadata.resolution.checkable_integrity().map(ToString::to_string)
-        else {
+        let Some(subject) = self.subject(&snapshot_key.without_peer(), metadata) else {
             return Ok(());
         };
         let input_key =
             pnpm_graph_hasher::calc_dep_state_input_key(graph, snapshot_key, patch_file_hash);
-        let mut files = Vec::new();
-        let mut blobs = BTreeMap::new();
-        for (path, info) in diff.added.unwrap_or_default() {
-            let integrity = digest_integrity(&info.digest)?;
-            let stored_path = store
-                .cas_file_path_by_mode(&info.digest, info.mode)
-                .ok_or_else(|| format!("invalid CAFS digest for built file {path:?}"))?;
-            let bytes = std::fs::read(&stored_path)
-                .map_err(|error| format!("failed to read {}: {error}", stored_path.display()))?;
-            files.push(ArtifactFile {
-                path,
-                integrity: integrity.clone(),
-                mode: info.mode,
-                size: info.size,
-            });
-            blobs
-                .entry(integrity.clone())
-                .or_insert_with(|| ArtifactBlobUpload { integrity, data: BASE64.encode(bytes) });
-        }
-        files.sort_unstable_by(|left, right| left.path.cmp(&right.path));
+        let upload = artifact_upload(diff.added.unwrap_or_default(), store)?;
         let payload = ArtifactPayload {
             kind: ARTIFACT_KIND.to_string(),
-            subject: ArtifactSubject::dependency_side_effects(
-                PackageIdentity {
-                    name: package_name,
-                    version: package_version(&metadata_key, metadata.version.as_deref()),
-                },
-                source_integrity,
-            ),
+            subject,
             input_key: input_key.clone(),
             owner: OwnerScope::organization(self.organization.clone()),
             builder_id: self.builder_id.clone(),
@@ -1038,22 +1091,85 @@ impl SharedSideEffectsPublisher {
             compatibility: CompatibilityConstraints::Tagged {
                 tags: vec![self.platform.tag().map_err(|error| error.to_string())?],
             },
-            manifest: ArtifactManifest { added: files, deleted: diff.deleted.unwrap_or_default() },
+            manifest: ArtifactManifest {
+                added: upload.files,
+                deleted: diff.deleted.unwrap_or_default(),
+            },
         };
-        let envelope =
-            SignedArtifactEnvelope::sign(&payload, self.key_id.clone(), &self.private_key)
-                .map_err(|error| error.to_string())?;
         self.runtime
-            .block_on(self.client.publish_artifact(
-                &PublishArtifactRequest {
-                    key: input_key,
-                    envelope,
-                    blobs: blobs.into_values().collect(),
-                },
-                self.authorization.as_deref(),
-            ))
+            .block_on(
+                self.client.publish_artifact(
+                    &PublishArtifactRequest {
+                        key: input_key,
+                        envelope: SignedArtifactEnvelope::sign(
+                            &payload,
+                            self.key_id.clone(),
+                            &self.private_key,
+                        )
+                        .map_err(|error| error.to_string())?,
+                        blobs: upload.blobs.into_values().collect(),
+                    },
+                    self.authorization.as_deref(),
+                ),
+            )
             .map_err(|error| error.to_string())
     }
+
+    /// The artifact's subject, when this publisher covers the package
+    /// and its source can be pinned.
+    fn subject(
+        &self,
+        metadata_key: &PackageKey,
+        metadata: &PackageMetadata,
+    ) -> Option<ArtifactSubject> {
+        let package_name = metadata_key.name.to_string();
+        if !self.packages.contains(&package_name) {
+            return None;
+        }
+        let source_integrity =
+            metadata.resolution.checkable_integrity().map(ToString::to_string)?;
+        Some(ArtifactSubject::dependency_side_effects(
+            PackageIdentity {
+                name: package_name,
+                version: package_version(metadata_key, metadata.version.as_deref()),
+            },
+            source_integrity,
+        ))
+    }
+}
+
+/// The built files as the artifact lists them, each one's bytes read
+/// from the CAFS for upload.
+struct ArtifactUpload {
+    files: Vec<ArtifactFile>,
+    blobs: BTreeMap<String, ArtifactBlobUpload>,
+}
+
+fn artifact_upload(
+    added: HashMap<String, CafsFileInfo>,
+    store: &pnpm_store_dir::StoreDir,
+) -> Result<ArtifactUpload, String> {
+    let mut files = Vec::new();
+    let mut blobs = BTreeMap::new();
+    for (path, info) in added {
+        let integrity = digest_integrity(&info.digest)?;
+        let stored_path = store
+            .cas_file_path_by_mode(&info.digest, info.mode)
+            .ok_or_else(|| format!("invalid CAFS digest for built file {path:?}"))?;
+        let bytes = std::fs::read(&stored_path)
+            .map_err(|error| format!("failed to read {}: {error}", stored_path.display()))?;
+        files.push(ArtifactFile {
+            path,
+            integrity: integrity.clone(),
+            mode: info.mode,
+            size: info.size,
+        });
+        blobs
+            .entry(integrity.clone())
+            .or_insert_with(|| ArtifactBlobUpload { integrity, data: BASE64.encode(bytes) });
+    }
+    files.sort_unstable_by(|left, right| left.path.cmp(&right.path));
+    Ok(ArtifactUpload { files, blobs })
 }
 
 fn dependency_package(candidate: &ArtifactCandidate) -> &PackageIdentity {

--- a/pnpm/crates/deps-restorer/src/symlink_direct_dependencies.rs
+++ b/pnpm/crates/deps-restorer/src/symlink_direct_dependencies.rs
@@ -169,34 +169,51 @@ where
 {
     /// Execute the subroutine.
     pub fn run<Reporter: self::Reporter>(self) -> Result<(), SymlinkDirectDependenciesError> {
-        let SymlinkDirectDependencies {
-            config,
-            layout,
-            importers,
-            packages,
-            dependency_groups,
-            workspace_root,
-            skipped,
-            link_only,
-            public_hoist_targets,
-            trusted_importer_ids,
-            link_options,
-            package_manifests,
-            requires_build_by_snapshot,
-        } = self;
-
-        // One bin lookup for the whole pass: the `hasBin` gate and the
-        // shim probe memo are importer-invariant.
-        let bin_lookup = crate::PrefetchedBinLookup::new(
-            packages,
-            package_manifests,
-            requires_build_by_snapshot,
-        );
-
         // Collect once so the same group order can drive every importer.
-        // The group order is shared across all importers.
-        let dependency_groups: Vec<DependencyGroup> = dependency_groups.into_iter().collect();
+        let dependency_groups: Vec<DependencyGroup> = self.dependency_groups.into_iter().collect();
+        ImporterPass {
+            config: self.config,
+            layout: self.layout,
+            importers: self.importers,
+            packages: self.packages,
+            dependency_groups,
+            workspace_root: self.workspace_root,
+            skipped: self.skipped,
+            link_only: self.link_only,
+            public_hoist_targets: self.public_hoist_targets,
+            trusted_importer_ids: self.trusted_importer_ids,
+            link_options: self.link_options,
+            // One bin lookup for the whole pass: the `hasBin` gate and
+            // the shim probe memo are importer-invariant.
+            bin_lookup: crate::PrefetchedBinLookup::new(
+                self.packages,
+                self.package_manifests,
+                self.requires_build_by_snapshot,
+            ),
+        }
+        .run::<Reporter>()
+    }
+}
 
+/// [`SymlinkDirectDependencies`] with its group list collected and its
+/// bin lookup built, which every importer's pass reads.
+struct ImporterPass<'a> {
+    config: &'static Config,
+    layout: &'a VirtualStoreLayout,
+    importers: &'a HashMap<String, ProjectSnapshot>,
+    packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
+    dependency_groups: Vec<DependencyGroup>,
+    workspace_root: &'a Path,
+    skipped: &'a SkippedSnapshots,
+    link_only: bool,
+    public_hoist_targets: Option<&'a BTreeMap<String, PathBuf>>,
+    trusted_importer_ids: Option<&'a HashSet<String>>,
+    link_options: &'a LinkBinsOptions,
+    bin_lookup: crate::PrefetchedBinLookup<'a>,
+}
+
+impl ImporterPass<'_> {
+    fn run<Reporter: self::Reporter>(&self) -> Result<(), SymlinkDirectDependenciesError> {
         // Each importer's modules dir is `<importer_root>/<modules_dir_basename>`.
         // The `modulesDir` setting is a directory name (a single
         // component, default `node_modules`) applied uniformly under
@@ -209,47 +226,17 @@ where
         // other stages (`.modules.yaml` writing, bin linking) use
         // `config.modules_dir`.
         let modules_dir_name: &OsStr =
-            config.modules_dir.file_name().unwrap_or_else(|| OsStr::new("node_modules"));
+            self.config.modules_dir.file_name().unwrap_or_else(|| OsStr::new("node_modules"));
 
         // Sorted so the fallible upfront validation below rejects a
         // hostile lockfile on a deterministic importer. `pnpm:root`
         // event order is not pinned — the per-importer work runs on
         // rayon, matching pnpm's `Promise.all` over importers — so
         // consumers key events off their `prefix`, never their order.
-        let mut keys: Vec<&str> = importers.keys().map(String::as_str).collect();
+        let mut keys: Vec<&str> = self.importers.keys().map(String::as_str).collect();
         keys.sort_unstable();
-
-        // `dedupeDirectDeps` short-circuits when there is no
-        // root importer or only one importer total — there's nothing
-        // to dedupe against.
-        let dedupe = config.dedupe_direct_deps && importers.contains_key(".") && keys.len() > 1;
-        let root_targets: Option<BTreeMap<String, PathBuf>> = dedupe.then(|| {
-            root_dedupe_targets(
-                layout,
-                &importers["."],
-                &importer_root_dir(workspace_root, "."),
-                &dependency_groups,
-                skipped,
-                link_only,
-                public_hoist_targets,
-            )
-        });
-
-        // Reject importer keys that would escape the workspace
-        // root. A malformed (or hostile) lockfile could otherwise
-        // make `Path::join` create `node_modules` outside the
-        // workspace — `Path::join` discards the base when the
-        // RHS is absolute, and `..` components are otherwise
-        // permitted. Importer ids the caller declared as projects
-        // (see [`Self::trusted_importer_ids`]) skip the check —
-        // an explicitly-configured project may live outside the
-        // lockfile dir. Validated before any importer links, so a
-        // rejected lockfile writes nothing.
-        for importer_id in &keys {
-            if !trusted_importer_ids.is_some_and(|trusted| trusted.contains(*importer_id)) {
-                validate_importer_id(importer_id)?;
-            }
-        }
+        let root_targets = self.root_dedupe_targets(&keys);
+        self.validate_importer_ids(&keys)?;
 
         // One rayon task per importer, mirroring pnpm's `Promise.all`
         // over `linkDirectDeps`' projects: each importer's symlink and
@@ -257,37 +244,81 @@ where
         // in `root_targets`, not the root importer's on-disk state), and
         // a serial walk would insert a fork-join barrier per importer
         // between the filesystem batches.
-        //
-        let task_groups = importer_task_groups(workspace_root, keys);
+        let task_groups = importer_task_groups(self.workspace_root, keys);
         task_groups.par_iter().try_for_each(|group| {
             group.iter().try_for_each(|importer_id| {
-                // Safe: the groups were built from `importers.keys()`.
-                let project_snapshot = &importers[*importer_id];
-                let project_dir = importer_root_dir(workspace_root, importer_id);
-                let modules_dir = project_dir.join(modules_dir_name);
-
-                // Only non-root importers get deduped against root: the
-                // root project is linked unfiltered, then each sibling's
-                // list is trimmed against what root links.
-                let dedupe_against = root_targets.as_ref().filter(|_| *importer_id != ".");
-
-                link_one_importer::<Reporter>(
-                    importer_id,
-                    layout,
-                    project_snapshot,
-                    packages,
-                    &project_dir,
-                    &modules_dir,
-                    dependency_groups.iter().copied(),
-                    skipped,
-                    link_only,
-                    dedupe_against,
-                    config.symlink,
-                    link_options,
-                    &bin_lookup,
-                )
+                self.link_importer::<Reporter>(importer_id, modules_dir_name, root_targets.as_ref())
             })
         })
+    }
+
+    /// `dedupeDirectDeps` short-circuits when there is no root importer
+    /// or only one importer total — there's nothing to dedupe against.
+    fn root_dedupe_targets(&self, keys: &[&str]) -> Option<BTreeMap<String, PathBuf>> {
+        let dedupe =
+            self.config.dedupe_direct_deps && self.importers.contains_key(".") && keys.len() > 1;
+        dedupe.then(|| {
+            root_dedupe_targets(
+                self.layout,
+                &self.importers["."],
+                &importer_root_dir(self.workspace_root, "."),
+                &self.dependency_groups,
+                self.skipped,
+                self.link_only,
+                self.public_hoist_targets,
+            )
+        })
+    }
+
+    /// Reject importer keys that would escape the workspace root. A
+    /// malformed (or hostile) lockfile could otherwise make `Path::join`
+    /// create `node_modules` outside the workspace — `Path::join`
+    /// discards the base when the RHS is absolute, and `..` components
+    /// are otherwise permitted. Importer ids the caller declared as
+    /// projects (see [`SymlinkDirectDependencies::trusted_importer_ids`])
+    /// skip the check — an explicitly-configured project may live
+    /// outside the lockfile dir. Validated before any importer links, so
+    /// a rejected lockfile writes nothing.
+    fn validate_importer_ids(&self, keys: &[&str]) -> Result<(), SymlinkDirectDependenciesError> {
+        for importer_id in keys {
+            if !self.trusted_importer_ids.is_some_and(|trusted| trusted.contains(*importer_id)) {
+                validate_importer_id(importer_id)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn link_importer<Reporter: self::Reporter>(
+        &self,
+        importer_id: &str,
+        modules_dir_name: &OsStr,
+        root_targets: Option<&BTreeMap<String, PathBuf>>,
+    ) -> Result<(), SymlinkDirectDependenciesError> {
+        // Safe: the task groups were built from `importers.keys()`.
+        let project_snapshot = &self.importers[importer_id];
+        let project_dir = importer_root_dir(self.workspace_root, importer_id);
+        let modules_dir = project_dir.join(modules_dir_name);
+
+        // Only non-root importers get deduped against root: the
+        // root project is linked unfiltered, then each sibling's
+        // list is trimmed against what root links.
+        let dedupe_against = root_targets.filter(|_| importer_id != ".");
+
+        link_one_importer::<Reporter>(
+            importer_id,
+            self.layout,
+            project_snapshot,
+            self.packages,
+            &project_dir,
+            &modules_dir,
+            self.dependency_groups.iter().copied(),
+            self.skipped,
+            self.link_only,
+            dedupe_against,
+            self.config.symlink,
+            self.link_options,
+            &self.bin_lookup,
+        )
     }
 }
 

--- a/pnpm/crates/deps-restorer/src/virtual_store_layout.rs
+++ b/pnpm/crates/deps-restorer/src/virtual_store_layout.rs
@@ -253,62 +253,15 @@ impl VirtualStoreLayout {
                 lockfile_dir: lockfile_dir.map(Path::to_path_buf),
             };
         };
-        let graph = lockfile_to_dep_graph(snapshots, packages, lockfile_dir);
-        // One conversion for the whole lockfile: the same string scopes every
-        // local directory snapshot in it.
-        //
-        // Lossy on purpose: the TypeScript CLI hashes the same slot from a JS
-        // string, and Node decodes a path as UTF-8 with replacement, so this is
-        // the identical input. Hashing the raw bytes instead would give the two
-        // stacks different slots for the same project.
-        let project_scope = lockfile_dir.map(|dir| dir.to_string_lossy());
-        // Build the engine-agnostic gating set once per install.
-        // `None` here disables gating so every snapshot still hashes
-        // with its engine string.
-        let build_required_dep_paths: Option<HashSet<String>> = allow_build_policy.map(|policy| {
-            let built_dep_paths = snapshots
-                .keys()
-                .filter(|key| policy.check(&key.without_peer().to_string()) == Some(true))
-                .map(ToString::to_string)
-                .collect();
-            pnpm_graph_hasher::build_required_dep_paths(&graph, &built_dep_paths)
-        });
-        let mut cache: DepsStateCache<String> = HashMap::new();
+        let mut hasher =
+            GvsHasher::new(snapshots, packages, engine, allow_build_policy, lockfile_dir);
         let mut gvs_suffixes: HashMap<PackageKey, String> = HashMap::with_capacity(snapshots.len());
         // Lockfile key order, not `HashMap` order: `calc_graph_node_hash`
-        // memoizes into `cache`, and for a snapshot inside a dependency
-        // cycle the digest that lands there depends on which snapshot the
-        // walk reached it from.
+        // memoizes into the hasher's cache, and for a snapshot inside a
+        // dependency cycle the digest that lands there depends on which
+        // snapshot the walk reached it from.
         for (snapshot_key, snapshot) in crate::deps_graph::in_lockfile_order(snapshots) {
-            // Per-snapshot engine resolution: a snapshot that declares
-            // its own `engines.runtime` carries the desugared
-            // `dependencies.node: 'runtime:<version>'` pin, which has
-            // to drive the engine portion of *its* hash rather than
-            // the install-wide fallback. Precedence: own pin first,
-            // install-wide fallback second. Default host platform /
-            // arch (`None`, `None`) matches whatever the caller used
-            // to format the fallback `engine` so the two strings
-            // remain comparable across snapshots in one install.
-            let own_engine =
-                find_own_runtime_node_major(snapshot).map(|major| engine_name(major, None, None));
-            let snapshot_engine = own_engine.as_deref().or(engine);
-            let metadata_key = snapshot_key.without_peer();
-            let metadata = packages.and_then(|map| map.get(&metadata_key));
-            let project =
-                local_directory_scope(metadata, &metadata_key.suffix, project_scope.as_deref());
-            let graph_key = snapshot_key.to_string();
-            let hex_digest = calc_graph_node_hash(
-                &graph,
-                &mut cache,
-                &graph_key,
-                snapshot_engine,
-                build_required_dep_paths.as_ref(),
-                project,
-            );
-            let name = metadata_key.name.to_string();
-            let version = gvs_version_segment(metadata, &metadata_key.suffix);
-            let suffix = format_global_virtual_store_path(&name, &version, &hex_digest);
-            gvs_suffixes.insert(snapshot_key.clone(), suffix);
+            gvs_suffixes.insert(snapshot_key.clone(), hasher.suffix(snapshot_key, snapshot));
         }
         VirtualStoreLayout {
             package_store_dir,
@@ -635,24 +588,14 @@ fn lockfile_to_dep_graph(
     let mut link_target_nodes = HashSet::new();
     for (snapshot_key, snapshot) in snapshots {
         let children = crate::deps_graph::build_children_with(snapshot, |alias, dep_ref| {
-            if let Some(snapshot_key) = dep_ref.resolve(alias) {
-                return Some(snapshot_key.to_string());
-            }
-            let link_target = dep_ref.as_link_target()?;
-            let lockfile_dir = lockfile_dir?;
-            let resolved = pnpm_fs::lexical_normalize(&lockfile_dir.join(link_target));
-            Some(format!("link:{}", resolved.to_string_lossy()))
+            child_graph_key(alias, dep_ref, lockfile_dir)
         });
         link_target_nodes
             .extend(children.values().filter(|child_key| child_key.starts_with("link:")).cloned());
-        let metadata_key = snapshot_key.without_peer();
-        let pkg_id_with_patch_hash = PkgIdWithPatchHash::from(
-            get_pkg_id_with_patch_hash(&snapshot_key.to_string()).to_string(),
+        graph.insert(
+            snapshot_key.to_string(),
+            DepsGraphNode { full_pkg_id: full_pkg_id_of(snapshot_key, packages), children },
         );
-        let resolution =
-            packages.and_then(|map| map.get(&metadata_key)).map(|meta| &meta.resolution);
-        let full_pkg_id = create_full_pkg_id(&pkg_id_with_patch_hash, resolution);
-        graph.insert(snapshot_key.to_string(), DepsGraphNode { full_pkg_id, children });
     }
     for link_target_node in link_target_nodes {
         graph.insert(
@@ -661,6 +604,114 @@ fn lockfile_to_dep_graph(
         );
     }
     graph
+}
+
+fn child_graph_key(
+    alias: &pnpm_lockfile::PkgName,
+    dep_ref: &pnpm_lockfile::SnapshotDepRef,
+    lockfile_dir: Option<&Path>,
+) -> Option<String> {
+    if let Some(snapshot_key) = dep_ref.resolve(alias) {
+        return Some(snapshot_key.to_string());
+    }
+    let link_target = dep_ref.as_link_target()?;
+    let resolved = pnpm_fs::lexical_normalize(&lockfile_dir?.join(link_target));
+    Some(format!("link:{}", resolved.to_string_lossy()))
+}
+
+fn full_pkg_id_of(
+    snapshot_key: &PackageKey,
+    packages: Option<&HashMap<PackageKey, PackageMetadata>>,
+) -> String {
+    let pkg_id_with_patch_hash =
+        PkgIdWithPatchHash::from(get_pkg_id_with_patch_hash(&snapshot_key.to_string()).to_string());
+    let resolution = packages
+        .and_then(|packages| packages.get(&snapshot_key.without_peer()))
+        .map(|meta| &meta.resolution);
+    create_full_pkg_id(&pkg_id_with_patch_hash, resolution)
+}
+
+/// Hashes every snapshot's global-virtual-store slot suffix over one dep
+/// graph, gating set and memo for the whole lockfile.
+struct GvsHasher<'h> {
+    graph: HashMap<String, DepsGraphNode<String>>,
+    /// The engine-agnostic gating set. `None` disables gating so every
+    /// snapshot still hashes with its engine string.
+    build_required_dep_paths: Option<HashSet<String>>,
+    cache: DepsStateCache<String>,
+    /// One conversion for the whole lockfile: the same string scopes
+    /// every local directory snapshot in it.
+    ///
+    /// Lossy on purpose: the TypeScript CLI hashes the same slot from a
+    /// JS string, and Node decodes a path as UTF-8 with replacement, so
+    /// this is the identical input. Hashing the raw bytes instead would
+    /// give the two stacks different slots for the same project.
+    project_scope: Option<std::borrow::Cow<'h, str>>,
+    engine: Option<&'h str>,
+    packages: Option<&'h HashMap<PackageKey, PackageMetadata>>,
+}
+
+impl<'h> GvsHasher<'h> {
+    fn new(
+        snapshots: &HashMap<PackageKey, SnapshotEntry>,
+        packages: Option<&'h HashMap<PackageKey, PackageMetadata>>,
+        engine: Option<&'h str>,
+        allow_build_policy: Option<&AllowBuildPolicy>,
+        lockfile_dir: Option<&'h Path>,
+    ) -> Self {
+        let graph = lockfile_to_dep_graph(snapshots, packages, lockfile_dir);
+        let build_required_dep_paths =
+            allow_build_policy.map(|policy| engine_gating_dep_paths(policy, snapshots, &graph));
+        Self {
+            graph,
+            build_required_dep_paths,
+            cache: HashMap::new(),
+            project_scope: lockfile_dir.map(|dir| dir.to_string_lossy()),
+            engine,
+            packages,
+        }
+    }
+
+    /// Per-snapshot engine resolution: a snapshot that declares its own
+    /// `engines.runtime` carries the desugared
+    /// `dependencies.node: 'runtime:<version>'` pin, which has to drive
+    /// the engine portion of *its* hash rather than the install-wide
+    /// fallback. Precedence: own pin first, install-wide fallback
+    /// second. Default host platform / arch (`None`, `None`) matches
+    /// whatever the caller used to format the fallback `engine` so the
+    /// two strings remain comparable across snapshots in one install.
+    fn suffix(&mut self, snapshot_key: &PackageKey, snapshot: &SnapshotEntry) -> String {
+        let own_engine =
+            find_own_runtime_node_major(snapshot).map(|major| engine_name(major, None, None));
+        let metadata_key = snapshot_key.without_peer();
+        let metadata = self.packages.and_then(|packages| packages.get(&metadata_key));
+        let hex_digest = calc_graph_node_hash(
+            &self.graph,
+            &mut self.cache,
+            &snapshot_key.to_string(),
+            own_engine.as_deref().or(self.engine),
+            self.build_required_dep_paths.as_ref(),
+            local_directory_scope(metadata, &metadata_key.suffix, self.project_scope.as_deref()),
+        );
+        format_global_virtual_store_path(
+            &metadata_key.name.to_string(),
+            &gvs_version_segment(metadata, &metadata_key.suffix),
+            &hex_digest,
+        )
+    }
+}
+
+fn engine_gating_dep_paths(
+    policy: &AllowBuildPolicy,
+    snapshots: &HashMap<PackageKey, SnapshotEntry>,
+    graph: &HashMap<String, DepsGraphNode<String>>,
+) -> HashSet<String> {
+    let built_dep_paths = snapshots
+        .keys()
+        .filter(|key| policy.check(&key.without_peer().to_string()) == Some(true))
+        .map(ToString::to_string)
+        .collect();
+    pnpm_graph_hasher::build_required_dep_paths(graph, &built_dep_paths)
 }
 
 /// `variations` (cross-platform variant) resolutions don't exist in

--- a/pnpm/crates/env-installer/src/resolve_and_install_config_deps.rs
+++ b/pnpm/crates/env-installer/src/resolve_and_install_config_deps.rs
@@ -190,11 +190,7 @@ async fn resolve_one(
         bare_specifier: Some(specifier.to_string()),
         ..WantedDependency::default()
     };
-    let resolve_opts = ResolveOptions {
-        project_dir: opts.root_dir.to_path_buf(),
-        lockfile_dir: opts.root_dir.to_path_buf(),
-        ..ResolveOptions::default()
-    };
+    let resolve_opts = resolve_options(opts.root_dir);
     let no_integrity = || ConfigDepError::BadConfigDep {
         message: format!(
             "Cannot resolve {name}@{specifier} as a configuration dependency because it has no integrity",
@@ -218,13 +214,7 @@ async fn resolve_one(
         SpecifierAndResolution { specifier: specifier.to_string(), version: version.clone() },
     );
     let mut resolution = result.resolution;
-    // A migrated dependency keeps the integrity pinned in pnpm-workspace.yaml,
-    // so the registry hands over the tarball URL without loosening the pin.
-    if let (Some(pinned), LockfileResolution::Tarball(tarball)) =
-        (pinned_integrity, &mut resolution)
-    {
-        tarball.integrity = Some(pinned.clone());
-    }
+    pin_integrity(&mut resolution, pinned_integrity);
     env_lockfile.packages.insert(
         key.clone(),
         registry_package_metadata(
@@ -247,6 +237,22 @@ async fn resolve_one(
         SnapshotEntry { optional_dependencies: optional_subdeps, ..SnapshotEntry::default() },
     );
     Ok(())
+}
+
+/// A migrated dependency keeps the integrity pinned in pnpm-workspace.yaml,
+/// so the registry hands over the tarball URL without loosening the pin.
+fn pin_integrity(resolution: &mut LockfileResolution, pinned: Option<&Integrity>) {
+    if let (Some(pinned), LockfileResolution::Tarball(tarball)) = (pinned, resolution) {
+        tarball.integrity = Some(pinned.clone());
+    }
+}
+
+pub(crate) fn resolve_options(root_dir: &std::path::Path) -> ResolveOptions {
+    ResolveOptions {
+        project_dir: root_dir.to_path_buf(),
+        lockfile_dir: root_dir.to_path_buf(),
+        ..ResolveOptions::default()
+    }
 }
 
 /// Insert the lockfile entries for an old-format config dependency

--- a/pnpm/crates/env-installer/src/resolve_optional_subdeps.rs
+++ b/pnpm/crates/env-installer/src/resolve_optional_subdeps.rs
@@ -7,9 +7,10 @@
 
 use crate::{
     ConfigDepError, manifest_lockfile::package_metadata, options::ConfigDepsInstallOptions,
+    resolve_and_install_config_deps::resolve_options,
 };
 use pnpm_lockfile::{EnvLockfile, PackageKey, PkgName, PkgVerPeer, SnapshotDepRef, SnapshotEntry};
-use pnpm_resolving_resolver_base::{ResolveOptions, Resolver, WantedDependency};
+use pnpm_resolving_resolver_base::{ResolveResult, Resolver, WantedDependency};
 use std::collections::HashMap;
 
 /// Resolve `parent_manifest.optionalDependencies` and record each into
@@ -43,45 +44,8 @@ pub async fn resolve_optional_subdeps(
             });
         }
 
-        let wanted = WantedDependency {
-            alias: Some(subdep_name.clone()),
-            bare_specifier: Some(subdep_spec.to_string()),
-            optional: Some(true),
-            ..WantedDependency::default()
-        };
-        let resolve_opts = ResolveOptions {
-            project_dir: opts.root_dir.to_path_buf(),
-            lockfile_dir: opts.root_dir.to_path_buf(),
-            ..ResolveOptions::default()
-        };
-        let result = resolver
-            .resolve(&wanted, &resolve_opts)
-            .await
-            .map_err(|error| ConfigDepError::Resolve {
-                spec: format!("{subdep_name}@{subdep_spec}"),
-                error,
-            })?
-            .ok_or_else(|| ConfigDepError::BadConfigDep {
-                message: format!(
-                    r#"Cannot resolve optionalDependency "{subdep_name}" of config dependency "{parent_name}" because it has no integrity"#,
-                ),
-            })?;
-
-        let Some(name_ver) = result.name_ver.as_ref() else {
-            return Err(ConfigDepError::BadConfigDep {
-                message: format!(
-                    r#"Cannot resolve optionalDependency "{subdep_name}" of config dependency "{parent_name}" because it has no integrity"#,
-                ),
-            });
-        };
-        if !resolution_has_integrity(&result.resolution) {
-            return Err(ConfigDepError::BadConfigDep {
-                message: format!(
-                    r#"Cannot resolve optionalDependency "{subdep_name}" of config dependency "{parent_name}" because it has no integrity"#,
-                ),
-            });
-        }
-        let subdep_version = name_ver.suffix.to_string();
+        let (subdep_version, result) =
+            resolve_subdep(resolver, opts, parent_name, subdep_name, subdep_spec).await?;
         let registry = opts.pick_registry(subdep_name);
         let pkg_key: PackageKey = format!("{subdep_name}@{subdep_version}")
             .parse()
@@ -112,6 +76,41 @@ pub async fn resolve_optional_subdeps(
     }
 
     Ok((!resolved.is_empty()).then_some(resolved))
+}
+
+/// Resolve one optional subdependency to its version and result, both
+/// backed by an integrity.
+async fn resolve_subdep(
+    resolver: &dyn Resolver,
+    opts: &ConfigDepsInstallOptions<'_>,
+    parent_name: &str,
+    subdep_name: &str,
+    subdep_spec: &str,
+) -> Result<(String, ResolveResult), ConfigDepError> {
+    let no_integrity = || ConfigDepError::BadConfigDep {
+        message: format!(
+            r#"Cannot resolve optionalDependency "{subdep_name}" of config dependency "{parent_name}" because it has no integrity"#,
+        ),
+    };
+    let wanted = WantedDependency {
+        alias: Some(subdep_name.to_string()),
+        bare_specifier: Some(subdep_spec.to_string()),
+        optional: Some(true),
+        ..WantedDependency::default()
+    };
+    let result = resolver
+        .resolve(&wanted, &resolve_options(opts.root_dir))
+        .await
+        .map_err(|error| ConfigDepError::Resolve {
+            spec: format!("{subdep_name}@{subdep_spec}"),
+            error,
+        })?
+        .ok_or_else(no_integrity)?;
+    let version = result.name_ver.as_ref().ok_or_else(no_integrity)?.suffix.to_string();
+    if !resolution_has_integrity(&result.resolution) {
+        return Err(no_integrity());
+    }
+    Ok((version, result))
 }
 
 pub(crate) fn resolution_has_integrity(resolution: &pnpm_lockfile::LockfileResolution) -> bool {

--- a/pnpm/crates/executor/src/run_script.rs
+++ b/pnpm/crates/executor/src/run_script.rs
@@ -123,10 +123,43 @@ pub fn run_script(opts: &RunScript<'_>) -> Result<ScriptExit, RunScriptError> {
     let shell =
         select_shell(opts.script_shell, cfg!(windows)).map_err(RunScriptError::ScriptShell)?;
 
+    let child_env = child_env(opts, &command);
+
+    if let ScriptOutput::Streamed { dep_path, emit } = opts.output {
+        let wd = opts.pkg_root.to_string_lossy().into_owned();
+        let streamed = StreamedScript { dep_path, stage: opts.stage, wd: &wd, emit };
+        return run_streamed(opts, &shell, &command, &child_env, streamed);
+    }
+
+    if !opts.silent {
+        // Echo `$ <script>` to stderr for an inherited-stdio run, the
+        // same as `pnpm run`. The dim styling is omitted.
+        let mut stderr = io::stderr();
+        let _ = writeln!(stderr, "$ {command}");
+    }
+
+    if opts.shell_emulator {
+        return execute_emulated(
+            &command,
+            opts.pkg_root,
+            &child_env,
+            EmulatedOutput::Inherit,
+            opts.process_tracker,
+        )
+        .map(ScriptExit::Emulated)
+        .map_err(RunScriptError::ShellEmulator);
+    }
+
+    run_in_shell(opts, &shell, &command, &child_env)
+}
+
+/// The script's environment: the parent's, the `npm_*` lifecycle variables,
+/// and `PATH` extended with the bin directories.
+fn child_env(opts: &RunScript<'_>, command: &str) -> HashMap<String, String> {
     let parent_env: HashMap<String, String> = env::vars().collect();
     let env_opts = EnvOptions {
         stage: opts.stage,
-        script: &command,
+        script: command,
         pkg_root: opts.pkg_root,
         init_cwd: opts.init_cwd,
         script_src_dir: opts.pkg_root,
@@ -154,61 +187,54 @@ pub fn run_script(opts: &RunScript<'_>) -> Result<ScriptExit, RunScriptError> {
     let mut child_env = built.env;
     child_env.retain(|key, _| !key.eq_ignore_ascii_case("PATH"));
     child_env.insert("PATH".to_string(), path_env.to_string_lossy().into_owned());
+    child_env
+}
 
-    if let ScriptOutput::Streamed { dep_path, emit } = opts.output {
-        let wd = opts.pkg_root.to_string_lossy().into_owned();
-        let streamed = StreamedScript { dep_path, stage: opts.stage, wd: &wd, emit };
-        streamed.started(&command);
-        let status = if opts.shell_emulator {
-            let emit_line = |stdio, line| streamed.emit_line(stdio, line);
-            execute_emulated(
-                &command,
-                opts.pkg_root,
-                &child_env,
-                EmulatedOutput::Lines(&emit_line),
-                opts.process_tracker,
-            )
-            .map(ScriptExit::Emulated)
-            .map_err(RunScriptError::ShellEmulator)?
-        } else {
-            run_piped(&shell, &command, opts.pkg_root, &child_env, streamed, opts.process_tracker)?
-        };
-        streamed.finished(status.code().unwrap_or(-1));
-        return Ok(status);
-    }
-
-    if !opts.silent {
-        // Echo `$ <script>` to stderr for an inherited-stdio run, the
-        // same as `pnpm run`. The dim styling is omitted.
-        let mut stderr = io::stderr();
-        let _ = writeln!(stderr, "$ {command}");
-    }
-
-    if opts.shell_emulator {
-        return execute_emulated(
-            &command,
+fn run_streamed(
+    opts: &RunScript<'_>,
+    shell: &SelectedShell,
+    command: &str,
+    child_env: &HashMap<String, String>,
+    streamed: StreamedScript<'_>,
+) -> Result<ScriptExit, RunScriptError> {
+    streamed.started(command);
+    let status = if opts.shell_emulator {
+        let emit_line = |stdio, line| streamed.emit_line(stdio, line);
+        execute_emulated(
+            command,
             opts.pkg_root,
-            &child_env,
-            EmulatedOutput::Inherit,
+            child_env,
+            EmulatedOutput::Lines(&emit_line),
             opts.process_tracker,
         )
         .map(ScriptExit::Emulated)
-        .map_err(RunScriptError::ShellEmulator);
-    }
+        .map_err(RunScriptError::ShellEmulator)?
+    } else {
+        run_piped(shell, command, opts.pkg_root, child_env, streamed, opts.process_tracker)?
+    };
+    streamed.finished(status.code().unwrap_or(-1));
+    Ok(status)
+}
 
-    // The script is appended through `push_script_arg` (not a chained
-    // `.arg`) so the Windows `cmd /d /s /c` verbatim path can use
-    // `raw_arg` and keep embedded quoting like `node -e "..."` intact —
-    // matching the lifecycle runner.
+/// The script is appended through `push_script_arg` (not a chained
+/// `.arg`) so the Windows `cmd /d /s /c` verbatim path can use
+/// `raw_arg` and keep embedded quoting like `node -e "..."` intact —
+/// matching the lifecycle runner.
+fn run_in_shell(
+    opts: &RunScript<'_>,
+    shell: &SelectedShell,
+    command: &str,
+    child_env: &HashMap<String, String>,
+) -> Result<ScriptExit, RunScriptError> {
     let mut cmd = Command::new(&shell.program);
     cmd.args(&shell.args);
-    push_script_arg(&mut cmd, &command, shell.windows_verbatim_args);
-    cmd.current_dir(opts.pkg_root).env_clear().envs(&child_env);
+    push_script_arg(&mut cmd, command, shell.windows_verbatim_args);
+    cmd.current_dir(opts.pkg_root).env_clear().envs(child_env);
     let mut child = spawn_child(&mut cmd, opts.process_tracker)
-        .map_err(|source| RunScriptError::Spawn { script: command.clone(), source })?;
-    let status =
-        child.wait().map_err(|source| RunScriptError::Wait { script: command.clone(), source })?;
-
+        .map_err(|source| RunScriptError::Spawn { script: command.to_string(), source })?;
+    let status = child
+        .wait()
+        .map_err(|source| RunScriptError::Wait { script: command.to_string(), source })?;
     Ok(ScriptExit::Process(status))
 }
 

--- a/pnpm/crates/executor/src/shell_emulator.rs
+++ b/pnpm/crates/executor/src/shell_emulator.rs
@@ -69,21 +69,37 @@ pub fn execute_emulated(
     // reaching the panic inside the shell.
     let cwd = path::absolute(cwd)
         .map_err(|source| ShellEmulatorError::Start { script: script.to_string(), source })?;
-    let env = env.iter().map(|(key, value)| (OsString::from(key), OsString::from(value))).collect();
     let cancellation = process_tracker.map(ProcessTracker::track_emulated);
-    let receiver = cancellation.as_ref().map(EmulatedCancellation::receiver);
-
+    let run = EmulatedRun {
+        list,
+        env: env.iter().map(|(key, value)| (OsString::from(key), OsString::from(value))).collect(),
+        cwd,
+        cancellation: cancellation.as_ref().map(EmulatedCancellation::receiver),
+    };
     match output {
-        EmulatedOutput::Inherit => run_to_completion(
-            script,
-            list,
-            env,
-            cwd,
-            ShellPipeWriter::stdout(),
-            ShellPipeWriter::stderr(),
-            receiver,
-        ),
-        EmulatedOutput::Lines(sink) => thread::scope(|scope| {
+        EmulatedOutput::Inherit => {
+            run.complete(script, ShellPipeWriter::stdout(), ShellPipeWriter::stderr())
+        }
+        EmulatedOutput::Lines(sink) => run.complete_into_lines(script, sink),
+    }
+}
+
+/// A parsed script with everything its run needs but its output pipes.
+struct EmulatedRun {
+    list: SequentialList,
+    env: HashMap<OsString, OsString>,
+    cwd: PathBuf,
+    cancellation: Option<tokio::sync::watch::Receiver<bool>>,
+}
+
+impl EmulatedRun {
+    /// Run with each output line handed to `sink`, tagged with its stream.
+    fn complete_into_lines(
+        self,
+        script: &str,
+        sink: &(dyn Fn(LifecycleStdio, String) + Sync),
+    ) -> Result<i32, ShellEmulatorError> {
+        thread::scope(|scope| {
             let (stdout_reader, stdout_writer) = pipe();
             let (stderr_reader, stderr_writer) = pipe();
             let stdout_pump =
@@ -93,31 +109,37 @@ pub fn execute_emulated(
 
             // Both writers are consumed by the run, so the pumps see EOF
             // as soon as it returns and the joins below finish promptly.
-            let code =
-                run_to_completion(script, list, env, cwd, stdout_writer, stderr_writer, receiver);
+            let code = self.complete(script, stdout_writer, stderr_writer);
             let _ = stdout_pump.join();
             let _ = stderr_pump.join();
             code
-        }),
+        })
     }
-}
 
-/// Drive the parsed script to completion and return its exit code.
-///
-/// The shell is driven on a thread of our own because
-/// `deno_task_shell` needs a current-thread tokio runtime with a
-/// `LocalSet` (it uses `spawn_local`), and building one on the calling
-/// thread would panic whenever that thread is already inside a runtime.
-fn run_to_completion(
-    script: &str,
-    list: SequentialList,
-    env: HashMap<OsString, OsString>,
-    cwd: PathBuf,
-    stdout: ShellPipeWriter,
-    stderr: ShellPipeWriter,
-    cancellation: Option<tokio::sync::watch::Receiver<bool>>,
-) -> Result<i32, ShellEmulatorError> {
-    let run = thread::spawn(move || {
+    /// Drive the parsed script to completion and return its exit code.
+    ///
+    /// The shell is driven on a thread of our own because
+    /// `deno_task_shell` needs a current-thread tokio runtime with a
+    /// `LocalSet` (it uses `spawn_local`), and building one on the calling
+    /// thread would panic whenever that thread is already inside a runtime.
+    fn complete(
+        self,
+        script: &str,
+        stdout: ShellPipeWriter,
+        stderr: ShellPipeWriter,
+    ) -> Result<i32, ShellEmulatorError> {
+        let run = thread::spawn(move || self.execute(stdout, stderr));
+        match run.join() {
+            Ok(result) => result
+                .map_err(|source| ShellEmulatorError::Start { script: script.to_string(), source }),
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+    }
+
+    /// Execute on the current thread, with `deno_task_shell`'s own
+    /// current-thread runtime and `LocalSet`.
+    fn execute(self, stdout: ShellPipeWriter, stderr: ShellPipeWriter) -> io::Result<i32> {
+        let EmulatedRun { list, env, cwd, cancellation } = self;
         let runtime = Builder::new_current_thread().enable_all().build()?;
         let kill_signal = KillSignal::default();
         let local_set = LocalSet::new();
@@ -132,12 +154,6 @@ fn run_to_completion(
         let state = ShellState::new(env, cwd, HashMap::new(), kill_signal);
         let stdin = ShellPipeReader::stdin();
         Ok(local_set.block_on(&runtime, execute_with_pipes(list, state, stdin, stdout, stderr)))
-    });
-
-    match run.join() {
-        Ok(result) => result
-            .map_err(|source| ShellEmulatorError::Start { script: script.to_string(), source }),
-        Err(payload) => std::panic::resume_unwind(payload),
     }
 }
 

--- a/pnpm/crates/git-fetcher/src/fetcher.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher.rs
@@ -21,14 +21,14 @@ use pnpm_fs_packlist::packlist;
 use pnpm_network::{redact_and_sanitize, redact_and_sanitize_multiline};
 use pnpm_package_manifest::safe_read_package_json_from_dir;
 use pnpm_reporter::Reporter;
-use pnpm_store_dir::{PackageFilesIndex, StoreDir, StoreIndexWriter};
+use pnpm_store_dir::{CafsFileInfo, PackageFilesIndex, StoreDir, StoreIndexWriter};
 use serde_json::Value;
 use std::{
     collections::HashMap,
     fs,
     path::{Path, PathBuf},
     process::Command,
-    sync::Arc,
+    sync::{Arc, LazyLock},
 };
 
 /// One-shot fetcher for a single git resolution. Holds borrows for the
@@ -123,33 +123,9 @@ impl GitFetcher<'_> {
         })
         .map_err(|err| name_fetch_failure(self.repo, self.package_name, err))?;
 
-        // `extra_env` is a borrow rather than `Option<&HashMap>`.
-        // Bind an empty map to a local so the borrow has the same lifetime
-        // as `prepare_opts` itself — relying on `&HashMap::new()`'s
-        // temporary-lifetime extension here would work today but is
-        // brittle to future expression-reshape edits in this block.
-        let empty_env: HashMap<String, String> = HashMap::new();
-        let prepare_opts = PreparePackageOptions {
-            allow_build: Box::new(|dep_path| (self.allow_build)(dep_path)),
-            pkg_resolution_id: self.package_id,
-            ignore_scripts: self.ignore_scripts,
-            unsafe_perm: self.unsafe_perm,
-            user_agent: self.user_agent,
-            scripts_prepend_node_path: self.scripts_prepend_node_path,
-            script_shell: self.script_shell,
-            node_execpath: self.node_execpath,
-            npm_execpath: self.npm_execpath,
-            pnpm_execpath: self.pnpm_execpath,
-            extra_bin_paths: &[],
-            extra_env: &empty_env,
-        };
         let PreparedPackage { pkg_dir, should_be_built } =
-            match prepare_package::<Reporter>(&prepare_opts, temp_location, self.path) {
-                Ok(p) => p,
-                Err(err) => {
-                    return Err(wrap_prepare_error(self.repo, err));
-                }
-            };
+            prepare_package::<Reporter>(&self.prepare_options(), temp_location, self.path)
+                .map_err(|err| wrap_prepare_error(self.repo, err))?;
         if self.ignore_scripts && should_be_built {
             tracing::warn!(
                 target: "pacquet::git_fetcher",
@@ -170,33 +146,77 @@ impl GitFetcher<'_> {
             return Err(GitFetcherError::Io(err));
         }
 
-        let manifest = safe_read_package_json_from_dir(&pkg_dir)
-            .unwrap_or(None)
-            .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
-        let files = packlist(&pkg_dir, &manifest).map_err(GitFetcherError::Packlist)?;
-
+        let files = packlist_of(&pkg_dir)?;
         let ImportedFiles { cas_paths, files_index } =
             import_into_cas(self.store_dir, &pkg_dir, &files)?;
 
         // Queue a `PackageFilesIndex` row so a future install's warm
         // prefetch finds the snapshot in `index.db` and skips the
         // clone+checkout+prepare+packlist re-run.
-        if let Some(writer) = self.store_index_writer {
-            writer.queue(
-                self.files_index_file.to_string(),
-                PackageFilesIndex {
-                    manifest: None,
-                    requires_build: Some(should_be_built),
-                    requires_prepare: Some(should_be_built),
-                    algo: "sha512".to_string(),
-                    files: files_index,
-                    side_effects: None,
-                    remote_side_effects_quarantine: None,
-                },
-            );
-        }
+        queue_files_index(
+            self.store_index_writer,
+            self.files_index_file,
+            files_index,
+            should_be_built,
+        );
 
         Ok(GitFetchOutput { cas_paths, built: should_be_built })
+    }
+}
+
+impl<'a> GitFetcher<'a> {
+    fn prepare_options(&self) -> PreparePackageOptions<'a> {
+        let allow_build = self.allow_build;
+        PreparePackageOptions {
+            allow_build: Box::new(move |dep_path| allow_build(dep_path)),
+            pkg_resolution_id: self.package_id,
+            ignore_scripts: self.ignore_scripts,
+            unsafe_perm: self.unsafe_perm,
+            user_agent: self.user_agent,
+            scripts_prepend_node_path: self.scripts_prepend_node_path,
+            script_shell: self.script_shell,
+            node_execpath: self.node_execpath,
+            npm_execpath: self.npm_execpath,
+            pnpm_execpath: self.pnpm_execpath,
+            extra_bin_paths: &[],
+            extra_env: &NO_EXTRA_ENV,
+        }
+    }
+}
+
+/// Git-hosted packages build with no extra environment.
+pub(crate) static NO_EXTRA_ENV: LazyLock<HashMap<String, String>> = LazyLock::new(HashMap::new);
+
+/// The files the package would publish, per its manifest (a missing or
+/// unreadable manifest counts as empty).
+pub(crate) fn packlist_of(pkg_dir: &Path) -> Result<Vec<String>, GitFetcherError> {
+    let manifest = safe_read_package_json_from_dir(pkg_dir)
+        .unwrap_or(None)
+        .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
+    packlist(pkg_dir, &manifest).map_err(GitFetcherError::Packlist)
+}
+
+/// Queue a `PackageFilesIndex` row so a future install's warm prefetch
+/// finds the snapshot in `index.db` and skips the fetch and prepare re-run.
+pub(crate) fn queue_files_index(
+    writer: Option<&Arc<StoreIndexWriter>>,
+    files_index_file: &str,
+    files: HashMap<String, CafsFileInfo>,
+    should_be_built: bool,
+) {
+    if let Some(writer) = writer {
+        writer.queue(
+            files_index_file.to_string(),
+            PackageFilesIndex {
+                manifest: None,
+                requires_build: Some(should_be_built),
+                requires_prepare: Some(should_be_built),
+                algo: "sha512".to_string(),
+                files,
+                side_effects: None,
+                remote_side_effects_quarantine: None,
+            },
+        );
     }
 }
 

--- a/pnpm/crates/git-fetcher/src/prepare_package.rs
+++ b/pnpm/crates/git-fetcher/src/prepare_package.rs
@@ -100,11 +100,9 @@ pub fn prepare_package<Reporter: self::Reporter>(
 
     assert_package_build_allowed(opts.allow_build.as_ref(), opts.pkg_resolution_id, &manifest)?;
 
-    let name = manifest.get("name").and_then(Value::as_str).unwrap_or("");
-    let version = manifest.get("version").and_then(Value::as_str).unwrap_or("");
     let wanted_pm = detect_wanted_pm(git_root_dir, Some(&manifest));
     let pm = wanted_pm.pm;
-    let dep_path = format!("{name}@{version}");
+    let dep_path = manifest_dep_path(&manifest);
 
     let mut extra_bin_paths = opts.extra_bin_paths.to_vec();
     // Kept alive until the prepare is over: dropping it takes the shims
@@ -133,6 +131,25 @@ pub fn prepare_package<Reporter: self::Reporter>(
         optional: false,
     };
 
+    run_install_and_prepublish::<Reporter>(pm, &run_opts, &manifest)?;
+    remove_install_node_modules(&pkg_dir)?;
+
+    Ok(PreparedPackage { pkg_dir, should_be_built: true })
+}
+
+fn manifest_dep_path(manifest: &Value) -> String {
+    let name = manifest.get("name").and_then(Value::as_str).unwrap_or("");
+    let version = manifest.get("version").and_then(Value::as_str).unwrap_or("");
+    format!("{name}@{version}")
+}
+
+/// Run `<pm> install` and then the prepublish lifecycle scripts, each
+/// against the manifest with that script injected.
+fn run_install_and_prepublish<Reporter: self::Reporter>(
+    pm: PreferredPm,
+    run_opts: &RunPostinstallHooks<'_>,
+    manifest: &Value,
+) -> Result<(), PreparePackageError> {
     let parent_env: HashMap<String, String> = std::env::vars().collect();
     let mut working_manifest = manifest.clone();
     let install_stage = format!("{}-install", pm.name());
@@ -141,7 +158,7 @@ pub fn prepare_package<Reporter: self::Reporter>(
     run_lifecycle_hook::<Reporter>(
         &install_stage,
         &install_script,
-        &run_opts,
+        run_opts,
         &working_manifest,
         &parent_env,
     )
@@ -153,21 +170,22 @@ pub fn prepare_package<Reporter: self::Reporter>(
         else {
             continue;
         };
-        run_lifecycle_hook::<Reporter>(&stage, &script, &run_opts, &working_manifest, &parent_env)
+        run_lifecycle_hook::<Reporter>(&stage, &script, run_opts, &working_manifest, &parent_env)
             .map_err(map_lifecycle_err)?;
     }
+    Ok(())
+}
 
-    // Remove the install-time `node_modules` so the deps don't leak
-    // into the CAS. Ignore `NotFound` (the script may not have
-    // populated `node_modules` at all).
-    let node_modules = pkg_dir.join("node_modules");
-    if let Err(error) = fs::remove_dir_all(&node_modules)
-        && error.kind() != std::io::ErrorKind::NotFound
-    {
-        return Err(PreparePackageError::Io(error));
+/// Remove the install-time `node_modules` so the deps don't leak
+/// into the CAS. Ignore `NotFound` (the script may not have
+/// populated `node_modules` at all).
+fn remove_install_node_modules(pkg_dir: &Path) -> Result<(), PreparePackageError> {
+    match fs::remove_dir_all(pkg_dir.join("node_modules")) {
+        Err(error) if error.kind() != std::io::ErrorKind::NotFound => {
+            Err(PreparePackageError::Io(error))
+        }
+        _ => Ok(()),
     }
-
-    Ok(PreparedPackage { pkg_dir, should_be_built: true })
 }
 
 /// Read the manifest, decide whether the package needs building, and

--- a/pnpm/crates/git-fetcher/src/tarball_fetcher.rs
+++ b/pnpm/crates/git-fetcher/src/tarball_fetcher.rs
@@ -27,14 +27,12 @@
 use crate::{
     cas_io::{ImportedFiles, import_into_cas, materialize_into, synthesize_files_index},
     error::GitFetcherError,
-    fetcher::GitFetchOutput,
+    fetcher::{GitFetchOutput, NO_EXTRA_ENV, packlist_of, queue_files_index},
     prepare_package::{AllowBuildRef, PreparePackageOptions, PreparedPackage, prepare_package},
 };
 use pnpm_executor::ScriptsPrependNodePath;
-use pnpm_fs_packlist::packlist;
-use pnpm_package_manifest::safe_read_package_json_from_dir;
 use pnpm_reporter::Reporter;
-use pnpm_store_dir::{PackageFilesIndex, StoreDir, StoreIndexWriter};
+use pnpm_store_dir::{StoreDir, StoreIndexWriter};
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
@@ -104,29 +102,8 @@ impl GitHostedTarballFetcher<'_> {
         // `prepack` / `publish` lifecycle scripts when needed, and
         // returns `pkg_dir` (which respects `self.path`) plus the
         // `should_be_built` flag.
-        let empty_env: HashMap<String, String> = HashMap::new();
-        let prepare_opts = PreparePackageOptions {
-            allow_build: Box::new(|dep_path| (self.allow_build)(dep_path)),
-            pkg_resolution_id: self.package_id,
-            ignore_scripts: self.ignore_scripts,
-            unsafe_perm: self.unsafe_perm,
-            user_agent: self.user_agent,
-            scripts_prepend_node_path: self.scripts_prepend_node_path,
-            script_shell: self.script_shell,
-            node_execpath: self.node_execpath,
-            npm_execpath: self.npm_execpath,
-            pnpm_execpath: self.pnpm_execpath,
-            extra_bin_paths: &[],
-            extra_env: &empty_env,
-        };
-        // Pacquet preserves the underlying error through the miette
-        // source chain — the install dispatcher's log line already
-        // includes `package_id`, so the chain renders as "prepare
-        // failed for `<pkg>` → `ERR_PNPM_PREPARE_PACKAGE` → underlying
-        // lifecycle error". A dedicated context variant is a follow-up
-        // if the rendered chain proves unclear.
         let PreparedPackage { pkg_dir, should_be_built } =
-            prepare_package::<Reporter>(&prepare_opts, temp_location, self.path)
+            prepare_package::<Reporter>(&self.prepare_options(), temp_location, self.path)
                 .map_err(GitFetcherError::Prepare)?;
 
         // Warn when scripts were ignored on a package that needs
@@ -144,10 +121,7 @@ impl GitHostedTarballFetcher<'_> {
         // checkout (build artifacts, source maps, test fixtures);
         // applying the packlist filter on the way back into CAS
         // matches the file set the package would publish.
-        let manifest = safe_read_package_json_from_dir(&pkg_dir)
-            .unwrap_or(None)
-            .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
-        let files = packlist(&pkg_dir, &manifest).map_err(GitFetcherError::Packlist)?;
+        let files = packlist_of(&pkg_dir)?;
 
         // Step 4: Fast path — when nothing got filtered out AND
         // prepare didn't mutate the tree (no build needed, or scripts
@@ -166,19 +140,12 @@ impl GitHostedTarballFetcher<'_> {
             // download doesn't write a `\traw` row at the same key, so
             // there's nothing to copy — but the CAS files themselves
             // are already in place, which is what `cas_paths` points at.
-            if let Some(writer) = self.store_index_writer {
-                let files_index = synthesize_files_index(&self.cas_paths)?;
-                writer.queue(
-                    self.files_index_file.to_string(),
-                    PackageFilesIndex {
-                        manifest: None,
-                        requires_build: Some(false),
-                        requires_prepare: Some(false),
-                        algo: "sha512".to_string(),
-                        files: files_index,
-                        side_effects: None,
-                        remote_side_effects_quarantine: None,
-                    },
+            if self.store_index_writer.is_some() {
+                queue_files_index(
+                    self.store_index_writer,
+                    self.files_index_file,
+                    synthesize_files_index(&self.cas_paths)?,
+                    false,
                 );
             }
             return Ok(GitFetchOutput { cas_paths: self.cas_paths, built: false });
@@ -203,22 +170,34 @@ impl GitHostedTarballFetcher<'_> {
         // pass entirely. The final row lands at the git-hosted
         // store-index key; the dispatcher already builds that key and
         // passes it via `files_index_file`.
-        if let Some(writer) = self.store_index_writer {
-            writer.queue(
-                self.files_index_file.to_string(),
-                PackageFilesIndex {
-                    manifest: None,
-                    requires_build: Some(should_be_built),
-                    requires_prepare: Some(should_be_built),
-                    algo: "sha512".to_string(),
-                    files: files_index,
-                    side_effects: None,
-                    remote_side_effects_quarantine: None,
-                },
-            );
-        }
+        queue_files_index(
+            self.store_index_writer,
+            self.files_index_file,
+            files_index,
+            should_be_built,
+        );
 
         Ok(GitFetchOutput { cas_paths, built: should_be_built })
+    }
+}
+
+impl<'a> GitHostedTarballFetcher<'a> {
+    fn prepare_options(&self) -> PreparePackageOptions<'a> {
+        let allow_build = self.allow_build;
+        PreparePackageOptions {
+            allow_build: Box::new(move |dep_path| allow_build(dep_path)),
+            pkg_resolution_id: self.package_id,
+            ignore_scripts: self.ignore_scripts,
+            unsafe_perm: self.unsafe_perm,
+            user_agent: self.user_agent,
+            scripts_prepend_node_path: self.scripts_prepend_node_path,
+            script_shell: self.script_shell,
+            node_execpath: self.node_execpath,
+            npm_execpath: self.npm_execpath,
+            pnpm_execpath: self.pnpm_execpath,
+            extra_bin_paths: &[],
+            extra_env: &NO_EXTRA_ENV,
+        }
     }
 }
 

--- a/pnpm/crates/hooks/src/custom_resolver_adapter.rs
+++ b/pnpm/crates/hooks/src/custom_resolver_adapter.rs
@@ -82,21 +82,7 @@ impl Resolver for CustomResolverAdapter {
         opts: &'a ResolveOptions,
     ) -> ResolveFuture<'a> {
         Box::pin(async move {
-            let key = Self::cache_key(wanted_dependency);
-
-            let cached = self.can_resolve_cache.lock().unwrap().get(&key).copied();
-            let can = if let Some(cached) = cached {
-                cached
-            } else {
-                let wanted_val = Self::wanted_to_value(wanted_dependency);
-                let result = self.resolver.can_resolve(wanted_val).await.map_err(|err| {
-                    Box::new(std::io::Error::other(err.to_string())) as ResolveError
-                })?;
-                self.can_resolve_cache.lock().unwrap().insert(key, result);
-                result
-            };
-
-            if !can {
+            if !self.can_resolve_cached(wanted_dependency).await? {
                 return Ok(None);
             }
 
@@ -108,28 +94,17 @@ impl Resolver for CustomResolverAdapter {
                     Box::new(std::io::Error::other(err.to_string())) as ResolveError
                 })?;
 
-            let id = result.get("id").and_then(Value::as_str).ok_or_else(|| {
-                let err: ResolveError = Box::new(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "Custom resolver did not return an 'id' field",
-                ));
-                err
-            })?;
+            let id = result
+                .get("id")
+                .and_then(Value::as_str)
+                .ok_or_else(|| invalid_data("Custom resolver did not return an 'id' field"))?;
 
             let resolution_val = result.get("resolution").ok_or_else(|| {
-                let err: ResolveError = Box::new(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "Custom resolver did not return a 'resolution' field",
-                ));
-                err
+                invalid_data("Custom resolver did not return a 'resolution' field")
             })?;
 
             let resolution = serde_json::from_value(resolution_val.clone()).map_err(|err| {
-                let resolve_err: ResolveError = Box::new(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("Custom resolver returned invalid resolution: {err}"),
-                ));
-                resolve_err
+                invalid_data(format!("Custom resolver returned invalid resolution: {err}"))
             })?;
 
             // The hook's whole result is carried through, so a manifest
@@ -138,11 +113,7 @@ impl Resolver for CustomResolverAdapter {
             let manifest = match result.get("manifest") {
                 Some(manifest_val) => {
                     Some(Arc::new(serde_json::from_value(manifest_val.clone()).map_err(|err| {
-                        let resolve_err: ResolveError = Box::new(std::io::Error::new(
-                            std::io::ErrorKind::InvalidData,
-                            format!("Custom resolver returned invalid manifest: {err}"),
-                        ));
-                        resolve_err
+                        invalid_data(format!("Custom resolver returned invalid manifest: {err}"))
                     })?))
                 }
                 None => None,
@@ -170,6 +141,27 @@ impl Resolver for CustomResolverAdapter {
     ) -> ResolveLatestFuture<'a> {
         Box::pin(async move { Ok(None) })
     }
+}
+
+impl CustomResolverAdapter {
+    async fn can_resolve_cached(&self, wanted: &WantedDependency) -> Result<bool, ResolveError> {
+        let key = Self::cache_key(wanted);
+        let cached = self.can_resolve_cache.lock().unwrap().get(&key).copied();
+        if let Some(cached) = cached {
+            return Ok(cached);
+        }
+        let result = self
+            .resolver
+            .can_resolve(Self::wanted_to_value(wanted))
+            .await
+            .map_err(|err| Box::new(std::io::Error::other(err.to_string())) as ResolveError)?;
+        self.can_resolve_cache.lock().unwrap().insert(key, result);
+        Ok(result)
+    }
+}
+
+fn invalid_data(message: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> ResolveError {
+    Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, message))
 }
 
 #[cfg(test)]

--- a/pnpm/crates/hooks/src/node_runtime.rs
+++ b/pnpm/crates/hooks/src/node_runtime.rs
@@ -46,42 +46,9 @@ impl NodeJsHooks {
         args: Value,
         logger: &crate::PreResolutionHookLogger,
     ) {
-        let file_path = self.file.to_string_lossy();
-        let Ok(file_path_escaped) = serde_json::to_string(&file_path) else { return };
         let Ok(ctx_payload) = serde_json::to_string(&args) else { return };
-
-        let (input_type, wrapper) = if file_path.ends_with(".mjs") {
-            (
-                "module",
-                format!(
-                    r#"import {{ readFileSync }} from 'node:fs';
-import {{ pathToFileURL }} from 'node:url';
-const hooks = await import(pathToFileURL({file_path_escaped}).href);
-const ctx = JSON.parse(readFileSync(0, 'utf8'));
-const logger = {{
-  info: (m) => {{ console.log(JSON.stringify({{"level":"info","message":String(m)}})); }},
-  warn: (m) => {{ console.log(JSON.stringify({{"level":"warn","message":String(m)}})); }}
-}};
-await (hooks.hooks && hooks.hooks['{func}'])?.(ctx, logger);
-"#,
-                ),
-            )
-        } else {
-            (
-                "commonjs",
-                format!(
-                    r#"(async () => {{
-  const hooks = require({file_path_escaped});
-  const ctx = JSON.parse(require('fs').readFileSync(0, 'utf8'));
-  const logger = {{
-    info: (m) => {{ console.log(JSON.stringify({{"level":"info","message":String(m)}})); }},
-    warn: (m) => {{ console.log(JSON.stringify({{"level":"warn","message":String(m)}})); }}
-  }};
-  await (hooks.hooks && hooks.hooks['{func}'])?.(ctx, logger);
-}})();
-"#,
-                ),
-            )
+        let Some((input_type, wrapper)) = hook_wrapper(&self.file.to_string_lossy(), func) else {
+            return;
         };
 
         let Ok(mut child) = Command::new("node")
@@ -99,34 +66,7 @@ await (hooks.hooks && hooks.hooks['{func}'])?.(ctx, logger);
             return;
         };
 
-        let stdin = child.stdin.take();
-        let stdout = child.stdout.take().expect("stdout is piped");
-        let stderr = child.stderr.take().expect("stderr is piped");
-
-        // Stream all three pipes concurrently instead of buffering:
-        // stdout/stderr are hook-controlled, so buffering would let a noisy
-        // pnpmfile grow memory without bound, and log messages should surface
-        // while the hook is still running (pnpm runs the hook in-process, so
-        // its logger calls render immediately). The context write runs in the
-        // same join because a pnpmfile that logs heavily at import time could
-        // otherwise fill the stdout pipe and deadlock against the stdin
-        // write. A write error is left for `child.wait()` to surface as a
-        // non-zero exit.
-        let write_context = async {
-            if let Some(mut stdin) = stdin {
-                let _ = stdin.write_all(ctx_payload.as_bytes()).await;
-            }
-            // Dropping stdin closes the pipe so `readFileSync(0)` sees EOF.
-        };
-        let forward_stdout = forward_hook_stdout(stdout, logger);
-        let collect_stderr = read_tail(stderr, STDERR_TAIL_LIMIT);
-        let wait_child = child.wait();
-        let hook_result = timeout(HOOK_TIMEOUT, async {
-            let ((), (), stderr_tail, status) =
-                tokio::join!(write_context, forward_stdout, collect_stderr, wait_child);
-            (stderr_tail, status)
-        })
-        .await;
+        let hook_result = drive_hook(&mut child, &ctx_payload, logger).await;
 
         let Ok((stderr_tail, Ok(status))) = hook_result else {
             (logger.warn)("pnpmfile hook timed out or failed to execute".to_string());
@@ -138,6 +78,82 @@ await (hooks.hooks && hooks.hooks['{func}'])?.(ctx, logger);
             (logger.warn)(format!("pnpmfile hook failed: {stderr}"));
         }
     }
+}
+
+/// The Node wrapper that loads the pnpmfile and calls `func` with the
+/// context read from stdin, keyed by the module type Node must parse it as.
+fn hook_wrapper(file_path: &str, func: &str) -> Option<(&'static str, String)> {
+    let file_path_escaped = serde_json::to_string(file_path).ok()?;
+    let (input_type, wrapper) = if file_path.ends_with(".mjs") {
+        (
+            "module",
+            format!(
+                r#"import {{ readFileSync }} from 'node:fs';
+import {{ pathToFileURL }} from 'node:url';
+const hooks = await import(pathToFileURL({file_path_escaped}).href);
+const ctx = JSON.parse(readFileSync(0, 'utf8'));
+const logger = {{
+  info: (m) => {{ console.log(JSON.stringify({{"level":"info","message":String(m)}})); }},
+  warn: (m) => {{ console.log(JSON.stringify({{"level":"warn","message":String(m)}})); }}
+}};
+await (hooks.hooks && hooks.hooks['{func}'])?.(ctx, logger);
+"#,
+            ),
+        )
+    } else {
+        (
+            "commonjs",
+            format!(
+                r#"(async () => {{
+  const hooks = require({file_path_escaped});
+  const ctx = JSON.parse(require('fs').readFileSync(0, 'utf8'));
+  const logger = {{
+info: (m) => {{ console.log(JSON.stringify({{"level":"info","message":String(m)}})); }},
+warn: (m) => {{ console.log(JSON.stringify({{"level":"warn","message":String(m)}})); }}
+  }};
+  await (hooks.hooks && hooks.hooks['{func}'])?.(ctx, logger);
+}})();
+"#,
+            ),
+        )
+    };
+    Some((input_type, wrapper))
+}
+
+/// Feed the hook its context and collect its stderr tail and exit status.
+async fn drive_hook(
+    child: &mut tokio::process::Child,
+    ctx_payload: &str,
+    logger: &crate::PreResolutionHookLogger,
+) -> Result<(Vec<u8>, std::io::Result<std::process::ExitStatus>), tokio::time::error::Elapsed> {
+    let stdin = child.stdin.take();
+    let stdout = child.stdout.take().expect("stdout is piped");
+    let stderr = child.stderr.take().expect("stderr is piped");
+
+    // Stream all three pipes concurrently instead of buffering:
+    // stdout/stderr are hook-controlled, so buffering would let a noisy
+    // pnpmfile grow memory without bound, and log messages should surface
+    // while the hook is still running (pnpm runs the hook in-process, so
+    // its logger calls render immediately). The context write runs in the
+    // same join because a pnpmfile that logs heavily at import time could
+    // otherwise fill the stdout pipe and deadlock against the stdin
+    // write. A write error is left for `child.wait()` to surface as a
+    // non-zero exit.
+    let write_context = async {
+        if let Some(mut stdin) = stdin {
+            let _ = stdin.write_all(ctx_payload.as_bytes()).await;
+        }
+        // Dropping stdin closes the pipe so `readFileSync(0)` sees EOF.
+    };
+    let forward_stdout = forward_hook_stdout(stdout, logger);
+    let collect_stderr = read_tail(stderr, STDERR_TAIL_LIMIT);
+    let wait_child = child.wait();
+    timeout(HOOK_TIMEOUT, async {
+        let ((), (), stderr_tail, status) =
+            tokio::join!(write_context, forward_stdout, collect_stderr, wait_child);
+        (stderr_tail, status)
+    })
+    .await
 }
 
 /// How much trailing stderr to keep for the failure message when the hook

--- a/pnpm/crates/hooks/src/worker.rs
+++ b/pnpm/crates/hooks/src/worker.rs
@@ -27,7 +27,7 @@ use std::{
 };
 use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
-    process::{Child, ChildStdin, Command},
+    process::{Child, ChildStdin, ChildStdout, Command},
     sync::{Mutex, Semaphore, oneshot},
     time::{Duration, timeout},
 };
@@ -151,19 +151,7 @@ impl NodeWorker {
         let stdout = child.stdout.take().expect("worker stdout is piped");
 
         let pending: PendingMap = Arc::new(StdMutex::new(HashMap::new()));
-        let pending_reader = Arc::clone(&pending);
-        let stdin_reader = Arc::clone(&stdin);
-        tokio::spawn(async move {
-            let mut lines = BufReader::new(stdout).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                dispatch_line(&pending_reader, &stdin_reader, &line);
-            }
-            // The worker exited: fail every still-pending request so callers
-            // don't hang waiting for a response that will never arrive.
-            for (_, pending) in pending_reader.lock().unwrap().drain() {
-                let _ = pending.done.send(Err("pnpmfile worker exited".to_string()));
-            }
-        });
+        spawn_stdout_reader(stdout, Arc::clone(&pending), Arc::clone(&stdin));
 
         Ok(Arc::new(NodeWorker {
             pnpmfile,
@@ -369,6 +357,21 @@ impl NodeWorker {
 /// Route one line from the worker to its pending request: forward `log` lines
 /// to the call's logger (the entry stays until the result arrives) and resolve
 /// the call on `ok`/`err`.
+/// Dispatch every line the worker writes; once it exits, fail every
+/// still-pending request so callers don't hang waiting for a response
+/// that will never arrive.
+fn spawn_stdout_reader(stdout: ChildStdout, pending: PendingMap, stdin: Arc<Mutex<ChildStdin>>) {
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(stdout).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            dispatch_line(&pending, &stdin, &line);
+        }
+        for (_, request) in pending.lock().unwrap().drain() {
+            let _ = request.done.send(Err("pnpmfile worker exited".to_string()));
+        }
+    });
+}
+
 fn dispatch_line(pending: &PendingMap, stdin: &Arc<Mutex<ChildStdin>>, line: &str) {
     let Ok(message) = serde_json::from_str::<Value>(line) else { return };
     let Some(id) = message.get("id").and_then(Value::as_u64) else { return };
@@ -412,7 +415,14 @@ fn dispatch_callback(
     if let Some(callbacks) = callbacks {
         let _ = callbacks.send(FetcherCallback { method, resolution, options, response });
     }
-    let stdin = Arc::clone(stdin);
+    reply_when_answered(Arc::clone(stdin), callback_id, receiver);
+}
+
+fn reply_when_answered(
+    stdin: Arc<Mutex<ChildStdin>>,
+    callback_id: u64,
+    receiver: oneshot::Receiver<Result<Value, Value>>,
+) {
     tokio::spawn(async move {
         let result = receiver.await.unwrap_or_else(|_| {
             Err(serde_json::json!({

--- a/pnpm/crates/injected-deps-syncer/src/lib.rs
+++ b/pnpm/crates/injected-deps-syncer/src/lib.rs
@@ -121,8 +121,9 @@ pub fn sync_injected_deps(opts: &SyncInjectedDeps<'_>) -> Result<(), SyncInjecte
         return Ok(());
     };
 
-    let injected_dep_key = injected_dep_key(workspace_dir, &pkg_root_dir);
-    let Some(target_dirs) = injected_deps.get(&injected_dep_key).filter(|dirs| !dirs.is_empty())
+    let Some(target_dirs) = injected_deps
+        .get(&injected_dep_key(workspace_dir, &pkg_root_dir))
+        .filter(|dirs| !dirs.is_empty())
     else {
         tracing::debug!(
             target: "pacquet::sync_injected_deps",
@@ -134,18 +135,11 @@ pub fn sync_injected_deps(opts: &SyncInjectedDeps<'_>) -> Result<(), SyncInjecte
 
     let resolved_targets: Vec<PathBuf> =
         target_dirs.iter().map(|target_dir| workspace_dir.join(target_dir)).collect();
-    for patcher in DirPatcher::from_multiple_targets(&pkg_root_dir, &resolved_targets)
-        .map_err(SyncInjectedDepsError::Patch)?
-    {
-        patcher.apply().map_err(SyncInjectedDepsError::Patch)?;
-    }
+    patch_targets(&pkg_root_dir, &resolved_targets)?;
 
-    let previous_bin_names = opts.manifest_before_scripts.map_or_else(Vec::new, |manifest| {
-        get_bins_from_package_manifest::<pnpm_cmd_shim::Host>(manifest, &pkg_root_dir)
-            .into_iter()
-            .map(|command| command.name)
-            .collect()
-    });
+    let previous_bin_names = opts
+        .manifest_before_scripts
+        .map_or_else(Vec::new, |manifest| bin_names(manifest, &pkg_root_dir));
     // The install hoists bins into the virtual store's own `.bin` as well.
     let hoisted_bin_dir = modules.as_ref().map(|modules| {
         workspace_dir.join(&modules.virtual_store_dir).join("node_modules").join(".bin")
@@ -157,6 +151,25 @@ pub fn sync_injected_deps(opts: &SyncInjectedDeps<'_>) -> Result<(), SyncInjecte
         previous_bin_names: &previous_bin_names,
         hoisted_bin_dir: hoisted_bin_dir.as_deref(),
     })
+}
+
+fn patch_targets(
+    pkg_root_dir: &Path,
+    resolved_targets: &[PathBuf],
+) -> Result<(), SyncInjectedDepsError> {
+    for patcher in DirPatcher::from_multiple_targets(pkg_root_dir, resolved_targets)
+        .map_err(SyncInjectedDepsError::Patch)?
+    {
+        patcher.apply().map_err(SyncInjectedDepsError::Patch)?;
+    }
+    Ok(())
+}
+
+fn bin_names(manifest: &serde_json::Value, pkg_root_dir: &Path) -> Vec<String> {
+    get_bins_from_package_manifest::<pnpm_cmd_shim::Host>(manifest, pkg_root_dir)
+        .into_iter()
+        .map(|command| command.name)
+        .collect()
 }
 
 /// The key `.modules.yaml` files an injected dependency under: the
@@ -187,15 +200,8 @@ struct RemoveStaleBins<'a> {
 }
 
 fn sync_bin_links(opts: &SyncBinLinks<'_>) -> Result<(), SyncInjectedDepsError> {
-    let SyncBinLinks {
-        pkg_root_dir,
-        resolved_targets,
-        workspace_dir,
-        previous_bin_names,
-        hoisted_bin_dir,
-    } = *opts;
-    let manifest = safe_read_package_json_from_dir(pkg_root_dir).map_err(|error| {
-        SyncInjectedDepsError::ReadManifest { dir: pkg_root_dir.to_path_buf(), error }
+    let manifest = safe_read_package_json_from_dir(opts.pkg_root_dir).map_err(|error| {
+        SyncInjectedDepsError::ReadManifest { dir: opts.pkg_root_dir.to_path_buf(), error }
     })?;
     let Some(manifest) = manifest.filter(|manifest| manifest.get("name").is_some()) else {
         return Ok(());
@@ -204,24 +210,21 @@ fn sync_bin_links(opts: &SyncBinLinks<'_>) -> Result<(), SyncInjectedDepsError> 
     // `link_bins` only ever creates shims, so a bin the script dropped keeps
     // its shim, pointing at a command that is no longer there.
     let current_bin_names: HashSet<String> =
-        get_bins_from_package_manifest::<pnpm_cmd_shim::Host>(&manifest, pkg_root_dir)
-            .into_iter()
-            .map(|command| command.name)
-            .collect();
+        bin_names(&manifest, opts.pkg_root_dir).into_iter().collect();
     let stale_bin_names: Vec<&String> =
-        previous_bin_names.iter().filter(|name| !current_bin_names.contains(*name)).collect();
+        opts.previous_bin_names.iter().filter(|name| !current_bin_names.contains(*name)).collect();
 
     let has_bins = manifest.get("bin").is_some();
     let manifest = Arc::new(manifest);
 
-    for target_dir in resolved_targets {
+    for target_dir in opts.resolved_targets {
         let Some(parent_modules_dir) = target_dir.parent() else {
             continue;
         };
         remove_stale_bins(RemoveStaleBins {
             target_dir,
             parent_modules_dir,
-            hoisted_bin_dir,
+            hoisted_bin_dir: opts.hoisted_bin_dir,
             stale_bin_names: &stale_bin_names,
         })?;
 
@@ -237,9 +240,16 @@ fn sync_bin_links(opts: &SyncBinLinks<'_>) -> Result<(), SyncInjectedDepsError> 
         .map_err(SyncInjectedDepsError::LinkBins)?;
     }
 
-    // Any project in the workspace may consume the injected package, so
-    // every project's bin directory is refreshed rather than only the
-    // ones this sync touched.
+    relink_project_bins(opts.workspace_dir, &stale_bin_names)
+}
+
+/// Any project in the workspace may consume the injected package, so
+/// every project's bin directory is refreshed rather than only the
+/// ones this sync touched.
+fn relink_project_bins(
+    workspace_dir: &Path,
+    stale_bin_names: &[&String],
+) -> Result<(), SyncInjectedDepsError> {
     let projects =
         find_workspace_projects_no_check(workspace_dir, &FindWorkspaceProjectsOpts::default())
             .map_err(|error| SyncInjectedDepsError::FindProjects { error })?;
@@ -249,7 +259,7 @@ fn sync_bin_links(opts: &SyncBinLinks<'_>) -> Result<(), SyncInjectedDepsError> 
         // relink below, so removing first costs nothing and catches the shim
         // this package left behind.
         let project_bin_dir = project_modules_dir.join(".bin");
-        for name in &stale_bin_names {
+        for name in stale_bin_names {
             remove_bin(&project_bin_dir.join(name.as_str())).map_err(|error| {
                 SyncInjectedDepsError::RemoveBin {
                     path: project_bin_dir.join(name.as_str()),

--- a/pnpm/crates/lockfile/src/freshness.rs
+++ b/pnpm/crates/lockfile/src/freshness.rs
@@ -394,20 +394,7 @@ fn check_recorded_config(
         });
     }
 
-    let empty: HashMap<String, String> = HashMap::new();
-    let lockfile_overrides: BTreeMap<String, String> = lockfile
-        .overrides
-        .as_ref()
-        .map(|map| map.iter().map(|(key, value)| (key.clone(), value.clone())).collect())
-        .unwrap_or_default();
-    let config_overrides: BTreeMap<String, String> =
-        check.overrides.unwrap_or(&empty).iter().map(|(k, v)| (k.clone(), v.clone())).collect();
-    if lockfile_overrides != config_overrides {
-        return Err(StalenessReason::OverridesChanged {
-            lockfile: lockfile_overrides,
-            config: config_overrides,
-        });
-    }
+    check_overrides(lockfile, check.overrides)?;
 
     if lockfile.package_extensions_checksum.as_deref() != check.package_extensions_checksum {
         return Err(StalenessReason::PackageExtensionsChecksumChanged {
@@ -438,6 +425,29 @@ fn check_recorded_config(
         return Err(StalenessReason::PatchedDependenciesChanged {
             lockfile: lockfile_patches.clone(),
             config: config_patches.clone(),
+        });
+    }
+    Ok(())
+}
+
+fn check_overrides(
+    lockfile: &Lockfile,
+    config_overrides: Option<&HashMap<String, String>>,
+) -> Result<(), StalenessReason> {
+    let lockfile_overrides: BTreeMap<String, String> = lockfile
+        .overrides
+        .as_ref()
+        .map(|map| map.iter().map(|(key, value)| (key.clone(), value.clone())).collect())
+        .unwrap_or_default();
+    let config_overrides: BTreeMap<String, String> = config_overrides
+        .into_iter()
+        .flatten()
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect();
+    if lockfile_overrides != config_overrides {
+        return Err(StalenessReason::OverridesChanged {
+            lockfile: lockfile_overrides,
+            config: config_overrides,
         });
     }
     Ok(())

--- a/pnpm/crates/napi/src/dependents.rs
+++ b/pnpm/crates/napi/src/dependents.rs
@@ -34,6 +34,7 @@ use pnpm_deps_inspection::{
     graph::{BuildGraphOptions, build_dependency_graph},
     search::Searcher,
 };
+use pnpm_lockfile::Lockfile;
 use pnpm_modules_yaml::{DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH, IncludedDependencies};
 
 use crate::error::report_to_napi_error;
@@ -168,79 +169,107 @@ fn reject_over_deep_trees(trees: &serde_json::Value) -> napi::Result<()> {
 
 fn build_trees(options: &DependentsOptions) -> napi::Result<Vec<DependentsTree>> {
     let lockfile_dir = PathBuf::from(&options.dir);
-    let modules_dir = options.modules_dir.as_ref().map(PathBuf::from);
-    let loaded = LoadedState::load(&lockfile_dir, modules_dir.as_deref(), false)
-        .map_err(|report| report_to_napi_error(&report))?;
-
-    let registries: BTreeMap<String, String> = match &options.registries {
-        Some(registries) if !registries.is_empty() => {
-            registries.iter().map(|(scope, url)| (scope.clone(), url.clone())).collect()
-        }
-        _ => BTreeMap::from([("default".to_string(), pnpm_config::default_registry())]),
-    };
-    let virtual_store_dir_max_length = options
-        .virtual_store_dir_max_length
-        .map_or(DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH as usize, |value| value as usize);
+    let loaded =
+        LoadedState::load(&lockfile_dir, options.modules_dir.as_deref().map(Path::new), false)
+            .map_err(|report| report_to_napi_error(&report))?;
+    let registries = registry_routes(options);
 
     // No lockfile: nothing is installed, so nothing depends on anything.
-    let Some(env) =
-        loaded.env(&lockfile_dir, virtual_store_dir_max_length, &registries, BTreeMap::new())
-    else {
+    let Some(env) = loaded.env(
+        &lockfile_dir,
+        virtual_store_dir_max_length(options),
+        &registries,
+        BTreeMap::new(),
+    ) else {
         return Ok(Vec::new());
     };
     let lockfile = env.current_lockfile;
-
-    let project_dirs: Vec<PathBuf> = if let Some(dirs) = &options.project_dirs {
-        dirs.iter().map(|dir| resolve_project_dir(&lockfile_dir, dir)).collect()
-    } else {
-        let excluded =
-            create_matcher(options.exclude_project_patterns.as_deref().unwrap_or_default());
-        lockfile
-            .importers
-            .keys()
-            .filter(|importer_id| !excluded.matches(importer_id))
-            .filter_map(|importer_id| safe_importer_dir(&lockfile_dir, importer_id))
-            .collect()
-    };
-
-    let mut importer_info: HashMap<String, ImporterInfo> = HashMap::new();
-    for importer_id in lockfile.importers.keys() {
-        // A key that cannot be safely joined (a malformed or hostile
-        // lockfile) is never dereferenced; the raw key still names the
-        // importer in the output.
-        let manifest = safe_importer_dir(&lockfile_dir, importer_id)
-            .map(|importer_dir| read_project_manifest(&importer_dir))
-            .unwrap_or_default();
-        let name = manifest.name.unwrap_or_else(|| {
-            if importer_id == "." { "the root project".to_string() } else { importer_id.clone() }
-        });
-        importer_info.insert(
-            importer_id.clone(),
-            ImporterInfo { name, version: manifest.version.unwrap_or_default() },
-        );
-    }
-
-    let include = IncludedDependencies {
-        dependencies: options.include_dependencies.unwrap_or(true),
-        dev_dependencies: options.include_dev_dependencies.unwrap_or(true),
-        optional_dependencies: options.include_optional_dependencies.unwrap_or(true),
-    };
+    let project_dirs = importer_dirs(options, lockfile, &lockfile_dir);
+    let importer_info = read_importer_info(lockfile, &lockfile_dir);
     let root_ids = importer_root_ids(lockfile, &lockfile_dir, &project_dirs);
     let graph = build_dependency_graph(
         &root_ids,
-        &BuildGraphOptions { lockfile, include, only_projects: false },
+        &BuildGraphOptions {
+            lockfile,
+            include: included_dependencies(options),
+            only_projects: false,
+        },
     );
     let searcher = Searcher::from_queries(&options.packages)
         .map_err(|report| report_to_napi_error(&report))?;
-    let manifest_fields = options.manifest_fields.clone().unwrap_or_default();
 
     Ok(build_dependents_tree(&BuildDependentsOptions {
         env: &env,
         graph: &graph,
         search: &searcher,
         importer_info: &importer_info,
-        manifest_fields: &manifest_fields,
+        manifest_fields: options.manifest_fields.as_deref().unwrap_or_default(),
     }))
+}
+
+fn registry_routes(options: &DependentsOptions) -> BTreeMap<String, String> {
+    match &options.registries {
+        Some(registries) if !registries.is_empty() => {
+            registries.iter().map(|(scope, url)| (scope.clone(), url.clone())).collect()
+        }
+        _ => BTreeMap::from([("default".to_string(), pnpm_config::default_registry())]),
+    }
+}
+
+fn virtual_store_dir_max_length(options: &DependentsOptions) -> usize {
+    options
+        .virtual_store_dir_max_length
+        .map_or(DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH as usize, |value| value as usize)
+}
+
+fn importer_dirs(
+    options: &DependentsOptions,
+    lockfile: &Lockfile,
+    lockfile_dir: &Path,
+) -> Vec<PathBuf> {
+    if let Some(dirs) = &options.project_dirs {
+        return dirs.iter().map(|dir| resolve_project_dir(lockfile_dir, dir)).collect();
+    }
+    let excluded = create_matcher(options.exclude_project_patterns.as_deref().unwrap_or_default());
+    lockfile
+        .importers
+        .keys()
+        .filter(|importer_id| !excluded.matches(importer_id))
+        .filter_map(|importer_id| safe_importer_dir(lockfile_dir, importer_id))
+        .collect()
+}
+
+/// A key that cannot be safely joined (a malformed or hostile lockfile) is
+/// never dereferenced; the raw key still names the importer in the output.
+fn read_importer_info(lockfile: &Lockfile, lockfile_dir: &Path) -> HashMap<String, ImporterInfo> {
+    lockfile
+        .importers
+        .keys()
+        .map(|importer_id| {
+            let manifest = safe_importer_dir(lockfile_dir, importer_id)
+                .map(|importer_dir| read_project_manifest(&importer_dir))
+                .unwrap_or_default();
+            let name = manifest.name.unwrap_or_else(|| {
+                if importer_id == "." {
+                    "the root project".to_string()
+                } else {
+                    importer_id.clone()
+                }
+            });
+            (
+                importer_id.clone(),
+                ImporterInfo { name, version: manifest.version.unwrap_or_default() },
+            )
+        })
+        .collect()
+}
+
+fn included_dependencies(options: &DependentsOptions) -> IncludedDependencies {
+    IncludedDependencies {
+        dependencies: options.include_dependencies.unwrap_or(true),
+        dev_dependencies: options.include_dev_dependencies.unwrap_or(true),
+        optional_dependencies: options.include_optional_dependencies.unwrap_or(true),
+    }
 }
 
 fn resolve_project_dir(lockfile_dir: &Path, dir: &str) -> PathBuf {

--- a/pnpm/crates/napi/src/install.rs
+++ b/pnpm/crates/napi/src/install.rs
@@ -17,7 +17,7 @@
 use std::{
     collections::{BTreeSet, HashMap},
     net::IpAddr,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{Arc, OnceLock},
 };
 
@@ -406,6 +406,20 @@ impl EngineMode {
     fn disable_optimistic_repeat_install(&self) -> bool {
         matches!(self, Self::Install(_) | Self::PeerIssues(_))
     }
+
+    fn peer_issues_sink(&self) -> Option<pnpm_package_manager::PeerIssuesSink> {
+        match self {
+            Self::PeerIssues(sink) => Some(Arc::clone(sink)),
+            Self::Install(_) | Self::Rebuild(_) => None,
+        }
+    }
+
+    fn deps_requiring_build_sink(&self) -> Option<DepsRequiringBuildSink> {
+        match self {
+            Self::Install(sink) => sink.as_ref().map(Arc::clone),
+            Self::Rebuild(_) | Self::PeerIssues(_) => None,
+        }
+    }
 }
 
 /// The install-shape decisions the engine mode and the caller's options
@@ -542,72 +556,28 @@ fn run_install_inner(
 ) -> napi::Result<String> {
     reject_non_object_manifests(&options.projects)?;
     let dir = PathBuf::from(&options.dir);
-
-    // The root importer is the project at `dir`; any others are siblings. A
-    // lone project takes the plain (non-workspace) install path; multiple
-    // importers are handed to the engine via `workspace_projects_override`.
-    let root_manifest_value = options
-        .projects
-        .iter()
-        .find(|project| std::path::Path::new(&project.root_dir) == dir)
-        .map(|project| project.manifest.clone())
-        .ok_or_else(|| {
-            napi::Error::from_reason(format!(
-                "install options had no project entry for the install dir {}",
-                options.dir,
-            ))
-        })?;
-    let workspace_projects_override = build_workspace_projects_override(&options.projects);
+    let manifest =
+        PackageManifest::from_value(dir.join("package.json"), root_manifest_value(options, &dir)?);
 
     reject_unsupported_install_options(options)?;
-    let ignore_package_manifest = ignores_package_manifest(options, &mode);
-    let overlay = build_overlay(options, ignore_package_manifest)?;
-    let config = resolve_config(&dir, &overlay).map_err(|error| to_napi_error(&error))?;
+    let config =
+        resolve_config(&dir, &build_overlay(options, ignores_package_manifest(options, &mode))?)
+            .map_err(|error| to_napi_error(&error))?;
 
-    let manifest = PackageManifest::from_value(dir.join("package.json"), root_manifest_value);
-    let http_client = Arc::new(
-        ThrottledClient::for_installs(
-            &config.proxy,
-            &config.tls,
-            &config.tls_by_uri,
-            &config.network_settings(),
-        )
-        .map_err(|error| to_napi_error(&error))?
-        .with_max_sockets_per_host(config.max_sockets),
-    );
+    let http_client = install_http_client(config)?;
     let lazy_lockfile = if config.lockfile {
         LazyLockfile::deferred(dir.clone(), config.wanted_lockfile_selection())
     } else {
         LazyLockfile::disabled()
     };
     let resolved_packages = ResolvedPackages::new();
-    let tarball_mem_cache = Arc::new(MemCache::new());
-    let lockfile_path =
-        manifest.path().parent().map(|parent| parent.join(config.wanted_lockfile_name()));
-
-    let mut groups = vec![DependencyGroup::Prod, DependencyGroup::Dev];
-    if options.include_optional_deps != Some(false) {
-        groups.push(DependencyGroup::Optional);
-    }
-
+    let lockfile_path = dir.join(config.wanted_lockfile_name());
     let shape = InstallShape::new(options, &mode);
-    let InstallShape {
-        lockfile_only,
-        frozen_lockfile,
-        prefer_frozen_lockfile,
-        update_seed_policy,
-        mutation,
-    } = shape;
 
-    let runtime =
-        tokio::runtime::Builder::new_multi_thread().enable_all().build().map_err(|error| {
-            napi::Error::from_reason(format!("failed to build tokio runtime: {error}"))
-        })?;
-
-    runtime
+    multi_thread_runtime()?
         .block_on(async {
             let install = Install {
-                tarball_mem_cache: Arc::clone(&tarball_mem_cache),
+                tarball_mem_cache: Arc::new(MemCache::new()),
                 resolved_packages: &resolved_packages,
                 http_client: &http_client,
                 http_client_arc: Arc::clone(&http_client),
@@ -615,35 +585,29 @@ fn run_install_inner(
                 manifest: &manifest,
                 emit_initial_manifest: true,
                 lockfile: MaybeLazyLockfile::Lazy(&lazy_lockfile),
-                lockfile_path: lockfile_path.as_deref(),
-                dependency_groups: groups,
-                frozen_lockfile,
-                prefer_frozen_lockfile,
+                lockfile_path: Some(&lockfile_path),
+                dependency_groups: dependency_groups(options),
+                frozen_lockfile: shape.frozen_lockfile,
+                prefer_frozen_lockfile: shape.prefer_frozen_lockfile,
                 ignore_manifest_check: options.ignore_package_manifest == Some(true),
                 skip_runtimes: false,
                 trust_lockfile: config.trust_lockfile,
                 update_checksums: false,
-                mutation,
+                mutation: shape.mutation,
                 installs_only: true,
                 supported_architectures: None,
                 node_linker: config.node_linker,
-                lockfile_only,
+                lockfile_only: shape.lockfile_only,
                 // A peer-issue query resolves without writing anything;
                 // the sink presence suppresses the CLI dry-run report.
                 dry_run: matches!(mode, EngineMode::PeerIssues(_)),
                 persist_policy_excludes: false,
-                update_seed_policy,
+                update_seed_policy: shape.update_seed_policy,
                 preferred_versions_override: None,
                 auth_override: None,
                 resolution_observer: None,
-                peer_issues_sink: match &mode {
-                    EngineMode::PeerIssues(sink) => Some(Arc::clone(sink)),
-                    EngineMode::Install(_) | EngineMode::Rebuild(_) => None,
-                },
-                deps_requiring_build_sink: match &mode {
-                    EngineMode::Install(sink) => sink.as_ref().map(Arc::clone),
-                    EngineMode::Rebuild(_) | EngineMode::PeerIssues(_) => None,
-                },
+                peer_issues_sink: mode.peer_issues_sink(),
+                deps_requiring_build_sink: mode.deps_requiring_build_sink(),
                 catalogs_override: None,
                 // The optimistic repeat-install fast path uses on-disk
                 // manifest mtimes as its freshness signal. NAPI installs use
@@ -652,7 +616,7 @@ fn run_install_inner(
                 // freshness check. Peer-issue queries must always resolve too.
                 disable_optimistic_repeat_install: mode.disable_optimistic_repeat_install(),
                 pnpmfile_hook_override: pnpmfile_hook,
-                workspace_projects_override,
+                workspace_projects_override: build_workspace_projects_override(&options.projects),
             };
             match mode {
                 EngineMode::Install(_) | EngineMode::PeerIssues(_) => {
@@ -668,14 +632,50 @@ fn run_install_inner(
     Ok(PathBuf::from(config.store_dir.clone()).display().to_string())
 }
 
-/// Build the in-memory workspace-projects override from the caller's importer
-/// list. `None` for a single importer (the plain, non-workspace install path);
-/// otherwise one [`pnpm_workspace::Project`] per importer so `workspace:`
-/// specifiers resolve across them and each importer gets its own resolved
-/// dependency tree. The root importer (the project at the install dir) is
-/// included too — `Install::run` skips its `"."` id for the per-importer
-/// manifest list (using `Install.manifest`) but still needs it in the
-/// `workspace:`-spec lookup.
+/// The root importer is the project at `dir`; any others are siblings. A
+/// lone project takes the plain (non-workspace) install path; multiple
+/// importers are handed to the engine via `workspace_projects_override`.
+fn root_manifest_value(options: &InstallOptions, dir: &Path) -> napi::Result<serde_json::Value> {
+    options
+        .projects
+        .iter()
+        .find(|project| Path::new(&project.root_dir) == dir)
+        .map(|project| project.manifest.clone())
+        .ok_or_else(|| {
+            napi::Error::from_reason(format!(
+                "install options had no project entry for the install dir {}",
+                options.dir,
+            ))
+        })
+}
+
+fn install_http_client(config: &pnpm_config::Config) -> napi::Result<Arc<ThrottledClient>> {
+    Ok(Arc::new(
+        ThrottledClient::for_installs(
+            &config.proxy,
+            &config.tls,
+            &config.tls_by_uri,
+            &config.network_settings(),
+        )
+        .map_err(|error| to_napi_error(&error))?
+        .with_max_sockets_per_host(config.max_sockets),
+    ))
+}
+
+fn dependency_groups(options: &InstallOptions) -> Vec<DependencyGroup> {
+    let mut groups = vec![DependencyGroup::Prod, DependencyGroup::Dev];
+    if options.include_optional_deps != Some(false) {
+        groups.push(DependencyGroup::Optional);
+    }
+    groups
+}
+
+fn multi_thread_runtime() -> napi::Result<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_multi_thread().enable_all().build().map_err(|error| {
+        napi::Error::from_reason(format!("failed to build tokio runtime: {error}"))
+    })
+}
+
 fn build_workspace_projects_override(
     projects: &[NodeApiProject],
 ) -> Option<Vec<pnpm_workspace::Project>> {
@@ -730,34 +730,7 @@ fn build_overlay(options: &InstallOptions, fetch_shaped: bool) -> napi::Result<C
         package_extensions: options.package_extensions.as_ref().map(|extensions| {
             extensions
                 .iter()
-                .map(|(selector, extension)| {
-                    let to_sorted = |map: &Option<HashMap<String, String>>| {
-                        map.as_ref()
-                            .map(|map| map.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
-                    };
-                    (
-                        selector.clone(),
-                        pnpm_config::PackageExtension {
-                            dependencies: to_sorted(&extension.dependencies),
-                            optional_dependencies: to_sorted(&extension.optional_dependencies),
-                            peer_dependencies: to_sorted(&extension.peer_dependencies),
-                            peer_dependencies_meta: extension.peer_dependencies_meta.as_ref().map(
-                                |meta| {
-                                    meta.iter()
-                                        .map(|(name, entry)| {
-                                            (
-                                                name.clone(),
-                                                pnpm_config::PeerDependencyMeta {
-                                                    optional: entry.optional,
-                                                },
-                                            )
-                                        })
-                                        .collect()
-                                },
-                            ),
-                        },
-                    )
-                })
+                .map(|(selector, extension)| (selector.clone(), package_extension(extension)))
                 .collect()
         }),
         patched_dependencies: options.patched_dependencies.clone(),
@@ -856,6 +829,24 @@ fn build_overlay(options: &InstallOptions, fetch_shaped: bool) -> napi::Result<C
 /// `PackageManifest::from_value` coerces a non-object to `{}` as a last-resort
 /// panic guard, but a silently-emptied manifest would drive resolution and
 /// lockfile writing off missing data — so fail closed with a clear error here.
+fn package_extension(input: &PackageExtensionInput) -> pnpm_config::PackageExtension {
+    let to_sorted = |map: &Option<HashMap<String, String>>| {
+        map.as_ref().map(|map| map.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+    };
+    pnpm_config::PackageExtension {
+        dependencies: to_sorted(&input.dependencies),
+        optional_dependencies: to_sorted(&input.optional_dependencies),
+        peer_dependencies: to_sorted(&input.peer_dependencies),
+        peer_dependencies_meta: input.peer_dependencies_meta.as_ref().map(|meta| {
+            meta.iter()
+                .map(|(name, entry)| {
+                    (name.clone(), pnpm_config::PeerDependencyMeta { optional: entry.optional })
+                })
+                .collect()
+        }),
+    }
+}
+
 fn reject_non_object_manifests(projects: &[NodeApiProject]) -> napi::Result<()> {
     for project in projects {
         if !project.manifest.is_object()

--- a/pnpm/crates/napi/src/read_config.rs
+++ b/pnpm/crates/napi/src/read_config.rs
@@ -11,7 +11,7 @@
 use std::collections::HashMap;
 
 use napi_derive::napi;
-use pnpm_network::{DEFAULT_REGISTRY_SCOPE, NoProxySetting, nerf_dart};
+use pnpm_network::{AuthHeadersByScope, DEFAULT_REGISTRY_SCOPE, NoProxySetting, nerf_dart};
 
 use crate::{
     config::{ConfigOverlay, resolve_config},
@@ -118,26 +118,7 @@ fn project_config(config: &pnpm_config::Config) -> ResolvedConfig {
         })
         .collect();
 
-    // The default registry lives in `config.registry`; the `registries`
-    // map carries it only when something set a `default` key explicitly.
-    let default_entry = (!config.registries_by_scope.contains_key("default"))
-        .then(|| ("default".to_string(), config.registry.clone()));
-    let registries = default_entry
-        .iter()
-        .map(|(name, url)| (name, url))
-        .chain(config.registries_by_scope.iter())
-        .map(|(name, url)| {
-            let uri = nerf_dart(url);
-            let scoped = by_scope.get(&uri);
-            // A scope registry prefers its scope-keyed credential; both
-            // registry kinds fall back to the registry-wide (`@`) one.
-            let auth_header = scoped
-                .and_then(|headers| if name == "default" { None } else { headers.get(name) })
-                .or_else(|| scoped.and_then(|headers| headers.get(DEFAULT_REGISTRY_SCOPE)))
-                .cloned();
-            ResolvedRegistry { name: name.clone(), url: url.clone(), auth_header }
-        })
-        .collect();
+    let registries = resolved_registries(config, &by_scope);
 
     let no_proxy = config.proxy.no_proxy.as_ref().map(|setting| match setting {
         NoProxySetting::Bypass => serde_json::Value::Bool(true),
@@ -199,3 +180,28 @@ fn import_method_name(method: pnpm_config::PackageImportMethod) -> &'static str 
 
 #[cfg(test)]
 mod tests;
+
+/// The default registry lives in `config.registry`; the `registries` map
+/// carries it only when something set a `default` key explicitly.
+fn resolved_registries(
+    config: &pnpm_config::Config,
+    by_scope: &AuthHeadersByScope,
+) -> Vec<ResolvedRegistry> {
+    let default_entry = (!config.registries_by_scope.contains_key("default"))
+        .then(|| ("default".to_string(), config.registry.clone()));
+    default_entry
+        .iter()
+        .map(|(name, url)| (name, url))
+        .chain(config.registries_by_scope.iter())
+        .map(|(name, url)| {
+            let scoped = by_scope.get(&nerf_dart(url));
+            // A scope registry prefers its scope-keyed credential; both
+            // registry kinds fall back to the registry-wide (`@`) one.
+            let auth_header = scoped
+                .and_then(|headers| if name == "default" { None } else { headers.get(name) })
+                .or_else(|| scoped.and_then(|headers| headers.get(DEFAULT_REGISTRY_SCOPE)))
+                .cloned();
+            ResolvedRegistry { name: name.clone(), url: url.clone(), auth_header }
+        })
+        .collect()
+}

--- a/pnpm/crates/napi/src/resolve.rs
+++ b/pnpm/crates/napi/src/resolve.rs
@@ -93,16 +93,8 @@ fn run_resolve_blocking(
     options: &ResolveDependencyOptions,
 ) -> napi::Result<ResolveDependencyResult> {
     let dir = PathBuf::from(&options.dir);
-    let overlay = ConfigOverlay {
-        store_dir: options.store_dir.as_ref().map(PathBuf::from),
-        cache_dir: options.cache_dir.as_ref().map(PathBuf::from),
-        registries: options.registries.as_ref().map(|map| map.clone().into_iter().collect()),
-        offline: options.offline,
-        prefer_offline: options.prefer_offline,
-        auth_header_by_uri: options.auth_header_by_uri.clone().map(|map| map.into_iter().collect()),
-        ..ConfigOverlay::default()
-    };
-    let config = resolve_config(&dir, &overlay).map_err(|error| to_napi_error(&error))?;
+    let config =
+        resolve_config(&dir, &resolve_overlay(options)).map_err(|error| to_napi_error(&error))?;
 
     let http_client = Arc::new(
         ThrottledClient::for_installs(
@@ -179,3 +171,15 @@ fn run_resolve_blocking(
 
 #[cfg(test)]
 mod tests;
+
+fn resolve_overlay(options: &ResolveDependencyOptions) -> ConfigOverlay {
+    ConfigOverlay {
+        store_dir: options.store_dir.as_ref().map(PathBuf::from),
+        cache_dir: options.cache_dir.as_ref().map(PathBuf::from),
+        registries: options.registries.as_ref().map(|map| map.clone().into_iter().collect()),
+        offline: options.offline,
+        prefer_offline: options.prefer_offline,
+        auth_header_by_uri: options.auth_header_by_uri.clone().map(|map| map.into_iter().collect()),
+        ..ConfigOverlay::default()
+    }
+}

--- a/pnpm/crates/network/src/tls.rs
+++ b/pnpm/crates/network/src/tls.rs
@@ -328,28 +328,35 @@ fn strip_port(url: &str) -> String {
     let Some((scheme, rest)) = url.split_once("://") else {
         return url.to_string();
     };
-    let (authority, path_tail) = match rest.split_once('/') {
-        Some((a, p)) => (a, Some(p)),
-        None => (rest, None),
-    };
+    let (authority, path_tail) = split_authority(rest);
     // Skip past any `user[:pw]@` userinfo. The port-bearing colon is
     // the one in the host segment, not in the userinfo.
     let host_segment = authority.rsplit_once('@').map_or(authority, |(_, h)| h);
     let userinfo = authority.strip_suffix(host_segment).unwrap_or("");
-    // IPv6 literals like `[::1]:8080` have `:` inside the brackets;
-    // find the port colon only *after* a closing `]` when present.
-    let port_colon = if let Some(bracket_end) = host_segment.find(']') {
-        host_segment[bracket_end..].find(':').map(|offset| bracket_end + offset)
-    } else {
-        host_segment.find(':')
-    };
-    let Some(idx) = port_colon else {
+    let Some(idx) = port_colon_index(host_segment) else {
         return url.to_string();
     };
     let host_no_port = &host_segment[..idx];
     match path_tail {
         Some(path) => format!("{scheme}://{userinfo}{host_no_port}/{path}"),
         None => format!("{scheme}://{userinfo}{host_no_port}/"),
+    }
+}
+
+fn split_authority(rest: &str) -> (&str, Option<&str>) {
+    match rest.split_once('/') {
+        Some((authority, path)) => (authority, Some(path)),
+        None => (rest, None),
+    }
+}
+
+/// IPv6 literals like `[::1]:8080` have `:` inside the brackets; the port
+/// colon is found only after a closing `]` when present.
+fn port_colon_index(host_segment: &str) -> Option<usize> {
+    if let Some(bracket_end) = host_segment.find(']') {
+        host_segment[bracket_end..].find(':').map(|offset| bracket_end + offset)
+    } else {
+        host_segment.find(':')
     }
 }
 

--- a/pnpm/crates/pack/src/lib.rs
+++ b/pnpm/crates/pack/src/lib.rs
@@ -250,6 +250,56 @@ where
     Reporter: self::Reporter,
     Sys: FsReadFile + FsFileLen + FsCreateDirAll + FsAtomicWrite,
 {
+    let source = prepare_source::<Reporter>(opts).await?;
+    let (tarball_name, pack_destination) =
+        resolve_output(opts, &source.normalized_name, &source.published_version)?;
+    let files_map = packed_files_map(opts, &source)?;
+    let manifest_json = serde_json::to_string_pretty(&source.publish_manifest)
+        .expect("publish manifest serializes to JSON")
+        .into_bytes();
+
+    let dest_dir = resolve_dest_dir(&source.dir, pack_destination.as_deref());
+    if !opts.dry_run {
+        create_dest_dir::<Sys>(&dest_dir)?;
+    }
+
+    // The size pass must run before `postpack`, which may delete
+    // prepack-generated files that were packed. See pnpm/pnpm#12775.
+    let unpacked_size = unpacked_size::<Sys>(&files_map, manifest_json.len() as u64)?
+        + opts.injected_files.iter().map(|(_, bytes)| bytes.len() as u64).sum::<u64>();
+    let contents = packed_contents_with_injected(&files_map, &opts.injected_files);
+
+    if !opts.dry_run {
+        let packed = PackedTarball {
+            dest_file: dest_dir.join(&tarball_name),
+            files_map: &files_map,
+            manifest_json: &manifest_json,
+        };
+        write_tarball::<Sys>(opts, &source, &packed).await?;
+        if !opts.ignore_scripts {
+            run_scripts_if_present::<Reporter>(opts, &["postpack"], &source.entry_manifest)?;
+        }
+    }
+
+    let tarball_path = packed_tarball_path(&opts.dir, &source.dir, &dest_dir, &tarball_name);
+    let published_manifest = with_registry_readme(source.publish_manifest, &source.dir)?;
+    Ok(PackResult { published_manifest, contents, tarball_path, unpacked_size })
+}
+
+/// The manifests a pack starts from: the project's, the publish directory's
+/// (after the prepack scripts) and the exportable one the tarball carries.
+struct PackSource {
+    entry_manifest: Value,
+    dir: PathBuf,
+    manifest: Value,
+    publish_manifest: Value,
+    normalized_name: String,
+    published_version: String,
+}
+
+async fn prepare_source<Reporter: self::Reporter>(
+    opts: &PackOptions,
+) -> Result<PackSource, PackError> {
     let entry_manifest = read_manifest(&opts.dir)?;
     prevent_bundled_dependencies_without_hoisted(opts.node_linker, &entry_manifest)?;
 
@@ -298,73 +348,71 @@ where
     .await?;
 
     let (normalized_name, published_version) = published_identity(&mut publish_manifest, name)?;
-    let (tarball_name, pack_destination) =
-        resolve_output(opts, &normalized_name, &published_version)?;
+    Ok(PackSource {
+        entry_manifest,
+        dir,
+        manifest,
+        publish_manifest,
+        normalized_name,
+        published_version,
+    })
+}
 
+fn packed_files_map(
+    opts: &PackOptions,
+    source: &PackSource,
+) -> Result<indexmap::IndexMap<String, PathBuf>, PackError> {
     let files = packlist_with_options(
-        &dir,
-        &publish_manifest,
+        &source.dir,
+        &source.publish_manifest,
         PacklistOptions { workspace_dir: opts.workspace_dir.as_deref() },
     )
     .map_err(PackError::Packlist)?;
-    let mut files_map = build_files_map(&dir, &files);
-    inject_workspace_license(opts, &dir, &mut files_map);
+    let mut files_map = build_files_map(&source.dir, &files);
+    inject_workspace_license(opts, &source.dir, &mut files_map);
     // A composed entry supersedes any same-named on-disk file (e.g. a stale
     // committed CHANGELOG.md), so drop it from the file map before packing.
     for (name, _) in &opts.injected_files {
         files_map.shift_remove(name);
     }
+    Ok(files_map)
+}
 
-    let manifest_json = serde_json::to_string_pretty(&publish_manifest)
-        .expect("publish manifest serializes to JSON")
-        .into_bytes();
+fn create_dest_dir<Sys: FsCreateDirAll>(dest_dir: &Path) -> Result<(), PackError> {
+    Sys::create_dir_all(dest_dir)
+        .map_err(|source| PackError::CreateDir { path: dest_dir.display().to_string(), source })
+}
 
-    let dest_dir = resolve_dest_dir(&dir, pack_destination.as_deref());
+struct PackedTarball<'a> {
+    dest_file: PathBuf,
+    files_map: &'a indexmap::IndexMap<String, PathBuf>,
+    manifest_json: &'a [u8],
+}
 
-    if !opts.dry_run {
-        Sys::create_dir_all(&dest_dir).map_err(|source| PackError::CreateDir {
-            path: dest_dir.display().to_string(),
-            source,
-        })?;
-    }
-
-    // The size pass must run before `postpack`, which may delete
-    // prepack-generated files that were packed. See pnpm/pnpm#12775.
-    let injected_size: u64 = opts.injected_files.iter().map(|(_, bytes)| bytes.len() as u64).sum();
-    let unpacked_size =
-        unpacked_size::<Sys>(&files_map, manifest_json.len() as u64)? + injected_size;
-    let contents = packed_contents_with_injected(&files_map, &opts.injected_files);
-
-    if !opts.dry_run {
-        let bins = executable_sources(&publish_manifest, &manifest, &dir);
-        let dest_file = dest_dir.join(&tarball_name);
-        let _output_guard = match &opts.output_locks {
-            Some(locks) => Some(locks.lock(&dest_file).await),
-            None => None,
-        };
-        Sys::atomic_write(&dest_file, &mut |writer| {
-            tarball::build_tarball::<Sys>(
-                writer,
-                &files_map,
-                &manifest_json,
-                &bins,
-                opts.pack_gzip_level,
-                &opts.injected_files,
-            )
-        })
-        .map_err(|source| PackError::WriteTarball {
-            path: dest_file.display().to_string(),
-            source,
-        })?;
-        if !opts.ignore_scripts {
-            run_scripts_if_present::<Reporter>(opts, &["postpack"], &entry_manifest)?;
-        }
-    }
-
-    let tarball_path = packed_tarball_path(&opts.dir, &dir, &dest_dir, &tarball_name);
-
-    let published_manifest = with_registry_readme(publish_manifest, &dir)?;
-    Ok(PackResult { published_manifest, contents, tarball_path, unpacked_size })
+async fn write_tarball<Sys: FsReadFile + FsAtomicWrite>(
+    opts: &PackOptions,
+    source: &PackSource,
+    packed: &PackedTarball<'_>,
+) -> Result<(), PackError> {
+    let bins = executable_sources(&source.publish_manifest, &source.manifest, &source.dir);
+    let _output_guard = match &opts.output_locks {
+        Some(locks) => Some(locks.lock(&packed.dest_file).await),
+        None => None,
+    };
+    Sys::atomic_write(&packed.dest_file, &mut |writer| {
+        tarball::build_tarball::<Sys>(
+            writer,
+            packed.files_map,
+            packed.manifest_json,
+            &bins,
+            opts.pack_gzip_level,
+            &opts.injected_files,
+        )
+    })
+    .map_err(|error| PackError::WriteTarball {
+        path: packed.dest_file.display().to_string(),
+        source: error,
+    })
 }
 
 /// The name the tarball is packed under, once the manifest's name *and*

--- a/pnpm/crates/package-manager/src/install/apply_materialization.rs
+++ b/pnpm/crates/package-manager/src/install/apply_materialization.rs
@@ -412,7 +412,7 @@ fn deferred_projects(
 /// a manifest failure can't leave a fresh current-lockfile
 /// pointing at incomplete install state — the next frozen
 /// reinstall would otherwise diff against a graph that never
-/// finished committing (review on <https://github.com/pnpm/pacquet/pull/442>).
+/// finished committing.
 ///
 /// A filtered isolated/PnP install merges its newly materialized
 /// closure into compatible prior current state, while a hoisted

--- a/pnpm/crates/package-manager/src/install/lifecycle.rs
+++ b/pnpm/crates/package-manager/src/install/lifecycle.rs
@@ -1,3 +1,5 @@
+use pnpm_deps_restorer::build_modules::exec_scripts_prepend_node_path;
+
 use super::{
     Config, DEV_PREINSTALL_ALREADY_RAN_ENV, DependencyGroup, ExecScriptsPrependNodePath, HashMap,
     HashSet, InstallError, Lockfile, NodeLinker, PackageManifest, Path, PathBuf, Reporter,
@@ -179,16 +181,6 @@ fn retain_known_projects(
 
 pub(super) fn modules_dir_basename(config: &Config) -> &std::ffi::OsStr {
     config.modules_dir.file_name().unwrap_or_else(|| std::ffi::OsStr::new("node_modules"))
-}
-
-/// Same tri-state mapping the dependency-build path applies; see the doc
-/// on [`pnpm_config::ScriptsPrependNodePath`].
-pub(super) fn exec_scripts_prepend_node_path(config: &Config) -> ExecScriptsPrependNodePath {
-    match config.scripts_prepend_node_path {
-        pnpm_config::ScriptsPrependNodePath::Always => ExecScriptsPrependNodePath::Always,
-        pnpm_config::ScriptsPrependNodePath::Never => ExecScriptsPrependNodePath::Never,
-        pnpm_config::ScriptsPrependNodePath::WarnOnly => ExecScriptsPrependNodePath::WarnOnly,
-    }
 }
 
 /// [`Config::extra_env_with_node_options`] plus the `NODE_OPTIONS` entry for

--- a/pnpm/crates/package-manager/src/patch.rs
+++ b/pnpm/crates/package-manager/src/patch.rs
@@ -5,8 +5,8 @@ use crate::{
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use node_semver::{Range, Version};
-use pnpm_config::{Config, PackageImportMethod, ScriptsPrependNodePath};
-use pnpm_executor::ScriptsPrependNodePath as ExecScriptsPrependNodePath;
+use pnpm_config::{Config, PackageImportMethod};
+use pnpm_deps_restorer::build_modules::exec_scripts_prepend_node_path;
 use pnpm_git_fetcher::{GitFetchOutput, GitFetcherError, GitHostedTarballFetcher};
 use pnpm_lockfile::{Lockfile, LockfileResolution, PackageKey};
 use pnpm_network::ThrottledClient;
@@ -294,9 +294,7 @@ async fn git_hosted_cas_paths<Reporter: self::Reporter>(
         ignore_scripts: config.ignore_scripts,
         unsafe_perm: config.unsafe_perm,
         user_agent: Some(&config.user_agent),
-        scripts_prepend_node_path: executor_scripts_prepend_node_path(
-            config.scripts_prepend_node_path,
-        ),
+        scripts_prepend_node_path: exec_scripts_prepend_node_path(config),
         script_shell: None,
         node_execpath: None,
         npm_execpath: None,
@@ -344,16 +342,6 @@ fn git_tarball_url(resolution: &LockfileResolution) -> Option<String> {
     let LockfileResolution::Tarball(tarball) = resolution else { return None };
     (tarball.is_git_hosted() || tarball.tarball.starts_with("https://pkg.pr.new/"))
         .then(|| tarball.tarball.clone())
-}
-
-fn executor_scripts_prepend_node_path(
-    scripts_prepend_node_path: ScriptsPrependNodePath,
-) -> ExecScriptsPrependNodePath {
-    match scripts_prepend_node_path {
-        ScriptsPrependNodePath::Always => ExecScriptsPrependNodePath::Always,
-        ScriptsPrependNodePath::Never => ExecScriptsPrependNodePath::Never,
-        ScriptsPrependNodePath::WarnOnly => ExecScriptsPrependNodePath::WarnOnly,
-    }
 }
 
 fn version_satisfies(version: &str, range: &str) -> bool {

--- a/pnpm/crates/package-manager/src/patch/tests.rs
+++ b/pnpm/crates/package-manager/src/patch/tests.rs
@@ -1,10 +1,7 @@
 use super::{
     PatchCandidate, PatchTarget, WritePackageForPatch, WritePackageForPatchError,
-    compare_candidates, default_patch_target, executor_scripts_prepend_node_path,
-    patch_candidates_from_lockfile, resolution_kind,
+    compare_candidates, default_patch_target, patch_candidates_from_lockfile, resolution_kind,
 };
-use pnpm_config::ScriptsPrependNodePath;
-use pnpm_executor::ScriptsPrependNodePath as ExecScriptsPrependNodePath;
 use pnpm_lockfile::{
     BinaryArchive, BinaryResolution, BinarySpec, ComVer, GitResolution, Lockfile,
     LockfileResolution, LockfileVersion, PackageKey, PackageMetadata, RegistryResolution,
@@ -441,22 +438,6 @@ async fn patch_extract_rejects_missing_package_metadata() {
     assert!(
         matches!(err, WritePackageForPatchError::MissingPackageMetadata { .. }),
         "missing metadata should be reported, got {err:?}",
-    );
-}
-
-#[test]
-fn executor_scripts_prepend_node_path_maps_all_variants() {
-    assert_eq!(
-        executor_scripts_prepend_node_path(ScriptsPrependNodePath::Always),
-        ExecScriptsPrependNodePath::Always,
-    );
-    assert_eq!(
-        executor_scripts_prepend_node_path(ScriptsPrependNodePath::Never),
-        ExecScriptsPrependNodePath::Never,
-    );
-    assert_eq!(
-        executor_scripts_prepend_node_path(ScriptsPrependNodePath::WarnOnly),
-        ExecScriptsPrependNodePath::WarnOnly,
     );
 }
 

--- a/pnpm/crates/package-manager/src/prefetching_resolver.rs
+++ b/pnpm/crates/package-manager/src/prefetching_resolver.rs
@@ -105,19 +105,6 @@ struct OwnedFetchCtx {
     current_cpu: &'static str,
     current_libc: &'static str,
     progress_reported: SharedReportedProgressKeys,
-    /// Set of URLs that already had a prefetch task spawned, used as
-    /// an atomic check-and-claim gate so concurrent resolves for the
-    /// same tarball can't both pass a non-atomic `MemCache` lookup and
-    /// race two spawns into the cache. [`DashSet::insert`] returns
-    /// `true` only for the caller that wins the slot; later callers
-    /// observe `false` and skip the spawn entirely. The
-    /// [`MemCache`]-side dedup still backstops correctness (the loser
-    /// would have parked on `Notify` instead of doing work), but
-    /// without this gate the bench saw ~3-5k redundant spawns per
-    /// install on the alotta-files fixture (one per dependent edge).
-    spawned_urls: Arc<DashSet<String>>,
-    /// Shares completed integrity discovery, including custom resolution rewrites.
-    integrity_cache: Arc<DashMap<String, Arc<OnceCell<LockfileResolution>>>>,
     prefetch_downloads: bool,
     custom_fetcher_session: Option<Arc<CustomFetcherSession>>,
     ignore_scripts: bool,
@@ -136,6 +123,19 @@ struct OwnedFetchCtx {
 /// `PhantomData` carries the type through.
 pub struct PrefetchingResolver<Reporter: self::Reporter> {
     inner: Box<dyn Resolver>,
+    /// Set of URLs that already had a prefetch task spawned, used as
+    /// an atomic check-and-claim gate so concurrent resolves for the
+    /// same tarball can't both pass a non-atomic `MemCache` lookup and
+    /// race two spawns into the cache. [`DashSet::insert`] returns
+    /// `true` only for the caller that wins the slot; later callers
+    /// observe `false` and skip the spawn entirely. The
+    /// [`MemCache`]-side dedup still backstops correctness (the loser
+    /// would have parked on `Notify` instead of doing work), but
+    /// without this gate the bench saw ~3-5k redundant spawns per
+    /// install on the alotta-files fixture (one per dependent edge).
+    spawned_urls: DashSet<String>,
+    /// Shares completed integrity discovery, including custom resolution rewrites.
+    integrity_cache: DashMap<String, Arc<OnceCell<LockfileResolution>>>,
     /// Shared with every prefetch task the resolver spawns.
     ctx: Arc<OwnedFetchCtx>,
     _phantom: PhantomData<fn() -> Reporter>,
@@ -183,13 +183,17 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
             current_cpu: pnpm_graph_hasher::host_arch(),
             current_libc: pnpm_graph_hasher::host_libc(),
             progress_reported: SharedReportedProgressKeys::clone(progress_reported),
-            spawned_urls: Arc::new(DashSet::new()),
-            integrity_cache: Arc::new(DashMap::new()),
             prefetch_downloads,
             custom_fetcher_session: custom_fetcher_session.cloned(),
             ignore_scripts: config.ignore_scripts,
         };
-        PrefetchingResolver { inner, ctx: Arc::new(ctx), _phantom: PhantomData }
+        PrefetchingResolver {
+            inner,
+            spawned_urls: DashSet::new(),
+            integrity_cache: DashMap::new(),
+            ctx: Arc::new(ctx),
+            _phantom: PhantomData,
+        }
     }
 
     /// Populate remote tarball resolutions whose integrity can only be
@@ -228,7 +232,7 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
         } else {
             package_url.clone()
         };
-        let cell = Arc::clone(&self.ctx.integrity_cache.entry(cache_key).or_default());
+        let cell = Arc::clone(&self.integrity_cache.entry(cache_key).or_default());
         let resolution = cell
             .get_or_try_init(|| async {
                 match self.ctx.custom_fetcher_session.as_ref() {
@@ -316,7 +320,7 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
     ) -> Result<LockfileResolution, ResolveError> {
         // This fetch warms the mem cache, so the prefetch path should not
         // spawn another task for the same URL.
-        self.ctx.spawned_urls.insert(package_url.to_string());
+        self.spawned_urls.insert(package_url.to_string());
         let resolved = FetchTarballForResolution {
             http_client: &self.ctx.http_client,
             store_dir: self.ctx.store_dir,
@@ -388,7 +392,7 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
         // `MemCache` is *not* atomic for this purpose — its
         // `contains_key` + `insert` is a TOCTOU pair under racing
         // resolvers.
-        if !self.ctx.spawned_urls.insert(package_url.to_string()) {
+        if !self.spawned_urls.insert(package_url.to_string()) {
             return;
         }
 

--- a/pnpm/crates/package-manager/src/prefetching_resolver/tests.rs
+++ b/pnpm/crates/package-manager/src/prefetching_resolver/tests.rs
@@ -378,7 +378,7 @@ async fn skips_the_background_download_with_prefetching_off() {
         .expect("resolve succeeds")
         .expect("resolver returns a result");
 
-    assert!(resolver.ctx.spawned_urls.is_empty(), "no download may be claimed");
+    assert!(resolver.spawned_urls.is_empty(), "no download may be claimed");
 }
 
 #[tokio::test]
@@ -396,5 +396,5 @@ async fn claims_the_background_download_with_prefetching_on() {
         .expect("resolve succeeds")
         .expect("resolver returns a result");
 
-    assert!(resolver.ctx.spawned_urls.contains(tarball_url), "the download must be claimed");
+    assert!(resolver.spawned_urls.contains(tarball_url), "the download must be claimed");
 }

--- a/pnpm/crates/patching/src/apply/tolerant.rs
+++ b/pnpm/crates/patching/src/apply/tolerant.rs
@@ -33,17 +33,7 @@ const MAX_FUZZING_OFFSET: isize = 20;
 pub(super) fn apply(original: &str, patch: &Patch<'_, str>) -> Result<String, String> {
     let mut lines: Vec<&str> = original.split('\n').collect();
 
-    let mut modifications = Vec::new();
-    for (index, hunk) in patch.hunks().iter().enumerate() {
-        let parts = split_into_parts(hunk.lines());
-        let old_range = hunk.old_range();
-        // Empty ranges name the gap after the line; nonempty ranges are one-based.
-        let start = to_isize(old_range.start()) - isize::from(!old_range.is_empty());
-        let matched = fuzzing_offsets()
-            .find_map(|offset| evaluate_hunk(&parts, &lines, start + offset, old_range.len()))
-            .ok_or_else(|| format!("error applying hunk #{}", index + 1))?;
-        modifications.extend(matched);
-    }
+    let modifications = plan_modifications(patch, &lines)?;
 
     let mut offset = 0_isize;
     for modification in modifications {
@@ -66,6 +56,25 @@ pub(super) fn apply(original: &str, patch: &Patch<'_, str>) -> Result<String, St
     }
 
     Ok(lines.join("\n"))
+}
+
+/// Where each hunk lands in `lines`, allowing the fuzz offsets.
+fn plan_modifications<'a>(
+    patch: &'a Patch<'_, str>,
+    lines: &[&str],
+) -> Result<Vec<Modification<'a>>, String> {
+    let mut modifications = Vec::new();
+    for (index, hunk) in patch.hunks().iter().enumerate() {
+        let parts = split_into_parts(hunk.lines());
+        let old_range = hunk.old_range();
+        // Empty ranges name the gap after the line; nonempty ranges are one-based.
+        let start = to_isize(old_range.start()) - isize::from(!old_range.is_empty());
+        let matched = fuzzing_offsets()
+            .find_map(|offset| evaluate_hunk(&parts, lines, start + offset, old_range.len()))
+            .ok_or_else(|| format!("error applying hunk #{}", index + 1))?;
+        modifications.extend(matched);
+    }
+    Ok(modifications)
 }
 
 /// The positions a hunk is tried at, relative to its recorded one:

--- a/pnpm/crates/pnpr-client/src/lib.rs
+++ b/pnpm/crates/pnpr-client/src/lib.rs
@@ -1013,42 +1013,12 @@ impl PnprClient {
         // free importer is still present-but-empty (pnpm records it as
         // `{ specifiers: {} }`), and a genuinely missing importer is surfaced
         // downstream by the lockfile merge, not a way to inject dependencies.
-        let permitted_importers: HashSet<String> = opts
-            .projects
-            .iter()
-            .map(|project| project.dir.clone())
-            .chain(opts.lockfile.iter().flat_map(|lockfile| lockfile.importers.keys().cloned()))
-            .collect();
+        let permitted_importers = permitted_importers(&opts);
         let project_transforms_requested = has_project_transforms(&opts);
-        let request = serde_json::json!({
-            "projects": opts.projects,
-            "registry": opts.registry,
-            "registries": opts.registries,
-            "overrides": opts.overrides,
-            "patchedDependencies": opts.patched_dependencies,
-            "packageExtensions": opts.package_extensions,
-            "allowUnusedPatches": opts.allow_unused_patches,
-            "catalogs": opts.catalogs,
-            "autoInstallPeers": opts.auto_install_peers,
-            "dedupePeers": opts.dedupe_peers,
-            "excludeLinksFromLockfile": opts.exclude_links_from_lockfile,
-            "lockfile": opts.lockfile,
-            "frozenLockfile": opts.frozen_lockfile,
-            "preferFrozenLockfile": opts.prefer_frozen_lockfile,
-            "updatePatches": opts.update_patches,
-            "fixLockfile": opts.fix_lockfile,
-            "ignoreManifestCheck": opts.ignore_manifest_check,
-            "trustLockfile": opts.trust_lockfile,
-            "resolutionMode": opts.resolution_mode,
-            "minimumReleaseAge": opts.minimum_release_age,
-            "minimumReleaseAgeExclude": opts.minimum_release_age_exclude,
-            "minimumReleaseAgeIgnoreMissingTime": opts.minimum_release_age_ignore_missing_time,
-            "trustPolicy": opts.trust_policy,
-            "trustPolicyExclude": opts.trust_policy_exclude,
-            "trustPolicyIgnoreAfter": opts.trust_policy_ignore_after,
-        });
-
-        let mut post = self.http.post(format!("{}-/pnpr/v0/resolve", self.base_url)).json(&request);
+        let mut post = self
+            .http
+            .post(format!("{}-/pnpr/v0/resolve", self.base_url))
+            .json(&resolve_request_body(&opts));
         if let Some(authorization) = opts.authorization.as_deref() {
             post = post.header("authorization", authorization);
         }
@@ -1080,38 +1050,8 @@ impl PnprClient {
         // servers fail without triggering downloads or buffering hints.
         // reqwest's `gzip` feature transparently inflates the byte stream if a
         // proxy compressed it, so the frames arrive as plain JSON lines.
-        let outcome = read_ndjson_frames(response, |line| match parse_frame(line)? {
-            Frame::Package {
-                id,
-                name,
-                version,
-                integrity,
-                tarball,
-                unpacked_size,
-                file_count,
-                revision,
-            } => {
-                on_package(ResolvedPackage {
-                    id,
-                    name,
-                    version,
-                    integrity,
-                    tarball,
-                    unpacked_size,
-                    file_count,
-                    revision,
-                });
-                Ok(None)
-            }
-            Frame::Done { lockfile, stats } => {
-                assert_requested_importers(&lockfile, &permitted_importers)?;
-                assert_transform_metadata(&lockfile, &opts)?;
-                Ok(Some(ResolveOutcome { lockfile: *lockfile, stats }))
-            }
-            Frame::Error { message } => Err(PnprClientError::Server(message)),
-            Frame::Violations { violations } => {
-                Err(PnprClientError::Verification(build_verify_error(violations)))
-            }
+        let outcome = read_ndjson_frames(response, |line| {
+            handle_resolve_frame(parse_frame(line)?, &mut on_package, &permitted_importers, &opts)
         })
         .await?;
         outcome.ok_or_else(|| {
@@ -1151,6 +1091,87 @@ where
         }
     }
     Ok(None)
+}
+
+/// The request's own projects plus the importers its input lockfile already
+/// carries: the only importers the response may name.
+fn permitted_importers(opts: &ResolveProjectsOptions) -> HashSet<String> {
+    opts.projects
+        .iter()
+        .map(|project| project.dir.clone())
+        .chain(opts.lockfile.iter().flat_map(|lockfile| lockfile.importers.keys().cloned()))
+        .collect()
+}
+
+fn resolve_request_body(opts: &ResolveProjectsOptions) -> serde_json::Value {
+    serde_json::json!({
+        "projects": opts.projects,
+        "registry": opts.registry,
+        "registries": opts.registries,
+        "overrides": opts.overrides,
+        "patchedDependencies": opts.patched_dependencies,
+        "packageExtensions": opts.package_extensions,
+        "allowUnusedPatches": opts.allow_unused_patches,
+        "catalogs": opts.catalogs,
+        "autoInstallPeers": opts.auto_install_peers,
+        "dedupePeers": opts.dedupe_peers,
+        "excludeLinksFromLockfile": opts.exclude_links_from_lockfile,
+        "lockfile": opts.lockfile,
+        "frozenLockfile": opts.frozen_lockfile,
+        "preferFrozenLockfile": opts.prefer_frozen_lockfile,
+        "updatePatches": opts.update_patches,
+        "fixLockfile": opts.fix_lockfile,
+        "ignoreManifestCheck": opts.ignore_manifest_check,
+        "trustLockfile": opts.trust_lockfile,
+        "resolutionMode": opts.resolution_mode,
+        "minimumReleaseAge": opts.minimum_release_age,
+        "minimumReleaseAgeExclude": opts.minimum_release_age_exclude,
+        "minimumReleaseAgeIgnoreMissingTime": opts.minimum_release_age_ignore_missing_time,
+        "trustPolicy": opts.trust_policy,
+        "trustPolicyExclude": opts.trust_policy_exclude,
+        "trustPolicyIgnoreAfter": opts.trust_policy_ignore_after,
+    })
+}
+
+fn handle_resolve_frame(
+    frame: Frame,
+    on_package: &mut impl FnMut(ResolvedPackage),
+    permitted_importers: &HashSet<String>,
+    opts: &ResolveProjectsOptions,
+) -> Result<Option<ResolveOutcome>, PnprClientError> {
+    match frame {
+        Frame::Package {
+            id,
+            name,
+            version,
+            integrity,
+            tarball,
+            unpacked_size,
+            file_count,
+            revision,
+        } => {
+            on_package(ResolvedPackage {
+                id,
+                name,
+                version,
+                integrity,
+                tarball,
+                unpacked_size,
+                file_count,
+                revision,
+            });
+            Ok(None)
+        }
+        Frame::Done { lockfile, stats } => {
+            assert_requested_importers(&lockfile, permitted_importers)?;
+            assert_transform_metadata(&lockfile, opts)?;
+            Ok(Some(ResolveOutcome { lockfile: *lockfile, stats }))
+        }
+        Frame::Error { message } => Err(PnprClientError::Server(message)),
+        Frame::Violations { violations } => {
+            Err(PnprClientError::Verification(build_verify_error(violations)))
+        }
+    }
 }
 
 /// The server's response is untrusted and the caller merges the returned

--- a/pnpm/crates/publish/src/extract_manifest_from_packed.rs
+++ b/pnpm/crates/publish/src/extract_manifest_from_packed.rs
@@ -76,9 +76,7 @@ pub fn extract_publish_manifest_from_packed(
         } else {
             continue;
         };
-        let mut text = String::new();
-        entry.read_to_string(&mut text).map_err(read_err)?;
-        *target = Some(text);
+        *target = Some(read_entry_text(&mut entry).map_err(read_err)?);
     }
 
     let manifest_text = manifest_text.ok_or_else(|| {
@@ -89,13 +87,26 @@ pub fn extract_publish_manifest_from_packed(
     let mut manifest: Value = parse_manifest(&manifest_text).map_err(|source| {
         ExtractManifestError::Parse { tarball_path: tarball_path.to_owned(), source }
     })?;
-    if let Some(readme) = readme
-        && manifest.get("readme").is_none_or(Value::is_null)
+    if let Some(readme) = readme {
+        attach_readme(&mut manifest, readme);
+    }
+    Ok(manifest)
+}
+
+fn read_entry_text<Reader: Read>(entry: &mut tar::Entry<'_, Reader>) -> std::io::Result<String> {
+    let mut text = String::new();
+    entry.read_to_string(&mut text)?;
+    Ok(text)
+}
+
+/// A packed README fills a manifest's missing `readme`, as npm's publish
+/// document carries it.
+fn attach_readme(manifest: &mut Value, readme: String) {
+    if manifest.get("readme").is_none_or(Value::is_null)
         && let Some(object) = manifest.as_object_mut()
     {
         object.insert("readme".to_string(), Value::String(readme));
     }
-    Ok(manifest)
 }
 
 /// Whether a normalized tar entry path names the package's root README,

--- a/pnpm/crates/publish/src/oidc/provenance.rs
+++ b/pnpm/crates/publish/src/oidc/provenance.rs
@@ -35,32 +35,12 @@ pub async fn determine_provenance<Sys>(
 where
     Sys: EnvVar + OidcFetch,
 {
-    let mut parts = id_token.split('.');
-    let (Some(header_b64), Some(payload_b64)) = (parts.next(), parts.next()) else {
-        return Err(ProvenanceError::MalformedIdToken.into());
-    };
-    if header_b64.is_empty() || payload_b64.is_empty() {
-        return Err(ProvenanceError::MalformedIdToken.into());
-    }
-
-    let payload = decode_jwt_payload(payload_b64)?;
-    let repository_visibility = payload.get("repository_visibility").and_then(Value::as_str);
-    let project_visibility = payload.get("project_visibility").and_then(Value::as_str);
-
-    let github_public = is_github_actions::<Sys>() && repository_visibility == Some("public");
-    let gitlab_public = is_gitlab::<Sys>()
-        && project_visibility == Some("public")
-        && Sys::var("SIGSTORE_ID_TOKEN").is_some_and(|token| !token.is_empty());
-    if !github_public && !gitlab_public {
+    let payload = id_token_payload(id_token)?;
+    if !is_public_ci_project::<Sys>(&payload) {
         return Err(ProvenanceError::InsufficientInformation.into());
     }
 
-    let path = format!("/-/package/{}/visibility", escaped_package_name(package_name));
-    let visibility_url = Url::parse(registry)
-        .and_then(|base| base.join(&path))
-        .map_err(DetermineProvenanceError::InvalidUrl)?
-        .to_string();
-
+    let visibility_url = visibility_url(registry, package_name)?;
     let authorization = format!("Bearer {auth_token}");
     let response = Sys::fetch(OidcRequest {
         method: OidcMethod::Get,
@@ -89,6 +69,38 @@ where
         .map_err(|error| DetermineProvenanceError::VisibilityParse(error.to_string()))?;
     let public = visibility.get("public").and_then(Value::as_bool).unwrap_or(false);
     Ok(public.then_some(true))
+}
+
+fn id_token_payload(id_token: &str) -> Result<Value, DetermineProvenanceError> {
+    let mut parts = id_token.split('.');
+    let (Some(header_b64), Some(payload_b64)) = (parts.next(), parts.next()) else {
+        return Err(ProvenanceError::MalformedIdToken.into());
+    };
+    if header_b64.is_empty() || payload_b64.is_empty() {
+        return Err(ProvenanceError::MalformedIdToken.into());
+    }
+    decode_jwt_payload(payload_b64)
+}
+
+/// Whether the token proves a public GitHub Actions or GitLab project, the
+/// two setups provenance can be generated for.
+fn is_public_ci_project<Sys: EnvVar>(payload: &Value) -> bool {
+    let repository_visibility = payload.get("repository_visibility").and_then(Value::as_str);
+    let project_visibility = payload.get("project_visibility").and_then(Value::as_str);
+
+    let github_public = is_github_actions::<Sys>() && repository_visibility == Some("public");
+    let gitlab_public = is_gitlab::<Sys>()
+        && project_visibility == Some("public")
+        && Sys::var("SIGSTORE_ID_TOKEN").is_some_and(|token| !token.is_empty());
+    github_public || gitlab_public
+}
+
+fn visibility_url(registry: &str, package_name: &str) -> Result<String, DetermineProvenanceError> {
+    let path = format!("/-/package/{}/visibility", escaped_package_name(package_name));
+    Url::parse(registry)
+        .and_then(|base| base.join(&path))
+        .map_err(DetermineProvenanceError::InvalidUrl)
+        .map(|url| url.to_string())
 }
 
 /// Decode the base64url JWT payload into JSON. A decode or parse failure is a

--- a/pnpm/crates/publish/src/publish_packed_pkg.rs
+++ b/pnpm/crates/publish/src/publish_packed_pkg.rs
@@ -374,11 +374,7 @@ async fn put_publish(
         .map_err(|error| PublishHttpError::Transport { reason: error.to_string() })?;
     let status = response.status();
     let status_text = status.canonical_reason().unwrap_or_default().to_owned();
-    let www_authenticate = response
-        .headers()
-        .get(reqwest::header::WWW_AUTHENTICATE)
-        .and_then(|value| value.to_str().ok())
-        .map(str::to_owned);
+    let www_authenticate = www_authenticate_header(&response);
     let body = response.text().await.unwrap_or_default();
 
     // The registry signals an OTP / web-auth challenge with a 401 that either
@@ -397,6 +393,14 @@ async fn put_publish(
         body,
         stage_id,
     })
+}
+
+fn www_authenticate_header(response: &reqwest::Response) -> Option<String> {
+    response
+        .headers()
+        .get(reqwest::header::WWW_AUTHENTICATE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned)
 }
 
 /// Whether a 401 response is an OTP / two-factor challenge: the
@@ -477,34 +481,18 @@ pub(crate) fn build_publish_document(
     }
 
     let tarball_name = format!("{name}-{version}.tgz");
-    let tarball_uri = format!("{name}/-/{tarball_name}");
-    let tarball_url = join_registry(registry, &tarball_uri)?.replacen("https://", "http://", 1);
-
-    let mut dist = Map::new();
-    dist.insert("integrity".to_owned(), Value::String(dist_hashes.integrity.to_owned()));
-    dist.insert("shasum".to_owned(), Value::String(dist_hashes.shasum.to_owned()));
-    dist.insert("tarball".to_owned(), Value::String(tarball_url));
-
-    let mut version_manifest = manifest.as_object().cloned().unwrap_or_default();
-    version_manifest.insert("_id".to_owned(), Value::String(format!("{name}@{version}")));
-    version_manifest.insert("version".to_owned(), Value::String(version.clone()));
-    version_manifest.insert("dist".to_owned(), Value::Object(dist));
-
-    let mut versions = Map::new();
-    versions.insert(version.clone(), Value::Object(version_manifest));
+    let tarball_url = join_registry(registry, &format!("{name}/-/{tarball_name}"))?
+        .replacen("https://", "http://", 1);
+    let versions =
+        versions_object(manifest, &name, &version, dist_object(dist_hashes, tarball_url));
 
     // A manifest-level `tag` wins over the default.
     let tag = manifest.get("tag").and_then(Value::as_str).unwrap_or(tag);
     let mut dist_tags = Map::new();
     dist_tags.insert(tag.to_owned(), Value::String(version));
 
-    let attachment = serde_json::json!({
-        "content_type": "application/octet-stream",
-        "data": base64_standard(tarball_data),
-        "length": tarball_data.len(),
-    });
     let mut attachments = Map::new();
-    attachments.insert(tarball_name, attachment);
+    attachments.insert(tarball_name, attachment_object(tarball_data));
 
     let mut root = Map::new();
     root.insert("_id".to_owned(), Value::String(name.clone()));
@@ -520,6 +508,40 @@ pub(crate) fn build_publish_document(
     );
     root.insert("_attachments".to_owned(), Value::Object(attachments));
     Ok(Value::Object(root))
+}
+
+fn dist_object(dist_hashes: &DistHashes<'_>, tarball_url: String) -> Map<String, Value> {
+    let mut dist = Map::new();
+    dist.insert("integrity".to_owned(), Value::String(dist_hashes.integrity.to_owned()));
+    dist.insert("shasum".to_owned(), Value::String(dist_hashes.shasum.to_owned()));
+    dist.insert("tarball".to_owned(), Value::String(tarball_url));
+    dist
+}
+
+/// The `versions` map holding the one published version: the manifest with
+/// its `_id`, `version` and `dist` set.
+fn versions_object(
+    manifest: &Value,
+    name: &str,
+    version: &str,
+    dist: Map<String, Value>,
+) -> Map<String, Value> {
+    let mut version_manifest = manifest.as_object().cloned().unwrap_or_default();
+    version_manifest.insert("_id".to_owned(), Value::String(format!("{name}@{version}")));
+    version_manifest.insert("version".to_owned(), Value::String(version.to_owned()));
+    version_manifest.insert("dist".to_owned(), Value::Object(dist));
+
+    let mut versions = Map::new();
+    versions.insert(version.to_owned(), Value::Object(version_manifest));
+    versions
+}
+
+fn attachment_object(tarball_data: &[u8]) -> Value {
+    serde_json::json!({
+        "content_type": "application/octet-stream",
+        "data": base64_standard(tarball_data),
+        "length": tarball_data.len(),
+    })
 }
 
 /// Resolve `path` against the registry the way `new URL(path, registry)` does.

--- a/pnpm/crates/real-hoist/src/lib.rs
+++ b/pnpm/crates/real-hoist/src/lib.rs
@@ -322,16 +322,7 @@ pub fn hoist(lockfile: &Lockfile, opts: &HoistOpts) -> Result<HoisterResult, Hoi
     // Pacquet has no consumer for this yet, but the wrapper handles
     // it so the signature is complete.
     for dep in &opts.external_dependencies {
-        let placeholder = Rc::new(HoisterTree {
-            name: dep.clone(),
-            ident_name: dep.clone(),
-            reference: "link:".to_string(),
-            peer_names: BTreeSet::new(),
-            dependency_kind: HoisterDependencyKind::ExternalSoftLink,
-            hoist_priority: 0,
-            dependencies: RefCell::new(IndexSet::new()),
-        });
-        root_children.insert(RcByPtr(placeholder));
+        root_children.insert(RcByPtr(external_placeholder(dep)));
     }
 
     // Non-root importers (workspace projects) become children of
@@ -347,29 +338,10 @@ pub fn hoist(lockfile: &Lockfile, opts: &HoistOpts) -> Result<HoisterResult, Hoi
     // `hoistedWorkspacePackages` in the headless linker) — it never
     // decides tree membership; gating membership on it silently
     // dropped every importer-only dependency from the install.
-    let mut non_root: Vec<(&String, &ProjectSnapshot)> = lockfile
-        .importers
-        .iter()
-        .filter(|(id, _)| id.as_str() != Lockfile::ROOT_IMPORTER_KEY)
-        .collect();
-    // HashMap iteration order is non-deterministic; sort so the
-    // output tree is stable across runs (matters for snapshot
-    // tests).
-    non_root.sort_by(|a, b| a.0.cmp(b.0));
-
-    for (importer_id, importer) in non_root {
+    for (importer_id, importer) in sorted_non_root_importers(lockfile) {
         let mut importer_children: IndexSet<RcByPtr<HoisterTree>> = IndexSet::new();
         collect_importer_deps(importer, lockfile, opts, &mut cache, &mut importer_children)?;
-        let importer_node = Rc::new(HoisterTree {
-            name: percent_encode_path(importer_id),
-            ident_name: percent_encode_path(importer_id),
-            reference: format!("workspace:{importer_id}"),
-            peer_names: BTreeSet::new(),
-            dependency_kind: HoisterDependencyKind::Workspace,
-            hoist_priority: 0,
-            dependencies: RefCell::new(importer_children),
-        });
-        root_children.insert(RcByPtr(importer_node));
+        root_children.insert(RcByPtr(importer_node(importer_id, importer_children)));
     }
 
     let root_node = Rc::new(HoisterTree {
@@ -394,6 +366,43 @@ pub fn hoist(lockfile: &Lockfile, opts: &HoistOpts) -> Result<HoisterResult, Hoi
     }
 
     Ok(result)
+}
+
+fn external_placeholder(dep: &str) -> Rc<HoisterTree> {
+    Rc::new(HoisterTree {
+        name: dep.to_string(),
+        ident_name: dep.to_string(),
+        reference: "link:".to_string(),
+        peer_names: BTreeSet::new(),
+        dependency_kind: HoisterDependencyKind::ExternalSoftLink,
+        hoist_priority: 0,
+        dependencies: RefCell::new(IndexSet::new()),
+    })
+}
+
+/// `HashMap` iteration order is non-deterministic; sort so the
+/// output tree is stable across runs (matters for snapshot
+/// tests).
+fn sorted_non_root_importers(lockfile: &Lockfile) -> Vec<(&String, &ProjectSnapshot)> {
+    let mut non_root: Vec<(&String, &ProjectSnapshot)> = lockfile
+        .importers
+        .iter()
+        .filter(|(id, _)| id.as_str() != Lockfile::ROOT_IMPORTER_KEY)
+        .collect();
+    non_root.sort_by(|a, b| a.0.cmp(b.0));
+    non_root
+}
+
+fn importer_node(importer_id: &str, children: IndexSet<RcByPtr<HoisterTree>>) -> Rc<HoisterTree> {
+    Rc::new(HoisterTree {
+        name: percent_encode_path(importer_id),
+        ident_name: percent_encode_path(importer_id),
+        reference: format!("workspace:{importer_id}"),
+        peer_names: BTreeSet::new(),
+        dependency_kind: HoisterDependencyKind::Workspace,
+        hoist_priority: 0,
+        dependencies: RefCell::new(children),
+    })
 }
 
 /// Conversion-phase caches. `nodes` interns one [`HoisterTree`] per

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -44,7 +44,7 @@ mod test_support;
 
 use reuse::{ReuseSource, record_direct_dep_versions};
 use walk::{
-    NodeSeed, level_aliases, level_versions, resolve_node_seed, walk_from_seeds,
+    ChildEdge, NodeSeed, level_aliases, level_versions, resolve_node_seed, walk_from_seeds,
     warm_children_resolutions,
 };
 
@@ -668,48 +668,15 @@ where
     // preferred-versions overlay (a per-level fold; the direct deps
     // themselves resolve against the importer's static preferred map
     // only).
-    let root_ancestors = Arc::new(Vec::new());
+    let root = DirectRoot {
+        reuse,
+        ancestors: Arc::new(Vec::new()),
+        parent_pkg_aliases,
+        base_overlay: &ctx.base_opts.preferred_versions_overlay,
+    };
     let seeds = wanted
         .into_iter()
-        .map(|(name, range, optional, injected)| {
-            let reuse = reuse.clone();
-            let root_ancestors = Arc::clone(&root_ancestors);
-            async move {
-                // `injected: Some(true)` only when the importer manifest's
-                // `dependenciesMeta[name].injected = true` opted this dep
-                // in. Otherwise leave it `None`: an absent meta entry
-                // yields no flag rather than `false`. The resolver OR's
-                // this with the global `inject_workspace_packages` flag,
-                // so `None` and `Some(false)` would produce identical
-                // behavior — but keeping `None` aligns the [`WantedKey`]
-                // cache buckets across the two pacquet branches that
-                // surface `injected`.
-                let wanted = WantedDependency {
-                    alias: Some(name),
-                    bare_specifier: Some(range),
-                    optional: Some(optional),
-                    injected: injected.then_some(true),
-                    ..WantedDependency::default()
-                };
-                let base_overlay = ctx.base_opts.preferred_versions_overlay.clone();
-                let seed = resolve_node_seed(
-                    ctx,
-                    resolver,
-                    wanted,
-                    &root_ancestors,
-                    0,
-                    false,
-                    reuse,
-                    base_overlay,
-                    None,
-                    parent_pkg_aliases,
-                    false,
-                )
-                .await?;
-                warm_children_resolutions(ctx, resolver, &seed).await;
-                Ok::<NodeSeed, ResolveDependencyTreeError>(seed)
-            }
-        })
+        .map(|spec| seed_direct(ctx, resolver, spec, &root))
         .pipe(future::try_join_all)
         .await?;
     // The level chain extends any caller-seeded overlay so descendant
@@ -734,6 +701,58 @@ where
     // closure, and without a completion bump it would never refresh.
     ctx.workspace.bump_revision();
     Ok(direct)
+}
+
+/// What every direct dep of one importer wave resolves against.
+struct DirectRoot<'r> {
+    reuse: ReuseSource,
+    ancestors: Arc<Vec<String>>,
+    parent_pkg_aliases: &'r Arc<ParentPkgAliases>,
+    base_overlay: &'r Option<Arc<PreferredVersionsOverlay>>,
+}
+
+/// `injected: Some(true)` only when the importer manifest's
+/// `dependenciesMeta[name].injected = true` opted this dep in. Otherwise
+/// leave it `None`: an absent meta entry yields no flag rather than
+/// `false`. The resolver OR's this with the global
+/// `inject_workspace_packages` flag, so `None` and `Some(false)` would
+/// produce identical behavior — but keeping `None` aligns the
+/// [`WantedKey`] cache buckets across the two pacquet branches that
+/// surface `injected`.
+async fn seed_direct<Chain>(
+    ctx: &TreeCtx,
+    resolver: &Chain,
+    (name, range, optional, injected): WantedSpec,
+    root: &DirectRoot<'_>,
+) -> Result<NodeSeed, ResolveDependencyTreeError>
+where
+    Chain: Resolver + ?Sized,
+{
+    let wanted = WantedDependency {
+        alias: Some(name),
+        bare_specifier: Some(range),
+        optional: Some(optional),
+        injected: injected.then_some(true),
+        ..WantedDependency::default()
+    };
+    let seed = resolve_node_seed(
+        ctx,
+        resolver,
+        wanted,
+        ChildEdge {
+            ancestor_ids: &root.ancestors,
+            depth: 0,
+            parent_optional: false,
+            reuse: root.reuse.clone(),
+            pick_overlay: root.base_overlay.clone(),
+            parent_dir: None,
+            parent_pkg_aliases: root.parent_pkg_aliases,
+            parent_is_workspace: false,
+        },
+    )
+    .await?;
+    warm_children_resolutions(ctx, resolver, &seed).await;
+    Ok(seed)
 }
 
 #[cfg(test)]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -637,7 +637,7 @@ pub(crate) type WantedSpec = (String, String, bool, bool);
 /// `false`. The resolver OR's this with the global
 /// `inject_workspace_packages` flag, so `None` and `Some(false)` would
 /// produce identical behavior — but keeping `None` aligns the
-/// [`WantedKey`] cache buckets across the two pacquet branches that
+/// [`WantedKey`](workspace_ctx::WantedKey) cache buckets across the two pacquet branches that
 /// surface `injected`.
 pub(crate) fn wanted_from_spec((name, range, optional, injected): WantedSpec) -> WantedDependency {
     WantedDependency {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -631,6 +631,24 @@ where
 /// meta from any manifest.
 pub(crate) type WantedSpec = (String, String, bool, bool);
 
+/// `injected: Some(true)` only when the importer manifest's
+/// `dependenciesMeta[name].injected = true` opted this dep in. Otherwise
+/// leave it `None`: an absent meta entry yields no flag rather than
+/// `false`. The resolver OR's this with the global
+/// `inject_workspace_packages` flag, so `None` and `Some(false)` would
+/// produce identical behavior — but keeping `None` aligns the
+/// [`WantedKey`] cache buckets across the two pacquet branches that
+/// surface `injected`.
+pub(crate) fn wanted_from_spec((name, range, optional, injected): WantedSpec) -> WantedDependency {
+    WantedDependency {
+        alias: Some(name),
+        bare_specifier: Some(range),
+        optional: Some(optional),
+        injected: injected.then_some(true),
+        ..WantedDependency::default()
+    }
+}
+
 /// Walk an additional set of `(alias, range)` pairs as new direct
 /// dependencies of the importer, extending `ctx` in place. Returns the
 /// per-edge [`DirectDep`] envelopes for the freshly-walked deps; the
@@ -711,34 +729,19 @@ struct DirectRoot<'r> {
     base_overlay: &'r Option<Arc<PreferredVersionsOverlay>>,
 }
 
-/// `injected: Some(true)` only when the importer manifest's
-/// `dependenciesMeta[name].injected = true` opted this dep in. Otherwise
-/// leave it `None`: an absent meta entry yields no flag rather than
-/// `false`. The resolver OR's this with the global
-/// `inject_workspace_packages` flag, so `None` and `Some(false)` would
-/// produce identical behavior — but keeping `None` aligns the
-/// [`WantedKey`] cache buckets across the two pacquet branches that
-/// surface `injected`.
 async fn seed_direct<Chain>(
     ctx: &TreeCtx,
     resolver: &Chain,
-    (name, range, optional, injected): WantedSpec,
+    spec: WantedSpec,
     root: &DirectRoot<'_>,
 ) -> Result<NodeSeed, ResolveDependencyTreeError>
 where
     Chain: Resolver + ?Sized,
 {
-    let wanted = WantedDependency {
-        alias: Some(name),
-        bare_specifier: Some(range),
-        optional: Some(optional),
-        injected: injected.then_some(true),
-        ..WantedDependency::default()
-    };
     let seed = resolve_node_seed(
         ctx,
         resolver,
-        wanted,
+        wanted_from_spec(spec),
         ChildEdge {
             ancestor_ids: &root.ancestors,
             depth: 0,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/finalized.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/finalized.rs
@@ -76,28 +76,28 @@ fn collect_finalized(ctx: &TreeCtx) -> Vec<FinalizedPackage> {
     newly_finalized.sort();
     let announcements = newly_finalized
         .iter()
-        .map(|pkg_id| {
-            let package = &packages[pkg_id];
-            let children = children_by_id
-                .get(pkg_id)
-                .map(|recorded| recorded.edges.as_slice())
-                .unwrap_or_default()
-                .iter()
-                .map(|edge| FinalizedChild {
-                    alias: edge.alias.clone(),
-                    pkg_id: Arc::clone(&edge.pkg_id),
-                    optional: edge.optional,
-                })
-                .collect();
-            FinalizedPackage {
-                pkg_id: Arc::clone(pkg_id),
-                result: Arc::clone(&package.result),
-                children,
-            }
-        })
+        .map(|pkg_id| announcement(pkg_id, &packages[pkg_id], children_by_id.get(pkg_id)))
         .collect();
     finalized_ids.extend(newly_finalized);
     announcements
+}
+
+fn announcement(
+    pkg_id: &Arc<str>,
+    package: &ResolvedPackage,
+    recorded: Option<&RecordedChildren>,
+) -> FinalizedPackage {
+    let children = recorded
+        .map(|recorded| recorded.edges.as_slice())
+        .unwrap_or_default()
+        .iter()
+        .map(|edge| FinalizedChild {
+            alias: edge.alias.clone(),
+            pkg_id: Arc::clone(&edge.pkg_id),
+            optional: edge.optional,
+        })
+        .collect();
+    FinalizedPackage { pkg_id: Arc::clone(pkg_id), result: Arc::clone(&package.result), children }
 }
 
 /// One sweep's view of the graph. `verdicts` memoises this sweep's

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
@@ -27,7 +27,7 @@ use super::{
         build_pkg_id_with_patch_hash, emit_deprecation_if_needed, extract_peer_dependencies,
     },
     tree_ctx::TreeCtx,
-    walk::{closes_cycle, node_alias, node_id_for, resolve_node},
+    walk::{ChildEdge, closes_cycle, node_alias, node_id_for, resolve_node},
     workspace_ctx::{
         ChildrenOwnerClaim, DirectDepVersions, RecordedChildrenContext, claim_children_owner,
         insert_tree_node, is_current_children_owner, lazy_children, make_non_owner_nodes_lazy,
@@ -535,26 +535,17 @@ fn subtree_children_reusable(
 /// [`fn@resolve_node`], specialized for a node whose subtree
 /// [`fn@try_reuse_node`] already confirmed reusable.
 #[async_recursion]
-#[expect(
-    clippy::too_many_arguments,
-    reason = "internal walker helper threading per-node context through the recursion"
-)]
 pub(super) async fn resolve_reused_node<Chain>(
     ctx: &TreeCtx,
     resolver: &Chain,
     wanted: WantedDependency,
-    ancestor_ids: &Arc<Vec<String>>,
-    depth: i32,
+    edge: &ChildEdge<'_>,
     current_is_optional: bool,
     reused: ReusedNode,
-    parent_pkg_aliases: &Arc<ParentPkgAliases>,
 ) -> Result<Option<DirectDep>, ResolveDependencyTreeError>
 where
     Chain: Resolver + ?Sized,
 {
-    let ReusedNode { key, result } = reused;
-    let result = Arc::new(result);
-
     // The synthesized result must stay out of `resolved_by_wanted`: its
     // manifest deliberately omits `dependencies` (a reused node's
     // children come from the snapshot graph), so if the fresh-resolve
@@ -563,72 +554,118 @@ where
     // provisional-`false` cycle guard — `extract_children` /
     // `pkg_is_leaf` would misread the package as dependency-less and
     // record it as a leaf, emptying its lockfile snapshot.
+    let result = Arc::new(reused.result);
 
     let id = build_pkg_id_with_patch_hash(ctx, &result).await?;
 
-    if closes_cycle(ancestor_ids, &id) {
+    if closes_cycle(edge.ancestor_ids, &id) {
         return Ok(None);
     }
 
     let alias = node_alias(&wanted, &result, &id);
+    let identity = reused_identity(ctx, &id, &result, &reused.key)?;
 
-    // Leaf classification reads the snapshot graph (the source of truth
-    // for a reused node's children), not the synthesized manifest (whose
-    // `dependencies` are deliberately omitted). A node with no recorded
-    // children and no peers is a leaf, matching `pkg_is_leaf`.
+    if register_reused_package(
+        ctx,
+        &id,
+        &result,
+        identity.peer_dependencies,
+        current_is_optional,
+        identity.is_leaf,
+    ) {
+        emit_deprecation_if_needed(ctx, &result, &id, edge.depth);
+    }
+
+    let next_ancestors: Vec<String> =
+        edge.ancestor_ids.iter().cloned().chain(std::iter::once(id.clone())).collect();
+    attach_reused_children(
+        ctx,
+        resolver,
+        edge,
+        ReusedChildren {
+            id: &id,
+            key: &reused.key,
+            snapshot: identity.snapshot,
+            child_refs: &identity.child_refs,
+            ancestor_ids: edge.ancestor_ids,
+            next_ancestors: &Arc::new(next_ancestors),
+            depth: edge.depth,
+            current_is_optional,
+            parent_pkg_aliases: edge.parent_pkg_aliases,
+        },
+        &identity.node_id,
+    )
+    .await?;
+
+    Ok(Some(DirectDep { alias, node_id: identity.node_id, id }))
+}
+
+/// What the snapshot graph says about a reused node. Leaf
+/// classification reads the snapshot graph (the source of truth for a
+/// reused node's children), not the synthesized manifest (whose
+/// `dependencies` are deliberately omitted). A node with no recorded
+/// children and no peers is a leaf, matching `pkg_is_leaf`.
+struct ReusedIdentity<'l> {
+    snapshot: Option<&'l SnapshotEntry>,
+    /// A reused node's children come from the snapshot rather than
+    /// from a manifest, so no `dependencies` entry of its synthesized
+    /// manifest can be peer-shadowed.
+    peer_dependencies: BTreeMap<String, PeerDep>,
+    child_refs: Vec<(String, PkgNameVerPeer)>,
+    is_leaf: bool,
+    node_id: NodeId,
+}
+
+fn reused_identity<'l>(
+    ctx: &'l TreeCtx,
+    id: &str,
+    result: &pnpm_resolving_resolver_base::ResolveResult,
+    key: &PkgNameVerPeer,
+) -> Result<ReusedIdentity<'l>, ResolveDependencyTreeError> {
     let snapshot = ctx
         .workspace
         .wanted_lockfile
         .as_ref()
         .and_then(|lockfile| lockfile.snapshots.as_ref())
-        .and_then(|snaps| snaps.get(&key));
-    // A reused node's children come from the snapshot rather than from
-    // a manifest, so no `dependencies` entry of its synthesized
-    // manifest can be peer-shadowed.
-    let peer_dependencies = extract_peer_dependencies(&result, &HashSet::default(), None)?;
+        .and_then(|snaps| snaps.get(key));
+    let peer_dependencies = extract_peer_dependencies(result, &HashSet::default(), None)?;
     let child_refs = snapshot_child_refs(snapshot, &peer_dependencies);
     let is_leaf = child_refs.is_empty() && peer_dependencies.is_empty();
-    let node_id = node_id_for(is_leaf, &id);
+    Ok(ReusedIdentity {
+        snapshot,
+        peer_dependencies,
+        child_refs,
+        is_leaf,
+        node_id: node_id_for(is_leaf, id),
+    })
+}
 
-    let package_is_new =
-        register_reused_package(ctx, &id, &result, peer_dependencies, current_is_optional, is_leaf);
-
-    if package_is_new {
-        emit_deprecation_if_needed(ctx, &result, &id, depth);
-    }
-
-    let next_ancestors: Vec<String> =
-        ancestor_ids.iter().cloned().chain(std::iter::once(id.clone())).collect();
-    let next_ancestors = Arc::new(next_ancestors);
-    let children_owner = claim_children_owner(ctx, &id, depth, ancestor_ids, HashSet::default());
-
-    let (children, others_stale) = reused_children(
-        ctx,
-        resolver,
-        &children_owner,
-        ReusedChildren {
-            id: &id,
-            key: &key,
-            snapshot,
-            child_refs: &child_refs,
-            ancestor_ids,
-            next_ancestors: &next_ancestors,
-            depth,
-            current_is_optional,
-            parent_pkg_aliases,
-        },
-    )
-    .await?;
-    remember_node_parent_ids(ctx, &node_id, Arc::clone(ancestor_ids));
-    insert_tree_node(ctx, node_id.clone(), &id, children, depth);
+/// Walk the reused node's children from the snapshot graph, insert the
+/// node, and demote the other occurrences to lazy when this one owns
+/// the children and their context moved.
+async fn attach_reused_children<Chain>(
+    ctx: &TreeCtx,
+    resolver: &Chain,
+    edge: &ChildEdge<'_>,
+    reused: ReusedChildren<'_>,
+    node_id: &NodeId,
+) -> Result<(), ResolveDependencyTreeError>
+where
+    Chain: Resolver + ?Sized,
+{
+    let reused_id = reused.id;
+    let children_owner =
+        claim_children_owner(ctx, reused_id, edge.depth, edge.ancestor_ids, HashSet::default());
+    let (children, others_stale) = reused_children(ctx, resolver, &children_owner, reused).await?;
+    remember_node_parent_ids(ctx, node_id, Arc::clone(edge.ancestor_ids));
+    insert_tree_node(ctx, node_id.clone(), reused_id, children, edge.depth);
     if children_owner.owns_children
         && (others_stale || !children_owner.children_context_unchanged)
-        && is_current_children_owner(ctx, &id, &children_owner.owner)
+        && is_current_children_owner(ctx, reused_id, &children_owner.owner)
     {
-        make_non_owner_nodes_lazy(ctx, &id, &node_id);
+        make_non_owner_nodes_lazy(ctx, reused_id, node_id);
     }
-
-    Ok(Some(DirectDep { alias, node_id, id }))
+    Ok(())
 }
 
 /// Insert a reused package into the workspace's package table, answering

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -10,7 +10,7 @@ use async_recursion::async_recursion;
 use futures_util::future;
 use pipe_trait::Pipe;
 use pnpm_catalogs_types::Catalogs;
-use pnpm_lockfile::{LockfileResolution, PkgNameVerPeer, TarballRevision};
+use pnpm_lockfile::{LockfileResolution, PkgNameVerPeer, SnapshotEntry, TarballRevision};
 use pnpm_resolving_resolver_base::{
     CurrentPkg, GitResolveError, NoMatchingVersionError, PreferredVersionsOverlay,
     RegistryResponseError, ResolveError, ResolveOptions, Resolver, UpdateBehavior,
@@ -88,14 +88,16 @@ where
         ctx,
         resolver,
         wanted,
-        ancestor_ids,
-        depth,
-        parent_optional,
-        reuse,
-        base_overlay.clone(),
-        None,
-        parent_pkg_aliases,
-        false,
+        ChildEdge {
+            ancestor_ids,
+            depth,
+            parent_optional,
+            reuse,
+            pick_overlay: base_overlay.clone(),
+            parent_dir: None,
+            parent_pkg_aliases,
+            parent_is_workspace: false,
+        },
     )
     .await?;
     let direct =
@@ -160,33 +162,35 @@ struct SeededPackage<'a> {
     is_leaf: bool,
 }
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "internal walker helper threading per-node context through the recursion"
-)]
+/// The parent-side context one child edge resolves in.
+pub(super) struct ChildEdge<'e> {
+    pub(super) ancestor_ids: &'e Arc<Vec<String>>,
+    pub(super) depth: i32,
+    pub(super) parent_optional: bool,
+    pub(super) reuse: ReuseSource,
+    pub(super) pick_overlay: Option<Arc<PreferredVersionsOverlay>>,
+    pub(super) parent_dir: Option<&'e Path>,
+    pub(super) parent_pkg_aliases: &'e Arc<ParentPkgAliases>,
+    pub(super) parent_is_workspace: bool,
+}
+
 #[async_recursion]
-pub(super) async fn resolve_node_seed<Chain>(
+pub(super) async fn resolve_node_seed<'e, Chain>(
     ctx: &TreeCtx,
     resolver: &Chain,
     wanted: WantedDependency,
-    ancestor_ids: &Arc<Vec<String>>,
-    depth: i32,
-    parent_optional: bool,
-    reuse: ReuseSource,
-    pick_overlay: Option<Arc<PreferredVersionsOverlay>>,
-    parent_dir: Option<&Path>,
-    parent_pkg_aliases: &Arc<ParentPkgAliases>,
-    parent_is_workspace: bool,
+    edge: ChildEdge<'e>,
 ) -> Result<NodeSeed, ResolveDependencyTreeError>
 where
+    'e: 'async_recursion,
     Chain: Resolver + ?Sized,
 {
-    let current_is_optional = wanted.optional.unwrap_or(false) || parent_optional;
+    let current_is_optional = wanted.optional.unwrap_or(false) || edge.parent_optional;
 
     // The edge's recorded snapshot key in the prior lockfile, if any.
     // Feeds both subtree reuse (below) and — when the edge re-resolves
     // anyway — the `currentPkg` payload custom resolvers receive.
-    let prior_key = reuse.prior_key(ctx, &wanted);
+    let prior_key = edge.reuse.prior_key(ctx, &wanted);
 
     // **Lockfile-resolution reuse.** When the prior lockfile already
     // resolved this edge (and the recorded version still satisfies the
@@ -203,22 +207,13 @@ where
     // stale pin onto the higher direct-dep version (reusing the subtree
     // would keep the pin, leaving the lockfile non-convergent).
     if ctx.workspace.reuse_lockfile_subtrees
-        && reuse.allows_reuse()
+        && edge.reuse.allows_reuse()
         && !node_depends_on_changed_direct_dep(ctx, prior_key.as_ref())
-        && let Some(reused) = try_reuse_node(ctx, &wanted, prior_key.as_ref(), depth)
+        && let Some(reused) = try_reuse_node(ctx, &wanted, prior_key.as_ref(), edge.depth)
     {
-        return resolve_reused_node(
-            ctx,
-            resolver,
-            wanted,
-            ancestor_ids,
-            depth,
-            current_is_optional,
-            reused,
-            parent_pkg_aliases,
-        )
-        .await
-        .map(NodeSeed::Done);
+        return resolve_reused_node(ctx, resolver, wanted, &edge, current_is_optional, reused)
+            .await
+            .map(NodeSeed::Done);
     }
 
     // Locked-version pin, the fresh-resolve counterpart of subtree
@@ -234,71 +229,129 @@ where
     // re-picking. Only plain semver ranges pin; aliased (`npm:`),
     // named-registry, and exotic specifiers keep today's behavior.
     let mut wanted = wanted;
-    pin_locked_version(ctx, &mut wanted, prior_key.as_ref(), depth);
+    pin_locked_version(ctx, &mut wanted, prior_key.as_ref(), edge.depth);
 
-    // Memoise the per-wanted resolve. The first caller for a given
-    // `(alias, bare_specifier, optional, injected)` runs the resolver chain and
-    // stores the `Arc<ResolveResult>` on `ctx.resolved_by_wanted`;
-    // every later caller for the same wanted dep clones the `Arc` and
-    // skips the chain entirely. Concurrent first-callers can both miss
-    // the cache and run `resolver.resolve` in parallel — the resolver's
-    // own per-cache-key semaphore (`pick_package::fetch_locker`)
-    // already coalesces those into a single network fetch, so the
-    // doubled work is bounded to in-memory packument lookups + semver
-    // matching, and the second to finish loses the `insert` race
-    // harmlessly (the entry holds an `Arc` to an equivalent
-    // `ResolveResult`).
-    // `resolutionMode` makes the version pick depend on whether this is
-    // a direct (`depth == 0`) or transitive dep, so the cache key and
-    // the resolver call both key off the depth-specific options.
-    let opts = ctx.opts_for_depth(depth);
-    // The prior lockfile entry rides along as `currentPkg`, handed to
-    // the resolver. Only custom resolvers read it today; the clone of
-    // the shared per-depth options is paid only when a prior entry
-    // exists for a freshly resolving edge.
-    let current_pkg = prior_key.as_ref().and_then(|key| {
+    let Some(result) = resolve_edge(ctx, resolver, &mut wanted, &edge, prior_key.as_ref()).await?
+    else {
+        return Ok(NodeSeed::Done(None));
+    };
+
+    if let Some(violation) = result.policy_violation.clone() {
+        lock_recoverable(&ctx.workspace.policy_violations).push(violation);
+    }
+
+    reject_exotic_subdep(ctx, &wanted, &result, edge.depth, edge.parent_is_workspace)?;
+
+    let id = build_pkg_id_with_patch_hash(ctx, &result).await?;
+
+    record_workspace_manifest_identity(ctx, &wanted, &result, &id);
+
+    if closes_cycle(edge.ancestor_ids, &id) {
+        return Ok(NodeSeed::Done(None));
+    }
+
+    seed_pending(ctx, &wanted, result, &edge, ResolvedEdge { id, prior_key, current_is_optional })
+}
+
+/// Memoise the per-wanted resolve. The first caller for a given
+/// `(alias, bare_specifier, optional, injected)` runs the resolver chain
+/// and stores the `Arc<ResolveResult>` on `ctx.resolved_by_wanted`;
+/// every later caller for the same wanted dep clones the `Arc` and
+/// skips the chain entirely. Concurrent first-callers can both miss the
+/// cache and run `resolver.resolve` in parallel — the resolver's own
+/// per-cache-key semaphore (`pick_package::fetch_locker`) already
+/// coalesces those into a single network fetch, so the doubled work is
+/// bounded to in-memory packument lookups + semver matching, and the
+/// second to finish loses the `insert` race harmlessly (the entry holds
+/// an `Arc` to an equivalent `ResolveResult`).
+///
+/// `None` when the edge is a droppable optional that failed to resolve.
+async fn resolve_edge<Chain>(
+    ctx: &TreeCtx,
+    resolver: &Chain,
+    wanted: &mut WantedDependency,
+    edge: &ChildEdge<'_>,
+    prior_key: Option<&PkgNameVerPeer>,
+) -> Result<Option<Arc<pnpm_resolving_resolver_base::ResolveResult>>, ResolveDependencyTreeError>
+where
+    Chain: Resolver + ?Sized,
+{
+    let base = edge_opts(ctx, wanted, edge, prior_key);
+    let opts = opts_relative_to_declaring_manifest(&base, wanted, edge.parent_dir);
+    let cache_key = edge_cache_key(ctx, wanted, &opts, edge, prior_key);
+    match resolve_wanted_cached(ctx, resolver, wanted, &opts, edge.pick_overlay.as_ref(), cache_key)
+        .await
+    {
+        Ok(result) => Ok(Some(result)),
+        Err(err) => {
+            drop_failed_optional_edge(ctx, wanted, edge.ancestor_ids, &opts, err)?;
+            Ok(None)
+        }
+    }
+}
+
+/// `resolutionMode` makes the version pick depend on whether this is a
+/// direct (`depth == 0`) or transitive dep, so the options key off the
+/// depth. The prior lockfile entry rides along as `currentPkg`, handed
+/// to the resolver. Only custom resolvers read it today; the clone of
+/// the shared per-depth options is paid only when a prior entry exists
+/// for a freshly resolving edge.
+fn edge_opts<'c>(
+    ctx: &'c TreeCtx,
+    wanted: &mut WantedDependency,
+    edge: &ChildEdge<'_>,
+    prior_key: Option<&PkgNameVerPeer>,
+) -> Cow<'c, ResolveOptions> {
+    let opts = ctx.opts_for_depth(edge.depth);
+    let current_pkg = prior_key.and_then(|key| {
         let lockfile = ctx.workspace.wanted_lockfile.as_ref()?;
         current_pkg_from_lockfile(lockfile, key, &ctx.workspace.registry_context)
     });
     if opts.update == UpdateBehavior::Patches {
-        pin_patched_revision(&mut wanted, current_pkg.as_ref(), prior_key.as_ref());
+        pin_patched_revision(wanted, current_pkg.as_ref(), prior_key);
     }
-    let opts_with_current_pkg;
-    let opts = match current_pkg {
+    match current_pkg {
         Some(current_pkg) => {
-            opts_with_current_pkg =
-                ResolveOptions { current_pkg: Some(current_pkg), ..opts.clone() };
-            &opts_with_current_pkg
+            Cow::Owned(ResolveOptions { current_pkg: Some(current_pkg), ..opts.clone() })
         }
-        None => opts,
-    };
-    let opts_for_file_dep = opts_relative_to_declaring_manifest(opts, &wanted, parent_dir);
-    let opts = opts_for_file_dep.as_ref();
-    // Project-relative resolutions (`link:`/`file:`/`workspace:`) are
-    // keyed by the consuming importer so one importer's relative path
-    // is never reused by another. See [`WantedKey`]. The prior key
-    // joins so two edges that share a specifier but recorded different
-    // versions never share a `currentPkg`-dependent result.
-    let project_scope = project_relative_cache_scope(&wanted, opts);
-    // The overlay's view for this edge joins the cache key: the same
-    // range can legitimately pick different versions under levels
-    // that resolved different siblings. The view keeps each candidate
-    // name (alias, `npm:` inner target, folded `jsr:` name) paired
-    // with its versions — the picker consults the overlay per name,
-    // so a flat union of versions could collide two overlays that
-    // distribute the same versions across different names. Empty for
-    // almost every edge, so the dedup keeps working where it matters.
-    let overlay_versions = pick_overlay
+        None => Cow::Borrowed(opts),
+    }
+}
+
+/// Project-relative resolutions (`link:`/`file:`/`workspace:`) are keyed
+/// by the consuming importer so one importer's relative path is never
+/// reused by another. See [`WantedKey`]. The prior key joins so two
+/// edges that share a specifier but recorded different versions never
+/// share a `currentPkg`-dependent result.
+///
+/// The overlay's view for this edge joins the cache key: the same range
+/// can legitimately pick different versions under levels that resolved
+/// different siblings. The view keeps each candidate name (alias, `npm:`
+/// inner target, folded `jsr:` name) paired with its versions — the
+/// picker consults the overlay per name, so a flat union of versions
+/// could collide two overlays that distribute the same versions across
+/// different names. Empty for almost every edge, so the dedup keeps
+/// working where it matters.
+fn edge_cache_key(
+    ctx: &TreeCtx,
+    wanted: &WantedDependency,
+    opts: &ResolveOptions,
+    edge: &ChildEdge<'_>,
+    prior_key: Option<&PkgNameVerPeer>,
+) -> WantedKey {
+    let project_scope = project_relative_cache_scope(wanted, opts);
+    let overlay_versions = edge
+        .pick_overlay
         .as_ref()
-        .map(|overlay| overlay_version_view(overlay, &wanted))
+        .map(|overlay| overlay_version_view(overlay, wanted))
         .unwrap_or_default();
     let update_target = is_update_target(
         ctx.update_scope(),
-        &wanted,
-        prior_key.as_ref().and_then(|key| key.suffix.version_semver()),
-        depth,
+        wanted,
+        prior_key.and_then(|key| key.suffix.version_semver()),
+        edge.depth,
     );
-    let cache_key = WantedKey::new((
+    WantedKey::new((
         wanted.alias.clone(),
         wanted.bare_specifier.clone(),
         wanted.optional,
@@ -306,110 +359,115 @@ where
         opts.pick_lowest_version,
         opts.published_by,
         project_scope,
-        prior_key.clone(),
+        prior_key.cloned(),
         overlay_versions,
         ctx.update_cache_scope(),
         update_target,
-    ));
-    let result =
-        match resolve_wanted_cached(ctx, resolver, &wanted, opts, pick_overlay.as_ref(), cache_key)
-            .await
-        {
-            Ok(result) => result,
-            Err(err) => {
-                drop_failed_optional_edge(ctx, &wanted, ancestor_ids, opts, err)?;
-                return Ok(NodeSeed::Done(None));
-            }
-        };
+    ))
+}
 
-    if let Some(violation) = result.policy_violation.clone() {
-        lock_recoverable(&ctx.workspace.policy_violations).push(violation);
-    }
+/// What a freshly resolved edge settled before its node seeds.
+struct ResolvedEdge {
+    id: String,
+    prior_key: Option<PkgNameVerPeer>,
+    current_is_optional: bool,
+}
 
-    reject_exotic_subdep(ctx, &wanted, &result, depth, parent_is_workspace)?;
-
-    let id = build_pkg_id_with_patch_hash(ctx, &result).await?;
-
-    record_workspace_manifest_identity(ctx, &wanted, &result, &id);
-
-    if closes_cycle(ancestor_ids, &id) {
-        return Ok(NodeSeed::Done(None));
-    }
-
-    let alias = node_alias(&wanted, &result, &id);
-
-    // Build (or look up) the ResolvedPackage envelope. The first
-    // visitor populates it; later visitors AND-fold the `optional`
-    // flag so a single non-optional path flips it back to `false`.
-    // Child traversal is claimed first, and a later
-    // deterministically-better occurrence replaces the shared
-    // `children_by_id` entry — plus, since the two are two halves of
-    // one manifest reading, the envelope's peer dependencies.
-    // Leaves (no deps / optional deps / peers / peerDependenciesMeta)
-    // reuse the package id as their `NodeId`, collapsing every parent
-    // edge onto one tree node. Non-leaves still get a fresh per-
-    // occurrence id so the peer resolver can attach different peer
-    // suffixes per call site.
-    // The leaf flag is computed before the dedup insert so it can be
-    // persisted on [`ResolvedPackage::is_leaf`] for the lazy realisation
-    // path to read back.
-    // Workspace-link nodes get empty children (the linked project
-    // resolves its own deps as a separate importer), `depth = -1` flags
-    // the node for the peer-resolution short-circuit, and the
-    // [`ResolvedPackage`] carries no peer dependencies (peer matching is
-    // the linked importer's responsibility, not the parent's). The node
-    // id is collapsed to a leaf so every reference to the same workspace
-    // path shares one [`NodeId`].
-    let is_link = id.starts_with("link:");
-    let resolves_children_through_catalogs = resolves_children_through_catalogs(&result);
-    let is_leaf = is_link || pkg_is_leaf(&result);
-    let node_id = node_id_for(is_leaf, &id);
-
+/// Build (or look up) the `ResolvedPackage` envelope. The first visitor
+/// populates it; later visitors AND-fold the `optional` flag so a single
+/// non-optional path flips it back to `false`. Child traversal is
+/// claimed first, and a later deterministically-better occurrence
+/// replaces the shared `children_by_id` entry — plus, since the two are
+/// two halves of one manifest reading, the envelope's peer dependencies.
+fn seed_pending(
+    ctx: &TreeCtx,
+    wanted: &WantedDependency,
+    result: Arc<pnpm_resolving_resolver_base::ResolveResult>,
+    edge: &ChildEdge<'_>,
+    resolved: ResolvedEdge,
+) -> Result<NodeSeed, ResolveDependencyTreeError> {
+    let alias = node_alias(wanted, &result, &resolved.id);
+    let identity = NodeIdentity::of(&result, &resolved.id);
     let peer_shadowed = peer_shadowed_dependencies(
         result.manifest.as_deref(),
-        parent_pkg_aliases,
+        edge.parent_pkg_aliases,
         ctx.workspace.auto_install_peers,
     );
     // The envelope's peer split follows the occurrence that owns the
     // package's children, which this level's settlement decides — see
     // [`fn@install_owner_peer_dependencies`]. Seeding only has to fill
     // a package nothing has resolved yet.
-    let package_is_new = register_seeded_package(
+    if register_seeded_package(
         ctx,
         SeededPackage {
-            id: &id,
+            id: &resolved.id,
             result: &result,
             peer_shadowed: &peer_shadowed,
-            resolves_children_through_catalogs,
-            current_is_optional,
-            is_link,
-            is_leaf,
+            resolves_children_through_catalogs: identity.resolves_children_through_catalogs,
+            current_is_optional: resolved.current_is_optional,
+            is_link: identity.is_link,
+            is_leaf: identity.is_leaf,
         },
-    )?;
-
-    if package_is_new {
-        emit_deprecation_if_needed(ctx, &result, &id, depth);
+    )? {
+        emit_deprecation_if_needed(ctx, &result, &resolved.id, edge.depth);
     }
 
     let next_ancestors: Vec<String> =
-        ancestor_ids.iter().cloned().chain(std::iter::once(id.clone())).collect();
-    let next_ancestors = Arc::new(next_ancestors);
+        edge.ancestor_ids.iter().cloned().chain(std::iter::once(resolved.id.clone())).collect();
 
     Ok(NodeSeed::Pending(Box::new(PendingNode {
         result,
-        id,
+        id: resolved.id,
         alias,
-        node_id,
-        is_link,
-        resolves_children_through_catalogs,
-        parent_ancestors: Arc::clone(ancestor_ids),
-        next_ancestors,
+        node_id: identity.node_id,
+        is_link: identity.is_link,
+        resolves_children_through_catalogs: identity.resolves_children_through_catalogs,
+        parent_ancestors: Arc::clone(edge.ancestor_ids),
+        next_ancestors: Arc::new(next_ancestors),
         peer_shadowed,
         claim: None,
-        depth,
-        current_is_optional,
-        prior_key,
+        depth: edge.depth,
+        current_is_optional: resolved.current_is_optional,
+        prior_key: resolved.prior_key,
     })))
+}
+
+/// Leaves (no deps / optional deps / peers / peerDependenciesMeta) reuse
+/// the package id as their `NodeId`, collapsing every parent edge onto
+/// one tree node. Non-leaves still get a fresh per-occurrence id so the
+/// peer resolver can attach different peer suffixes per call site.
+///
+/// Workspace-link nodes get empty children (the linked project resolves
+/// its own deps as a separate importer), `depth = -1` flags the node for
+/// the peer-resolution short-circuit, and the [`ResolvedPackage`]
+/// carries no peer dependencies (peer matching is the linked importer's
+/// responsibility, not the parent's). The node id is collapsed to a leaf
+/// so every reference to the same workspace path shares one [`NodeId`].
+///
+/// [`ResolvedPackage`]: crate::ResolvedPackage
+struct NodeIdentity {
+    is_link: bool,
+    resolves_children_through_catalogs: bool,
+    /// Computed before the dedup insert so it can be persisted on
+    /// [`ResolvedPackage::is_leaf`] for the lazy realisation path to
+    /// read back.
+    ///
+    /// [`ResolvedPackage::is_leaf`]: crate::ResolvedPackage::is_leaf
+    is_leaf: bool,
+    node_id: NodeId,
+}
+
+impl NodeIdentity {
+    fn of(result: &Arc<pnpm_resolving_resolver_base::ResolveResult>, id: &str) -> Self {
+        let is_link = id.starts_with("link:");
+        let is_leaf = is_link || pkg_is_leaf(result);
+        Self {
+            is_link,
+            resolves_children_through_catalogs: resolves_children_through_catalogs(result),
+            is_leaf,
+            node_id: node_id_for(is_leaf, id),
+        }
+    }
 }
 
 /// Leaves (no deps / optional deps / peers / `peerDependenciesMeta`) reuse the
@@ -1107,13 +1165,33 @@ async fn seed_node_children<Chain>(
 where
     Chain: Resolver + ?Sized,
 {
-    let FrontierNode { pending, claim, children_overlay, children_pkg_aliases } = node;
-    // Look up cached children specs first; only read the manifest on a
-    // miss. The cache value is held by `Arc` so revisits clone the
-    // refcount instead of the inner `Vec<ChildSpec>`, and
-    // it is cached unfiltered because which of the specs the package's
-    // own `peerDependencies` shadow is a property of the owner
-    // occurrence, not of the manifest.
+    let child_specs = child_specs_of(ctx, &node.pending, &node.claim.peer_shadowed)?;
+    let scope = ChildSeedScope::of(ctx, &node.pending);
+    let seeds = child_specs
+        .iter()
+        .map(|spec| seed_child(ctx, resolver, &node, &scope, spec))
+        .pipe(future::try_join_all)
+        .await?;
+    let grandchild_overlay =
+        PreferredVersionsOverlay::layer(node.children_overlay.clone(), level_versions(ctx, &seeds));
+    let grandchild_pkg_aliases = node.children_pkg_aliases.extend(level_aliases(&seeds));
+    Ok(SeededNode { node, child_specs, seeds, grandchild_overlay, grandchild_pkg_aliases })
+}
+
+/// The occurrence's child specs: its manifest's dependencies less the
+/// names its own `peerDependencies` shadow, with a workspace project's
+/// catalog specifiers resolved.
+///
+/// The manifest's specs are cached per package id. The cache value is
+/// held by `Arc` so revisits clone the refcount instead of the inner
+/// `Vec<ChildSpec>`, and it is cached unfiltered because which of the
+/// specs the package's own `peerDependencies` shadow is a property of
+/// the owner occurrence, not of the manifest.
+fn child_specs_of(
+    ctx: &TreeCtx,
+    pending: &PendingNode,
+    peer_shadowed: &HashSet<String>,
+) -> Result<Arc<Vec<ChildSpec>>, ResolveDependencyTreeError> {
     let cached =
         lock_recoverable(&ctx.workspace.children_specs_by_id).get(pending.id.as_str()).cloned();
     let child_specs = if let Some(specs) = cached {
@@ -1125,7 +1203,6 @@ where
             .or_insert_with(|| Arc::clone(&specs));
         specs
     };
-    let peer_shadowed = &claim.peer_shadowed;
     let child_specs = if peer_shadowed.is_empty() {
         child_specs
     } else {
@@ -1136,108 +1213,117 @@ where
             .collect::<Vec<ChildSpec>>()
             .pipe(Arc::new)
     };
-    let child_specs = if let Some(catalogs) =
-        catalogs_for_children(ctx, pending.resolves_children_through_catalogs)
-    {
-        child_specs
+    Ok(match catalogs_for_children(ctx, pending.resolves_children_through_catalogs) {
+        Some(catalogs) => child_specs
             .iter()
             .cloned()
             .collect::<Vec<ChildSpec>>()
             .pipe(|specs| resolve_catalog_child_specs(specs, catalogs))?
-            .pipe(Arc::new)
-    } else {
-        child_specs
-    };
-    // An *updated* parent (one that landed on a different version than
-    // the lockfile recorded, or a new dep) discards its
-    // `resolvedDependencies` child refs, forcing its subtree to
-    // re-resolve. A parent that freshly resolved but landed back on its
-    // previously recorded version keeps the prior child refs alive
-    // (pnpm's non-`parentPkg.updated` arm), and each child edge
-    // re-enters the reuse gate with its recorded key — so a
-    // still-satisfied subtree is reused rather than re-resolved.
-    // Re-resolving those children would re-pick open ranges (`*`) at
-    // their newest versions and churn the lockfile.
-    let prior_children_snapshot = pending
-        .prior_key
-        .as_ref()
-        .filter(|key| landed_on_prior_entry(key, &pending.id))
-        .and_then(|key| ctx.workspace.wanted_lockfile.as_ref()?.snapshots.as_ref()?.get(key));
-    // Snapshot this importer's direct-dep versions once for the whole
-    // child fanout instead of locking per edge.
-    let direct_versions =
-        lock_recoverable(&ctx.workspace.direct_dep_versions).get(&ctx.importer_id).map(Arc::clone);
-    let declaring_dir = declaring_manifest_dir(ctx, &pending.result);
-    let parent_is_workspace = pending.result.resolved_via == "workspace";
-    let child_depth = pending.depth + 1;
-    let child_optional_parent = pending.current_is_optional;
-    let next_ancestors = Arc::clone(&pending.next_ancestors);
-    let seeds = child_specs
-        .iter()
-        .map(|(child_name, child_range, child_optional, child_injected)| {
-            let mut child_wanted = WantedDependency {
-                alias: Some(child_name.clone()),
-                bare_specifier: Some(child_range.clone()),
-                optional: Some(*child_optional),
-                injected: child_injected.then_some(true),
-                ..WantedDependency::default()
-            };
-            let mut child_prior = prior_children_snapshot
-                .and_then(|snapshot| prior_child_key(snapshot, child_name, child_range));
-            // Stale-pin refresh: force the edge onto a higher in-range
-            // direct-dep version instead of reusing the pin, so the
-            // pinned version is never resolved or fetched.
-            let forced_version = child_prior
-                .as_ref()
-                .and_then(|key| key.suffix.version_semver().cloned())
-                .zip(child_range.parse::<node_semver::Range>().ok())
-                .and_then(|(pinned, range)| {
-                    higher_direct_dep_version(
-                        direct_versions.as_deref(),
-                        child_name,
-                        &pinned,
-                        &range,
-                    )
-                });
-            if let Some(higher) = forced_version {
-                child_wanted.bare_specifier = Some(higher.to_string());
-                child_prior = None;
-            }
-            let next_ancestors = Arc::clone(&next_ancestors);
-            let pick_overlay = children_overlay.clone();
-            let declaring_dir = declaring_dir.clone();
-            let parent_pkg_aliases = &children_pkg_aliases;
-            async move {
-                let seed = resolve_node_seed(
-                    ctx,
-                    resolver,
-                    child_wanted,
-                    &next_ancestors,
-                    child_depth,
-                    child_optional_parent,
-                    ReuseSource::Transitive { key: child_prior },
-                    pick_overlay,
-                    declaring_dir.as_deref(),
-                    parent_pkg_aliases,
-                    parent_is_workspace,
-                )
-                .await?;
-                warm_children_resolutions(ctx, resolver, &seed).await;
-                Ok::<NodeSeed, ResolveDependencyTreeError>(seed)
-            }
-        })
-        .pipe(future::try_join_all)
-        .await?;
-    let grandchild_overlay =
-        PreferredVersionsOverlay::layer(children_overlay.clone(), level_versions(ctx, &seeds));
-    let grandchild_pkg_aliases = children_pkg_aliases.extend(level_aliases(&seeds));
-    Ok(SeededNode {
-        node: FrontierNode { pending, claim, children_overlay, children_pkg_aliases },
-        child_specs,
-        seeds,
-        grandchild_overlay,
-        grandchild_pkg_aliases,
+            .pipe(Arc::new),
+        None => child_specs,
     })
+}
+
+/// What every child edge of one occurrence resolves against.
+struct ChildSeedScope<'s> {
+    /// The parent's recorded snapshot, kept when it landed on its prior
+    /// entry. An *updated* parent (one that landed on a different
+    /// version than the lockfile recorded, or a new dep) discards its
+    /// `resolvedDependencies` child refs, forcing its subtree to
+    /// re-resolve. A parent that freshly resolved but landed back on its
+    /// previously recorded version keeps the prior child refs alive
+    /// (pnpm's non-`parentPkg.updated` arm), and each child edge
+    /// re-enters the reuse gate with its recorded key — so a
+    /// still-satisfied subtree is reused rather than re-resolved.
+    /// Re-resolving those children would re-pick open ranges (`*`) at
+    /// their newest versions and churn the lockfile.
+    prior_children_snapshot: Option<&'s SnapshotEntry>,
+    /// This importer's direct-dep versions, snapshotted once for the
+    /// whole child fanout instead of locking per edge.
+    direct_versions: Option<Arc<super::workspace_ctx::DirectDepVersions>>,
+    declaring_dir: Option<Arc<Path>>,
+    parent_is_workspace: bool,
+}
+
+impl<'s> ChildSeedScope<'s> {
+    fn of(ctx: &'s TreeCtx, pending: &PendingNode) -> Self {
+        Self {
+            prior_children_snapshot: pending
+                .prior_key
+                .as_ref()
+                .filter(|key| landed_on_prior_entry(key, &pending.id))
+                .and_then(|key| {
+                    ctx.workspace.wanted_lockfile.as_ref()?.snapshots.as_ref()?.get(key)
+                }),
+            direct_versions: lock_recoverable(&ctx.workspace.direct_dep_versions)
+                .get(&ctx.importer_id)
+                .map(Arc::clone),
+            declaring_dir: declaring_manifest_dir(ctx, &pending.result),
+            parent_is_workspace: pending.result.resolved_via == "workspace",
+        }
+    }
+}
+
+async fn seed_child<Chain>(
+    ctx: &TreeCtx,
+    resolver: &Chain,
+    node: &FrontierNode,
+    scope: &ChildSeedScope<'_>,
+    spec: &ChildSpec,
+) -> Result<NodeSeed, ResolveDependencyTreeError>
+where
+    Chain: Resolver + ?Sized,
+{
+    let (wanted, prior) = child_wanted(scope, spec);
+    let seed = resolve_node_seed(
+        ctx,
+        resolver,
+        wanted,
+        ChildEdge {
+            ancestor_ids: &node.pending.next_ancestors,
+            depth: node.pending.depth + 1,
+            parent_optional: node.pending.current_is_optional,
+            reuse: ReuseSource::Transitive { key: prior },
+            pick_overlay: node.children_overlay.clone(),
+            parent_dir: scope.declaring_dir.as_deref(),
+            parent_pkg_aliases: &node.children_pkg_aliases,
+            parent_is_workspace: scope.parent_is_workspace,
+        },
+    )
+    .await?;
+    warm_children_resolutions(ctx, resolver, &seed).await;
+    Ok(seed)
+}
+
+/// The edge's wanted dependency and its prior key. Stale-pin refresh:
+/// the edge is forced onto a higher in-range direct-dep version instead
+/// of reusing the pin, so the pinned version is never resolved or
+/// fetched.
+fn child_wanted(
+    scope: &ChildSeedScope<'_>,
+    (name, range, optional, injected): &ChildSpec,
+) -> (WantedDependency, Option<PkgNameVerPeer>) {
+    let mut wanted = WantedDependency {
+        alias: Some(name.clone()),
+        bare_specifier: Some(range.clone()),
+        optional: Some(*optional),
+        injected: injected.then_some(true),
+        ..WantedDependency::default()
+    };
+    let mut prior =
+        scope.prior_children_snapshot.and_then(|snapshot| prior_child_key(snapshot, name, range));
+    if let Some(higher) = prior
+        .as_ref()
+        .and_then(|key| key.suffix.version_semver().cloned())
+        .zip(range.parse::<node_semver::Range>().ok())
+        .and_then(|(pinned, parsed)| {
+            higher_direct_dep_version(scope.direct_versions.as_deref(), name, &pinned, &parsed)
+        })
+    {
+        wanted.bare_specifier = Some(higher.to_string());
+        prior = None;
+    }
+    (wanted, prior)
 }
 
 /// Whether the `parent → child` edge closes a dependency cycle's

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -1057,20 +1057,24 @@ impl WorkspaceTreeCtx {
             let packages = lock_recoverable(&self.packages);
             fold_visited_versions(&packages, newly_visited, &mut cache);
         }
-        {
-            let identities = lock_recoverable(&self.workspace_manifest_identities);
-            let RunVersionsCache { awaiting_identity, versions, .. } = &mut *cache;
-            awaiting_identity.retain(|pkg_id| match identities.get(pkg_id) {
-                Some((name, version)) => {
-                    fold_version(versions, name.clone(), version.clone());
-                    false
-                }
-                None => true,
-            });
-        }
+        self.fold_settled_identities(&mut cache);
         cache.revision = revision;
         cache.children_rewrites = children_rewrites;
         cache
+    }
+
+    /// Fold the versions of the workspace packages whose manifest
+    /// identity has settled since the cache last looked.
+    fn fold_settled_identities(&self, cache: &mut RunVersionsCache) {
+        let identities = lock_recoverable(&self.workspace_manifest_identities);
+        let RunVersionsCache { awaiting_identity, versions, .. } = cache;
+        awaiting_identity.retain(|pkg_id| match identities.get(pkg_id) {
+            Some((name, version)) => {
+                fold_version(versions, name.clone(), version.clone());
+                false
+            }
+            None => true,
+        });
     }
 
     /// Record the manifest identity of a `name_ver`-less package wanted

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -481,7 +481,7 @@ struct HoistSettings {
 impl ResolveImporterOptions {
     /// The importer's tree context, and the settings the hoist state
     /// keeps. The manifest hooks are workspace-wide; they live on the
-    /// shared [`WorkspaceTreeCtx`] and the caller (`resolve_importer`
+    /// shared [`WorkspaceTreeCtx`] and the caller ([`resolve_importer`]
     /// or `resolve_workspace`) is responsible for setting them there
     /// before handing the `Arc` over.
     fn into_tree_ctx(

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -682,17 +682,15 @@ impl ImporterHoistState {
                 Some(round) => round,
                 None => self.next_required_round(peer_discovery),
             };
-            let RequiredRound { provider_pkg_ids, discovery, walk_was_full } = round;
-
-            self.merge_missing_issues(&discovery, walk_was_full);
+            self.merge_missing_issues(&round.discovery, round.walk_was_full);
             let (missing_required, fresh_optional) = partition_missing_peers(
                 &self.merged_missing,
                 &self.parent_pkg_aliases,
                 self.auto_install_peers_from_highest_match,
             );
             self.append_resolved_peer_providers(
-                &discovery.resolved_peer_providers_by_alias,
-                &provider_pkg_ids,
+                &round.discovery.resolved_peer_providers_by_alias,
+                &round.provider_pkg_ids,
                 &missing_required,
             );
             self.merge_fresh_optional_peers(fresh_optional);
@@ -702,55 +700,71 @@ impl ImporterHoistState {
                 self.converged_children_rewrites = self.ctx.workspace().children_rewrites();
                 break;
             }
-
-            let missing_as_pairs: Vec<(String, MissingPeerInfo)> =
-                missing_required.iter().map(|(n, info)| (n.clone(), info.clone())).collect();
-            // Both hoists bias toward the run-resolved preferred
-            // versions: the seed buckets for the missing names merged
-            // with every version resolved into the settled tree so far.
-            let hoist_preferred = self.ctx.preferred_versions_for_names(
-                &self.preferred_versions_seed,
-                missing_as_pairs.iter().map(|(name, _)| name.as_str()),
-            );
-            let hoisted = hoist_peers(
-                &HoistPeersOptions {
-                    auto_install_peers: self.auto_install_peers,
-                    all_preferred_versions: &hoist_preferred,
-                    workspace_root_deps: self.hoist_root_deps(),
-                    override_bare_specifier: self.override_bare_specifier.as_deref(),
-                    project_dir: &self.project_dir,
-                },
-                &missing_as_pairs,
-            );
-            if hoisted.is_empty() {
+            if !self.hoist_missing_required(resolver, &missing_required).await? {
                 break;
             }
-
-            for name in hoisted.keys() {
-                self.parent_pkg_aliases.insert(name.clone());
-            }
-
-            // Hoisted required peers are installed at the importer
-            // level as non-optional direct deps — they exist precisely
-            // to satisfy a missing required peer, so flipping their
-            // own `optional` flag to `true` would defeat the
-            // auto-install. Hoisted peers don't carry
-            // `dependenciesMeta` from any manifest, so `injected`
-            // defaults to `false`: the hoist path constructs a fresh
-            // wanted dependency without threading the per-dep meta.
-            let new_wanted: Vec<WantedSpec> =
-                hoisted.into_iter().map(|(name, range)| (name, range, false, false)).collect();
-            let new_direct = extend_tree(
-                &self.ctx,
-                resolver,
-                new_wanted,
-                &self.importer_id,
-                &ParentPkgAliases::root(self.parent_pkg_aliases.clone()),
-            )
-            .await?;
-            self.direct.extend(new_direct);
         }
         Ok(())
+    }
+
+    /// Hoist the missing required peers to the importer level and resolve
+    /// them as direct deps. `false` when nothing could be hoisted.
+    ///
+    /// Both hoists bias toward the run-resolved preferred versions: the
+    /// seed buckets for the missing names merged with every version
+    /// resolved into the settled tree so far.
+    async fn hoist_missing_required<Chain>(
+        &mut self,
+        resolver: &Chain,
+        missing_required: &BTreeMap<String, MissingPeerInfo>,
+    ) -> Result<bool, ResolveImporterError>
+    where
+        Chain: Resolver + ?Sized,
+    {
+        let missing_as_pairs: Vec<(String, MissingPeerInfo)> =
+            missing_required.iter().map(|(n, info)| (n.clone(), info.clone())).collect();
+        let hoist_preferred = self.ctx.preferred_versions_for_names(
+            &self.preferred_versions_seed,
+            missing_as_pairs.iter().map(|(name, _)| name.as_str()),
+        );
+        let hoisted = hoist_peers(
+            &HoistPeersOptions {
+                auto_install_peers: self.auto_install_peers,
+                all_preferred_versions: &hoist_preferred,
+                workspace_root_deps: self.hoist_root_deps(),
+                override_bare_specifier: self.override_bare_specifier.as_deref(),
+                project_dir: &self.project_dir,
+            },
+            &missing_as_pairs,
+        );
+        if hoisted.is_empty() {
+            return Ok(false);
+        }
+
+        for name in hoisted.keys() {
+            self.parent_pkg_aliases.insert(name.clone());
+        }
+
+        // Hoisted required peers are installed at the importer
+        // level as non-optional direct deps — they exist precisely
+        // to satisfy a missing required peer, so flipping their
+        // own `optional` flag to `true` would defeat the
+        // auto-install. Hoisted peers don't carry
+        // `dependenciesMeta` from any manifest, so `injected`
+        // defaults to `false`: the hoist path constructs a fresh
+        // wanted dependency without threading the per-dep meta.
+        let new_wanted: Vec<WantedSpec> =
+            hoisted.into_iter().map(|(name, range)| (name, range, false, false)).collect();
+        let new_direct = extend_tree(
+            &self.ctx,
+            resolver,
+            new_wanted,
+            &self.importer_id,
+            &ParentPkgAliases::root(self.parent_pkg_aliases.clone()),
+        )
+        .await?;
+        self.direct.extend(new_direct);
+        Ok(true)
     }
 
     /// The workspace root's own dependencies, when peers resolve from there.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -406,6 +406,117 @@ pub(crate) struct RequiredRound {
     walk_was_full: bool,
 }
 
+/// The importer's wanted direct deps and what the hoist state seeds from
+/// them. pnpm seeds `parentPkgAliases` from the importer's wanted
+/// dependencies, before any of them resolve, so a direct dep's own
+/// peer-shadowed dependency is dropped even when the shadowing sibling
+/// is still resolving — and stays seeded even when the sibling drops
+/// out (a skipped optional).
+struct DirectSeeds {
+    initial_wanted: Vec<WantedSpec>,
+    wanted_specifier_by_alias: BTreeMap<String, String>,
+    parent_pkg_aliases: HashSet<String>,
+}
+
+impl DirectSeeds {
+    fn of<DependencyGroupList>(
+        manifest: &PackageManifest,
+        dependency_groups: DependencyGroupList,
+        opts: &ResolveImporterOptions,
+    ) -> Result<Self, ResolveImporterError>
+    where
+        DependencyGroupList: IntoIterator<Item = DependencyGroup>,
+    {
+        let initial_wanted = importer_direct_wanted_specs(
+            manifest,
+            dependency_groups,
+            opts.auto_install_peers,
+            &opts.catalogs,
+        )?;
+        Ok(Self {
+            wanted_specifier_by_alias: initial_wanted
+                .iter()
+                .map(|(alias, range, ..)| (alias.clone(), range.clone()))
+                .collect(),
+            parent_pkg_aliases: initial_wanted.iter().map(|(alias, ..)| alias.clone()).collect(),
+            initial_wanted,
+        })
+    }
+}
+
+/// The peer versions the prior lockfile locked for the importer, and
+/// their names.
+struct LockedPeers {
+    versions: Arc<HashMap<String, HashSet<String>>>,
+    names: Arc<HashSet<String>>,
+}
+
+impl LockedPeers {
+    fn of(ctx: &TreeCtx, importer_id: &str) -> Self {
+        let versions = Arc::new(importer_locked_peer_versions(
+            ctx.workspace().wanted_lockfile().map(AsRef::as_ref),
+            importer_id,
+        ));
+        Self { names: Arc::new(versions.keys().cloned().collect()), versions }
+    }
+}
+
+/// What the hoist state keeps of the importer's options once the tree
+/// context has taken the rest.
+struct HoistSettings {
+    auto_install_peers: bool,
+    auto_install_peers_from_highest_match: bool,
+    resolve_peers_from_workspace_root: bool,
+    dedupe_peers: bool,
+    dedupe_peer_dependents: bool,
+    all_preferred_versions: Arc<PreferredVersions>,
+    override_bare_specifier: Option<Arc<DependencyOverrider>>,
+    exclude_links_from_lockfile: bool,
+    lockfile_dir: Option<std::path::PathBuf>,
+    project_dir: std::path::PathBuf,
+    modules_dir: Option<std::path::PathBuf>,
+    peers_suffix_max_length: usize,
+}
+
+impl ResolveImporterOptions {
+    /// The importer's tree context, and the settings the hoist state
+    /// keeps. The manifest hooks are workspace-wide; they live on the
+    /// shared [`WorkspaceTreeCtx`] and the caller (`resolve_importer`
+    /// or `resolve_workspace`) is responsible for setting them there
+    /// before handing the `Arc` over.
+    fn into_tree_ctx(
+        self,
+        importer_id: &str,
+        importer_order: usize,
+        workspace: Arc<WorkspaceTreeCtx>,
+    ) -> (TreeCtx, HoistSettings) {
+        let project_dir = self.base_opts.project_dir.clone();
+        let tree_lockfile_dir = self.lockfile_dir.clone().unwrap_or_else(|| project_dir.clone());
+        let ctx = TreeCtx::with_workspace(workspace, self.base_opts)
+            .with_lockfile_dir(&tree_lockfile_dir)
+            .with_importer_id(importer_id)
+            .with_importer_order(importer_order)
+            .with_patched_dependencies(self.patched_dependencies)
+            .with_resolution_mode(self.pick_lowest_direct, self.subdep_published_by)
+            .with_catalogs(self.catalogs);
+        let settings = HoistSettings {
+            auto_install_peers: self.auto_install_peers,
+            auto_install_peers_from_highest_match: self.auto_install_peers_from_highest_match,
+            resolve_peers_from_workspace_root: self.resolve_peers_from_workspace_root,
+            dedupe_peers: self.dedupe_peers,
+            dedupe_peer_dependents: self.dedupe_peer_dependents,
+            all_preferred_versions: self.all_preferred_versions,
+            override_bare_specifier: self.override_bare_specifier,
+            exclude_links_from_lockfile: self.exclude_links_from_lockfile,
+            lockfile_dir: self.lockfile_dir,
+            project_dir,
+            modules_dir: self.modules_dir,
+            peers_suffix_max_length: self.peers_suffix_max_length,
+        };
+        (ctx, settings)
+    }
+}
+
 impl ImporterHoistState {
     /// Resolve the importer's initial direct-dependency wave and set
     /// up the hoist-round state.
@@ -422,104 +533,60 @@ impl ImporterHoistState {
         DependencyGroupList: IntoIterator<Item = DependencyGroup>,
         Chain: Resolver + ?Sized,
     {
-        let ResolveImporterOptions {
-            auto_install_peers,
-            auto_install_peers_from_highest_match,
-            resolve_peers_from_workspace_root,
-            dedupe_peers,
-            dedupe_peer_dependents,
-            all_preferred_versions,
-            override_bare_specifier,
-            patched_dependencies,
-            base_opts,
-            pick_lowest_direct,
-            subdep_published_by,
-            catalogs,
-            exclude_links_from_lockfile,
-            lockfile_dir,
-            modules_dir,
-            peers_suffix_max_length,
-            catalog_server: _,
-            // The manifest hooks are workspace-wide; they live on the shared
-            // [`WorkspaceTreeCtx`] and the caller (`resolve_importer` or
-            // `resolve_workspace`) is responsible for setting them there before
-            // handing the `Arc` to this function.
-            manifest_hook: _,
-            overrides_hook: _,
-            pnpmfile_hook: _,
-        } = opts;
-
-        let initial_wanted = importer_direct_wanted_specs(
-            manifest,
-            dependency_groups,
-            auto_install_peers,
-            &catalogs,
-        )?;
-        let project_dir = base_opts.project_dir.clone();
-        let tree_lockfile_dir = lockfile_dir.clone().unwrap_or_else(|| project_dir.clone());
-        let mut ctx = TreeCtx::with_workspace(workspace, base_opts)
-            .with_lockfile_dir(&tree_lockfile_dir)
-            .with_importer_id(importer_id)
-            .with_importer_order(importer_order)
-            .with_patched_dependencies(patched_dependencies)
-            .with_resolution_mode(pick_lowest_direct, subdep_published_by)
-            .with_catalogs(catalogs);
-        let locked_peer_versions = Arc::new(importer_locked_peer_versions(
-            ctx.workspace().wanted_lockfile().map(AsRef::as_ref),
-            importer_id,
-        ));
-        let locked_peer_names = Arc::new(locked_peer_versions.keys().cloned().collect());
-        record_changed_direct_deps(&ctx, importer_id, &initial_wanted);
-        let wanted_specifier_by_alias: BTreeMap<String, String> = initial_wanted
-            .iter()
-            .map(|(alias, range, ..)| (alias.clone(), range.clone()))
-            .collect();
-        // pnpm seeds `parentPkgAliases` from the importer's wanted
-        // dependencies, before any of them resolve, so a direct dep's
-        // own peer-shadowed dependency is dropped even when the
-        // shadowing sibling is still resolving — and stays seeded even
-        // when the sibling drops out (a skipped optional).
-        let mut parent_pkg_aliases: HashSet<String> =
-            initial_wanted.iter().map(|(alias, ..)| alias.clone()).collect();
+        let mut seeds = DirectSeeds::of(manifest, dependency_groups, &opts)?;
+        let (mut ctx, settings) = opts.into_tree_ctx(importer_id, importer_order, workspace);
+        let locked = LockedPeers::of(&ctx, importer_id);
+        record_changed_direct_deps(&ctx, importer_id, &seeds.initial_wanted);
         let direct = extend_tree(
             &ctx,
             resolver,
-            initial_wanted,
+            std::mem::take(&mut seeds.initial_wanted),
             importer_id,
-            &ParentPkgAliases::root(parent_pkg_aliases.clone()),
+            &ParentPkgAliases::root(seeds.parent_pkg_aliases.clone()),
         )
         .await?;
-        parent_pkg_aliases.extend(direct.iter().map(|dep| dep.alias.clone()));
+        seeds.parent_pkg_aliases.extend(direct.iter().map(|dep| dep.alias.clone()));
         ctx.resolve_new_direct_deps_as_subdeps();
-        Ok(ImporterHoistState {
+        Ok(Self::assemble(importer_id, ctx, direct, seeds, locked, settings))
+    }
+
+    fn assemble(
+        importer_id: &str,
+        ctx: TreeCtx,
+        direct: Vec<DirectDep>,
+        seeds: DirectSeeds,
+        locked: LockedPeers,
+        settings: HoistSettings,
+    ) -> Self {
+        ImporterHoistState {
             importer_id: importer_id.to_string(),
             ctx,
             direct,
             workspace_root_deps: Arc::default(),
-            wanted_specifier_by_alias,
+            wanted_specifier_by_alias: seeds.wanted_specifier_by_alias,
             hoisted_peer_provider_node_ids: HashSet::default(),
             discovery_converged: false,
             converged_children_rewrites: 0,
             walked_direct_len: 0,
             walked_children_rewrites: 0,
             merged_missing: HashMap::default(),
-            parent_pkg_aliases,
+            parent_pkg_aliases: seeds.parent_pkg_aliases,
             all_missing_optional_peers: BTreeMap::new(),
-            preferred_versions_seed: all_preferred_versions,
-            locked_peer_names,
-            locked_peer_versions,
-            override_bare_specifier,
-            hoist_peers: auto_install_peers || dedupe_peer_dependents,
-            auto_install_peers,
-            auto_install_peers_from_highest_match,
-            resolve_peers_from_workspace_root,
-            peers_suffix_max_length,
-            dedupe_peers,
-            exclude_links_from_lockfile,
-            lockfile_dir,
-            project_dir,
-            modules_dir,
-        })
+            preferred_versions_seed: settings.all_preferred_versions,
+            locked_peer_names: locked.names,
+            locked_peer_versions: locked.versions,
+            override_bare_specifier: settings.override_bare_specifier,
+            hoist_peers: settings.auto_install_peers || settings.dedupe_peer_dependents,
+            auto_install_peers: settings.auto_install_peers,
+            auto_install_peers_from_highest_match: settings.auto_install_peers_from_highest_match,
+            resolve_peers_from_workspace_root: settings.resolve_peers_from_workspace_root,
+            peers_suffix_max_length: settings.peers_suffix_max_length,
+            dedupe_peers: settings.dedupe_peers,
+            exclude_links_from_lockfile: settings.exclude_links_from_lockfile,
+            lockfile_dir: settings.lockfile_dir,
+            project_dir: settings.project_dir,
+            modules_dir: settings.modules_dir,
+        }
     }
 
     pub(crate) fn importer_id(&self) -> &str {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -350,22 +350,51 @@ pub fn resolve_peers_workspace(
         PeerDiscoveryCaches::default(),
         false,
     );
+    let importers = sorted_importer_inputs(importers);
+    let peer_dependency_issues_by_importer =
+        walk_importers(&mut walker, &importers, resolve_peers_from_workspace_root);
+    walker.patch_pending_peer_edges();
+    let mut finished = finish_workspace_graph(&walker, &importers, lockfile_dir);
+    if dedupe_injected_deps_enabled {
+        dedupe_injected_deps(
+            &mut finished.graph,
+            &mut finished.direct_dependencies_by_importer,
+            &importers
+                .iter()
+                .map(|importer| (importer.id.clone(), importer.root_dir.clone()))
+                .collect(),
+            lockfile_dir,
+        );
+    }
+    if dedupe_peer_dependents_enabled {
+        dedupe_peer_dependents(&mut finished.graph, &mut finished.direct_dependencies_by_importer);
+    }
+    WorkspaceResolvePeersResult {
+        graph: finished.graph,
+        direct_dependencies_by_importer: finished.direct_dependencies_by_importer,
+        peer_dependency_issues_by_importer,
+        paths_by_node_id: finished.paths_by_node_id,
+    }
+}
 
-    // Walk importers in id order. Occurrence realization and the shared
-    // verdict caches are first-writer-wins, so a stable walk order makes
-    // the graph a function of the importer set rather than of the
-    // caller's listing order (pnpm/pnpm#13846).
-    let importers: Vec<&ImporterPeerInput> = {
-        let mut sorted: Vec<&ImporterPeerInput> = importers.iter().collect();
-        sorted.sort_by(|left, right| left.id.cmp(&right.id));
-        sorted
-    };
+/// Importers in id order. Occurrence realization and the shared verdict
+/// caches are first-writer-wins, so a stable walk order makes the graph
+/// a function of the importer set rather than of the caller's listing
+/// order (pnpm/pnpm#13846).
+fn sorted_importer_inputs(importers: &[ImporterPeerInput]) -> Vec<&ImporterPeerInput> {
+    let mut sorted: Vec<&ImporterPeerInput> = importers.iter().collect();
+    sorted.sort_by(|left, right| left.id.cmp(&right.id));
+    sorted
+}
 
-    let mut direct_dependencies_by_importer: BTreeMap<String, BTreeMap<String, DepPath>> =
-        BTreeMap::new();
-    let mut peer_dependency_issues_by_importer: BTreeMap<String, PeerDependencyIssues> =
-        BTreeMap::new();
-    let mut importer_root_dirs: BTreeMap<String, PathBuf> = BTreeMap::new();
+/// Walk every importer, with the root importer's direct deps as the
+/// fallback parents when peers resolve from the workspace root, and
+/// collect the importers whose peers came out bad or missing.
+fn walk_importers(
+    walker: &mut Walker<'_>,
+    importers: &[&ImporterPeerInput],
+    resolve_peers_from_workspace_root: bool,
+) -> BTreeMap<String, PeerDependencyIssues> {
     let root_importer = resolve_peers_from_workspace_root
         .then(|| importers.iter().copied().find(|importer| importer.id == "."))
         .flatten();
@@ -377,57 +406,55 @@ pub fn resolve_peers_workspace(
         (walker.opts.project_dir, walker.opts.modules_dir) = previous_dirs;
         parents
     });
-    for importer in &importers {
-        importer_root_dirs.insert(importer.id.clone(), importer.root_dir.clone());
-        let issues = walk_importer(&mut walker, importer, root_importer, root_parents.as_ref());
+    let mut issues_by_importer = BTreeMap::new();
+    for importer in importers {
+        let issues = walk_importer(walker, importer, root_importer, root_parents.as_ref());
         if !issues.bad.is_empty() || !issues.missing.is_empty() {
-            peer_dependency_issues_by_importer.insert(importer.id.clone(), issues);
+            issues_by_importer.insert(importer.id.clone(), issues);
         }
     }
-    walker.patch_pending_peer_edges();
-    // Recompute depPaths with full peer suffixes once, after every
-    // importer is walked, then rebuild the graph and re-key each
-    // importer's direct deps.
+    issues_by_importer
+}
+
+struct FinishedWorkspaceGraph {
+    graph: DependenciesGraph,
+    direct_dependencies_by_importer: BTreeMap<String, BTreeMap<String, DepPath>>,
+    paths_by_node_id: HashMap<NodeId, DepPath>,
+}
+
+/// Recompute depPaths with full peer suffixes once, after every importer
+/// is walked, then rebuild the graph and re-key each importer's direct
+/// deps.
+fn finish_workspace_graph(
+    walker: &Walker<'_>,
+    importers: &[&ImporterPeerInput],
+    lockfile_dir: &Path,
+) -> FinishedWorkspaceGraph {
     let final_dep_paths = walker.build_final_dep_paths();
-    for importer in &importers {
-        let anchor = crate::link_target::ImporterAnchor::new(&importer.root_dir, lockfile_dir);
-        let direct_by_alias: BTreeMap<String, DepPath> = importer
-            .direct
-            .iter()
-            .map(|dep| {
-                let dep_path = walker.final_dep_path_of(&dep.node_id, &final_dep_paths);
-                let dep_path = importer_relative_link_dep_path(
-                    &dep_path,
-                    &anchor,
-                    Some(lockfile_dir),
-                    Some(&importer.root_dir),
-                );
-                (dep.alias.clone(), dep_path)
-            })
-            .collect();
-        direct_dependencies_by_importer.insert(importer.id.clone(), direct_by_alias);
-    }
-    let mut graph = walker.build_final_graph(&final_dep_paths);
-    let paths_by_node_id = walker.final_paths_by_node_id(&final_dep_paths);
-
-    if dedupe_injected_deps_enabled {
-        dedupe_injected_deps(
-            &mut graph,
-            &mut direct_dependencies_by_importer,
-            &importer_root_dirs,
-            lockfile_dir,
-        );
-    }
-
-    if dedupe_peer_dependents_enabled {
-        dedupe_peer_dependents(&mut graph, &mut direct_dependencies_by_importer);
-    }
-
-    WorkspaceResolvePeersResult {
-        graph,
+    let direct_dependencies_by_importer = importers
+        .iter()
+        .map(|importer| {
+            let anchor = crate::link_target::ImporterAnchor::new(&importer.root_dir, lockfile_dir);
+            let direct_by_alias = importer
+                .direct
+                .iter()
+                .map(|dep| {
+                    let dep_path = importer_relative_link_dep_path(
+                        &walker.final_dep_path_of(&dep.node_id, &final_dep_paths),
+                        &anchor,
+                        Some(lockfile_dir),
+                        Some(&importer.root_dir),
+                    );
+                    (dep.alias.clone(), dep_path)
+                })
+                .collect();
+            (importer.id.clone(), direct_by_alias)
+        })
+        .collect();
+    FinishedWorkspaceGraph {
+        graph: walker.build_final_graph(&final_dep_paths),
         direct_dependencies_by_importer,
-        peer_dependency_issues_by_importer,
-        paths_by_node_id,
+        paths_by_node_id: walker.final_paths_by_node_id(&final_dep_paths),
     }
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
@@ -8,7 +8,7 @@ use crate::{
     node_id::NodeId,
     resolve_peers::{
         context::{ParentPkgInfo, ParentRef, ParentRefs, SharedChain},
-        walker::{MissingPeerInfo, NodeOutput, SubtreeMissingByPkg, Walker},
+        walker::{MissingPeerInfo, NodeOutput, NodeWalkContext, SubtreeMissingByPkg, Walker},
     },
     resolved_tree::{AncestorIds, ChildEdge, DependenciesTreeNode, TreeChildren},
 };
@@ -109,11 +109,7 @@ pub(super) struct DeferredChildContext<'a> {
     pub(super) edge: &'a ChildEdge,
     pub(super) node_id: NodeId,
     pub(super) parent_ids: &'a AncestorIds,
-    pub(super) parent_refs: &'a Arc<ParentRefs>,
-    pub(super) parent_dep_paths: &'a Arc<HashMap<String, ParentPkgInfo>>,
-    pub(super) chain_names: &'a SharedChain<String>,
-    pub(super) parent_node_ids: &'a SharedChain<NodeId>,
-    pub(super) parent_pkg_ids: &'a SharedChain<String>,
+    pub(super) walk: &'a NodeWalkContext<'a>,
     pub(super) depth: i32,
 }
 
@@ -527,7 +523,7 @@ impl Walker<'_> {
         &mut self,
         context: &DeferredChildContext<'_>,
     ) -> NodeOutput {
-        match self.deferred_child_resolution(context.parent_refs, &context.edge.pkg_id) {
+        match self.deferred_child_resolution(context.walk.parent_refs, &context.edge.pkg_id) {
             DeferredChildResolution::Pure(dep_path) => self.peerless_output(dep_path),
             DeferredChildResolution::Cached(cached) => cached.output,
             DeferredChildResolution::Materialize(pkg_id) => {
@@ -540,14 +536,7 @@ impl Walker<'_> {
                         true,
                     ),
                 );
-                let output = self.resolve_node(
-                    &context.node_id,
-                    context.parent_refs,
-                    context.parent_dep_paths,
-                    context.chain_names,
-                    context.parent_node_ids,
-                    context.parent_pkg_ids,
-                );
+                let output = self.resolve_node(&context.node_id, context.walk);
                 if !self.parent_pkgs_of_node.contains_key(&context.node_id)
                     && !should_retain_materialized_node(
                         &self.retained_peer_node_ids,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
@@ -145,6 +145,13 @@ pub(super) struct PeerProviderChildren {
     pub(super) edge_indices_by_name: HashMap<String, Vec<usize>>,
 }
 
+/// A lazy node whose provider children are previewed.
+struct LazyProviders {
+    parent_ids: AncestorIds,
+    pkg_id: std::sync::Arc<str>,
+    depth: i32,
+}
+
 pub(super) struct UndoRealize {
     newly_inserted: Vec<NodeId>,
     prev_parent_ids: AncestorIds,
@@ -518,50 +525,39 @@ impl Walker<'_> {
 
     pub(super) fn resolve_deferred_child(
         &mut self,
-        context: DeferredChildContext<'_>,
+        context: &DeferredChildContext<'_>,
     ) -> NodeOutput {
-        let DeferredChildContext {
-            edge,
-            node_id,
-            parent_ids,
-            parent_refs,
-            parent_dep_paths,
-            chain_names,
-            parent_node_ids,
-            parent_pkg_ids,
-            depth,
-        } = context;
-        match self.deferred_child_resolution(parent_refs, &edge.pkg_id) {
+        match self.deferred_child_resolution(context.parent_refs, &context.edge.pkg_id) {
             DeferredChildResolution::Pure(dep_path) => self.peerless_output(dep_path),
             DeferredChildResolution::Cached(cached) => cached.output,
             DeferredChildResolution::Materialize(pkg_id) => {
                 self.tree.dependencies_tree.insert(
-                    node_id.clone(),
+                    context.node_id.clone(),
                     DependenciesTreeNode::new(
                         pkg_id,
-                        TreeChildren::Lazy { parent_ids: parent_ids.clone() },
-                        depth,
+                        TreeChildren::Lazy { parent_ids: context.parent_ids.clone() },
+                        context.depth,
                         true,
                     ),
                 );
                 let output = self.resolve_node(
-                    &node_id,
-                    parent_refs,
-                    parent_dep_paths,
-                    chain_names,
-                    parent_node_ids,
-                    parent_pkg_ids,
+                    &context.node_id,
+                    context.parent_refs,
+                    context.parent_dep_paths,
+                    context.chain_names,
+                    context.parent_node_ids,
+                    context.parent_pkg_ids,
                 );
-                if !self.parent_pkgs_of_node.contains_key(&node_id)
+                if !self.parent_pkgs_of_node.contains_key(&context.node_id)
                     && !should_retain_materialized_node(
                         &self.retained_peer_node_ids,
                         Some(&output),
-                        &node_id,
+                        &context.node_id,
                     )
                 {
-                    self.tree.dependencies_tree.remove(&node_id);
-                    self.node_dep_paths.remove(&node_id);
-                    self.visited_this_call.remove(&node_id);
+                    self.tree.dependencies_tree.remove(&context.node_id);
+                    self.node_dep_paths.remove(&context.node_id);
+                    self.visited_this_call.remove(&context.node_id);
                 }
                 output
             }
@@ -612,45 +608,54 @@ impl Walker<'_> {
         &mut self,
         node_id: &NodeId,
     ) -> (BTreeMap<String, NodeId>, Option<UndoRealize>) {
-        let (parent_ids, pkg_id, depth) = {
-            let node = &self.tree.dependencies_tree[node_id];
-            match &node.children {
-                TreeChildren::Realized(children) => {
-                    let providers = children
-                        .iter()
-                        .filter(|(alias, child_node_id)| {
-                            self.tree
-                                .dependencies_tree
-                                .get(*child_node_id)
-                                .and_then(|child| {
-                                    self.tree.packages.get(&child.resolved_package_id)
-                                })
-                                .is_some_and(|pkg| self.is_peer_relevant(alias, pkg))
-                        })
-                        .map(|(alias, child_node_id)| (alias.clone(), child_node_id.clone()))
-                        .collect();
-                    return (providers, None);
-                }
-                TreeChildren::Lazy { parent_ids } => (
-                    parent_ids.clone(),
-                    std::sync::Arc::<str>::clone(&node.resolved_package_id),
-                    node.depth,
-                ),
-            }
-        };
-        let children = self.tree.children_by_id.get(&pkg_id).cloned().unwrap_or_default();
+        let node = &self.tree.dependencies_tree[node_id];
+        match &node.children {
+            TreeChildren::Realized(children) => (self.realized_provider_children(children), None),
+            TreeChildren::Lazy { parent_ids } => self.lazy_provider_children(LazyProviders {
+                parent_ids: parent_ids.clone(),
+                pkg_id: std::sync::Arc::<str>::clone(&node.resolved_package_id),
+                depth: node.depth,
+            }),
+        }
+    }
+
+    fn realized_provider_children(
+        &self,
+        children: &BTreeMap<String, NodeId>,
+    ) -> BTreeMap<String, NodeId> {
+        children
+            .iter()
+            .filter(|(alias, child_node_id)| {
+                self.tree
+                    .dependencies_tree
+                    .get(*child_node_id)
+                    .and_then(|child| self.tree.packages.get(&child.resolved_package_id))
+                    .is_some_and(|pkg| self.is_peer_relevant(alias, pkg))
+            })
+            .map(|(alias, child_node_id)| (alias.clone(), child_node_id.clone()))
+            .collect()
+    }
+
+    /// Insert a lazy node's peer-relevant children as lazy nodes of
+    /// their own, so the providers can be previewed without realizing
+    /// the whole children map.
+    fn lazy_provider_children(
+        &mut self,
+        lazy: LazyProviders,
+    ) -> (BTreeMap<String, NodeId>, Option<UndoRealize>) {
+        let children = self.tree.children_by_id.get(&lazy.pkg_id).cloned().unwrap_or_default();
         let provider_edge_indices = self
             .peer_provider_children_by_pkg_id
-            .get(&*pkg_id)
+            .get(&*lazy.pkg_id)
             .map_or(&[][..], |providers| providers.relevant_edge_indices.as_slice());
         let canonical_scc = self.canonical_scc();
-        let full_chain = parent_ids.pushed(pkg_id.to_string());
+        let full_chain = lazy.parent_ids.pushed(lazy.pkg_id.to_string());
         let mut providers = BTreeMap::new();
         let mut newly_inserted = Vec::new();
         for &edge_index in provider_edge_indices {
             let edge = &children[edge_index];
             let Some(pkg) = self.tree.packages.get(&edge.pkg_id) else { continue };
-            if Self::cuts_cycle_edge(&canonical_scc, &pkg_id, &edge.pkg_id) {
+            if Self::cuts_cycle_edge(&canonical_scc, &lazy.pkg_id, &edge.pkg_id) {
                 continue;
             }
             let child_node_id =
@@ -661,7 +666,7 @@ impl Walker<'_> {
                     DependenciesTreeNode::new(
                         std::sync::Arc::<str>::clone(&edge.pkg_id),
                         TreeChildren::Lazy { parent_ids: full_chain.clone() },
-                        depth + 1,
+                        lazy.depth + 1,
                         true,
                     ),
                 );
@@ -669,7 +674,7 @@ impl Walker<'_> {
             }
             providers.insert(edge.alias.clone(), child_node_id);
         }
-        (providers, Some(UndoRealize { newly_inserted, prev_parent_ids: parent_ids }))
+        (providers, Some(UndoRealize { newly_inserted, prev_parent_ids: lazy.parent_ids }))
     }
 
     /// Realize the `(alias → NodeId)` children of `node_id` if it's

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/discovery.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/discovery.rs
@@ -10,7 +10,7 @@ use crate::{
         HoistMissingScope, ResolvePeersOptions,
         cache::{PeerProviderChildren, PeersCacheItem},
         context::{ChainSuffixMemo, CurrentProviderSource, ParentPkgInfo, SharedChain},
-        walker::{MissingSummary, NodeOutput, Walker},
+        walker::{MissingSummary, NodeOutput, RootWalk, Walker},
     },
     resolved_tree::{DirectDep, ResolvedTree},
 };
@@ -167,12 +167,7 @@ fn discover_peers(
     }];
     let mut walker =
         Walker::new(tree, opts, HashMap::default(), current_provider_sources, caches, true);
-
-    let importer_parents = Arc::new(walker.build_importer_parents_from(parents_direct));
-    let parent_chain_names = SharedChain::default();
-    let parent_node_ids = SharedChain::default();
-    let parent_pkg_ids_chain = SharedChain::default();
-    let importer_parent_dep_paths = walker.parent_dep_paths_from_refs(&importer_parents);
+    let root = RootWalk::of(&walker, parents_direct);
     let (own_direct, provider_direct): (Vec<&DirectDep>, Vec<&DirectDep>) = walk_direct
         .iter()
         .partition(|dep| !walker.opts.hoisted_peer_provider_node_ids.contains(&dep.node_id));
@@ -181,29 +176,11 @@ fn discover_peers(
         walker.remember_parent_context_if_peer_provider(
             &dep.alias,
             &dep.node_id,
-            &importer_parent_dep_paths,
+            &root.parent_dep_paths,
         );
     }
-    let fold_output = |result: &mut PeerDiscoveryResult, output: NodeOutput| {
-        for (peer_alias, peer_node_id) in output.auto_install_resolved_peers {
-            result.resolved_peer_providers_by_alias.insert(peer_alias, peer_node_id);
-        }
-        if let Some(summary) = output.subtree_missing_by_pkg
-            && !result.missing_summaries.iter().any(|seen| Arc::ptr_eq(seen, &summary))
-        {
-            result.missing_summaries.push(summary);
-        }
-    };
     for dep in &own_direct {
-        let output = walker.resolve_node(
-            &dep.node_id,
-            &importer_parents,
-            &importer_parent_dep_paths,
-            &parent_chain_names,
-            &parent_node_ids,
-            &parent_pkg_ids_chain,
-        );
-        fold_output(&mut result, output);
+        result.fold(walker.resolve_node(&dep.node_id, &root.context()));
     }
     // See ResolvePeersOptions::hoisted_peer_provider_node_ids — a
     // provider is normally resolved at its tree position during the
@@ -216,22 +193,27 @@ fn discover_peers(
         walker.remember_parent_context_if_peer_provider(
             &dep.alias,
             &dep.node_id,
-            &importer_parent_dep_paths,
+            &root.parent_dep_paths,
         );
-        let output = walker.resolve_node(
-            &dep.node_id,
-            &importer_parents,
-            &importer_parent_dep_paths,
-            &parent_chain_names,
-            &parent_node_ids,
-            &parent_pkg_ids_chain,
-        );
-        fold_output(&mut result, output);
+        result.fold(walker.resolve_node(&dep.node_id, &root.context()));
     }
-    walker.drain_pending_canonical_nodes(&importer_parents, &importer_parent_dep_paths);
+    walker.drain_pending_canonical_nodes(&root.importer_parents, &root.parent_dep_paths);
     result.peer_dependency_issues = std::mem::take(&mut walker.issues);
     result.missing_ancestor_pkg_ids = std::mem::take(&mut walker.missing_ancestor_pkg_ids);
     (result, walker.into_caches())
+}
+
+impl PeerDiscoveryResult {
+    fn fold(&mut self, output: NodeOutput) {
+        for (peer_alias, peer_node_id) in output.auto_install_resolved_peers {
+            self.resolved_peer_providers_by_alias.insert(peer_alias, peer_node_id);
+        }
+        if let Some(summary) = output.subtree_missing_by_pkg
+            && !self.missing_summaries.iter().any(|seen| Arc::ptr_eq(seen, &summary))
+        {
+            self.missing_summaries.push(summary);
+        }
+    }
 }
 
 pub(crate) fn apply_hoist_missing_scope(

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
@@ -191,60 +191,36 @@ impl Walker<'_> {
     /// depPath-keyed graph, and the [`NodeRecord`] the post-walk rebuild
     /// consumes. A discovery pass runs neither of the passes that read
     /// these, so it never calls this.
-    pub(super) fn record_walked_node(&mut self, node: WalkedNode<'_>) {
-        let WalkedNode {
-            node_id,
-            pkg,
-            dep_path,
-            parent_node_ids,
-            parent_pkg_ids_chain,
-            children,
-            child_dep_paths,
-            all_resolved_peers,
-            all_missing_peers,
-            own_resolved_peers,
-            depth,
-            installable,
-            is_pure,
-        } = node;
-
+    pub(super) fn record_walked_node(&mut self, mut node: WalkedNode<'_>) {
         // Seeds both the node's record edges and its graph children, so
         // it is computed once: a second call would rescan the ancestor
         // chain and re-realize every matching occurrence's children.
-        let mut record_edges =
-            self.previously_resolved_children(parent_node_ids, parent_pkg_ids_chain, &pkg.id);
-        let graph_children =
-            self.graph_children_of(dep_path, &record_edges, child_dep_paths, all_resolved_peers);
+        let mut record_edges = self.previously_resolved_children(
+            node.parent_node_ids,
+            node.parent_pkg_ids_chain,
+            &node.pkg.id,
+        );
+        let graph_children = self.graph_children_of(
+            node.dep_path,
+            &record_edges,
+            std::mem::take(&mut node.child_dep_paths),
+            node.all_resolved_peers,
+        );
         let transitive_peer_dependencies =
-            transitive_peer_names(pkg, all_resolved_peers, all_missing_peers);
-
-        // Finish this node's NodeId-level edges for the post-walk
-        // [`Walker::build_final_dep_paths`] rebuild: its regular children
-        // overlaid with its *own* resolved peers — this node's own peer
-        // resolution, not the descendants' peers bubbled up for the
-        // suffix. A peer a descendant resolved (e.g. `debug`'s optional
-        // `supports-color`) is symlinked at the descendant that declares
-        // it, so it must not appear in this node's dependencies.
-        let remapped_backedges = self.remapped_backedge_children(&pkg.id, children, depth + 1);
-        record_edges.extend(children.clone());
-        for (alias, node_id) in remapped_backedges {
-            record_edges.insert(alias, node_id);
-        }
-        for (peer_alias, peer_node_id) in own_resolved_peers {
-            record_edges.insert(peer_alias.clone(), peer_node_id.clone());
-        }
-        let optional_child_aliases = self.optional_child_aliases(&pkg.id, &record_edges);
+            transitive_peer_names(node.pkg, node.all_resolved_peers, node.all_missing_peers);
+        self.extend_record_edges(&mut record_edges, &node);
+        let optional_child_aliases = self.optional_child_aliases(&node.pkg.id, &record_edges);
         let record_order = self.next_record_order;
         self.next_record_order += 1;
         self.node_records.insert(
-            node_id.clone(),
+            node.node_id.clone(),
             NodeRecord {
                 edges: record_edges,
                 optional_child_aliases: optional_child_aliases.clone(),
                 transitive_peer_dependencies: transitive_peer_dependencies.clone(),
-                depth,
-                installable,
-                is_pure,
+                depth: node.depth,
+                installable: node.installable,
+                is_pure: node.is_pure,
                 order: record_order,
             },
         );
@@ -253,26 +229,45 @@ impl Walker<'_> {
         // graph entry. On a conflict, keep the entry with the smallest
         // `depth` so install order matches.
         self.graph
-            .entry(dep_path.clone())
-            .and_modify(|node| {
-                if node.depth > depth {
-                    node.depth = depth;
+            .entry(node.dep_path.clone())
+            .and_modify(|entry| {
+                if entry.depth > node.depth {
+                    entry.depth = node.depth;
                 }
             })
             .or_insert(DependenciesGraphNode {
-                dep_path: dep_path.clone(),
-                resolved_package_id: pkg.id.to_string(),
-                resolve_result: Arc::clone(&pkg.result),
+                dep_path: node.dep_path.clone(),
+                resolved_package_id: node.pkg.id.to_string(),
+                resolve_result: Arc::clone(&node.pkg.result),
                 children: graph_children,
                 optional_children: optional_child_aliases,
-                peer_dependencies: pkg.peer_dependencies.clone(),
+                peer_dependencies: node.pkg.peer_dependencies.clone(),
                 transitive_peer_dependencies,
-                resolved_peer_names: all_resolved_peers.keys().cloned().collect(),
-                depth,
-                installable,
-                is_pure,
-                optional: pkg.optional,
+                resolved_peer_names: node.all_resolved_peers.keys().cloned().collect(),
+                depth: node.depth,
+                installable: node.installable,
+                is_pure: node.is_pure,
+                optional: node.pkg.optional,
             });
+    }
+
+    /// Finish this node's NodeId-level edges for the post-walk
+    /// [`Walker::build_final_dep_paths`] rebuild: its regular children
+    /// overlaid with its *own* resolved peers — this node's own peer
+    /// resolution, not the descendants' peers bubbled up for the
+    /// suffix. A peer a descendant resolved (e.g. `debug`'s optional
+    /// `supports-color`) is symlinked at the descendant that declares
+    /// it, so it must not appear in this node's dependencies.
+    fn extend_record_edges(&mut self, edges: &mut BTreeMap<String, NodeId>, node: &WalkedNode<'_>) {
+        let remapped_backedges =
+            self.remapped_backedge_children(&node.pkg.id, node.children, node.depth + 1);
+        edges.extend(node.children.clone());
+        for (alias, node_id) in remapped_backedges {
+            edges.insert(alias, node_id);
+        }
+        for (peer_alias, peer_node_id) in node.own_resolved_peers {
+            edges.insert(peer_alias.clone(), peer_node_id.clone());
+        }
     }
 
     /// The children's depPath edges become this node's graph children.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -2553,11 +2553,13 @@ fn a_backedge_cut_subtree_is_pure() {
     for dep in &direct {
         walker.resolve_node(
             &dep.node_id,
-            &importer_parents,
-            &importer_parent_dep_paths,
-            &crate::resolve_peers::context::SharedChain::default(),
-            &crate::resolve_peers::context::SharedChain::default(),
-            &crate::resolve_peers::context::SharedChain::default(),
+            &crate::resolve_peers::walker::NodeWalkContext {
+                parent_refs: &importer_parents,
+                parent_dep_paths: &importer_parent_dep_paths,
+                chain_names: &crate::resolve_peers::context::SharedChain::default(),
+                parent_node_ids: &crate::resolve_peers::context::SharedChain::default(),
+                parent_pkg_ids: &crate::resolve_peers::context::SharedChain::default(),
+            },
         );
     }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -12,7 +12,7 @@ use crate::{
         ResolvePeersOptions, ResolvePeersResult,
         cache::{
             CacheHitContext, DeferredChildContext, PeerProviderChildren, PeersCacheItem,
-            merge_realize_undo,
+            UndoRealize, merge_realize_undo,
         },
         context::{
             ComparablePeerRange, CurrentProviderSource, ParentPkgInfo, ParentRef, ParentRefs,
@@ -329,11 +329,13 @@ impl<'tree> Walker<'tree> {
             }
             self.resolve_node(
                 &node_id,
-                importer_parents,
-                importer_parent_dep_paths,
-                &SharedChain::default(),
-                &SharedChain::default(),
-                &SharedChain::default(),
+                &NodeWalkContext {
+                    parent_refs: importer_parents,
+                    parent_dep_paths: importer_parent_dep_paths,
+                    chain_names: &SharedChain::default(),
+                    parent_node_ids: &SharedChain::default(),
+                    parent_pkg_ids: &SharedChain::default(),
+                },
             );
         }
         self.in_canonical_drain = false;
@@ -505,6 +507,93 @@ pub(super) struct NodeWalkContext<'a> {
     pub(super) parent_pkg_ids: &'a SharedChain<String>,
 }
 
+/// The importer-level walk context: the direct deps' parents and the
+/// empty ancestor chains.
+pub(super) struct RootWalk {
+    pub(super) importer_parents: Arc<ParentRefs>,
+    pub(super) parent_dep_paths: Arc<HashMap<String, ParentPkgInfo>>,
+    chain_names: SharedChain<String>,
+    parent_node_ids: SharedChain<NodeId>,
+    parent_pkg_ids: SharedChain<String>,
+}
+
+impl RootWalk {
+    pub(super) fn of(walker: &Walker<'_>, parents_direct: &[DirectDep]) -> Self {
+        let importer_parents = Arc::new(walker.build_importer_parents_from(parents_direct));
+        let parent_dep_paths = walker.parent_dep_paths_from_refs(&importer_parents);
+        Self {
+            importer_parents,
+            parent_dep_paths,
+            chain_names: SharedChain::default(),
+            parent_node_ids: SharedChain::default(),
+            parent_pkg_ids: SharedChain::default(),
+        }
+    }
+
+    pub(super) fn context(&self) -> NodeWalkContext<'_> {
+        NodeWalkContext {
+            parent_refs: &self.importer_parents,
+            parent_dep_paths: &self.parent_dep_paths,
+            chain_names: &self.chain_names,
+            parent_node_ids: &self.parent_node_ids,
+            parent_pkg_ids: &self.parent_pkg_ids,
+        }
+    }
+}
+
+/// The occurrence's package and tree-node facts, read once on entry.
+struct NodeEntry {
+    pkg: Arc<ResolvedPackage>,
+    pkg_name: String,
+    depth: i32,
+    installable: bool,
+    provider_children: BTreeMap<String, NodeId>,
+    preview_undo: Option<UndoRealize>,
+}
+
+/// The ancestor chains the node's children walk under.
+struct ChildChains {
+    names: SharedChain<String>,
+    node_ids: SharedChain<NodeId>,
+    pkg_ids: SharedChain<String>,
+}
+
+impl ChildChains {
+    fn context<'c>(
+        &'c self,
+        parent_refs: &'c Arc<ParentRefs>,
+        parent_dep_paths: &'c Arc<HashMap<String, ParentPkgInfo>>,
+    ) -> NodeWalkContext<'c> {
+        NodeWalkContext {
+            parent_refs,
+            parent_dep_paths,
+            chain_names: &self.names,
+            parent_node_ids: &self.node_ids,
+            parent_pkg_ids: &self.pkg_ids,
+        }
+    }
+}
+
+/// What walking a node's children produced.
+struct ChildrenWalk {
+    outputs: ChildOutputs,
+    children_map: Arc<BTreeMap<String, NodeId>>,
+    discovery_children: Option<(Arc<Vec<ChildEdge>>, AncestorIds)>,
+    realize_undo: Option<UndoRealize>,
+    chains: ChildChains,
+}
+
+/// The node's peer verdict, shared with its caches and records.
+struct SettledPeers {
+    dep_path: DepPath,
+    own_resolved: HashMap<String, NodeId>,
+    all_resolved: Arc<HashMap<String, NodeId>>,
+    all_missing: Arc<HashMap<String, MissingPeerInfo>>,
+    missing_from_children: Arc<HashMap<String, MissingPeerInfo>>,
+    subtree_missing_by_pkg: SubtreeMissingByPkg,
+    is_pure: bool,
+}
+
 /// The still-lazy children a discovery walk descends into.
 #[derive(Clone, Copy)]
 struct DeferredChildren<'a> {
@@ -568,62 +657,20 @@ struct NodePeersContext<'a> {
 
 impl Walker<'_> {
     pub(super) fn walk(mut self) -> ResolvePeersResult {
-        let importer_parents = Arc::new(self.build_importer_parents());
-        let parent_chain_names = SharedChain::default();
-        let parent_node_ids = SharedChain::default();
-        let parent_pkg_ids_chain = SharedChain::default();
-        let mut direct_by_alias = BTreeMap::new();
         // Clone direct deps into an owned `Vec` so the recursion
         // below can mutate `self.tree` (realising lazy children)
         // without conflicting with this loop's borrow of
         // `self.tree.direct`.
         let direct: Vec<DirectDep> = self.tree.direct.clone();
-        let importer_parent_dep_paths = self.parent_dep_paths_from_refs(&importer_parents);
-        let importer_walk = NodeWalkContext {
-            parent_refs: &importer_parents,
-            parent_dep_paths: &importer_parent_dep_paths,
-            chain_names: &parent_chain_names,
-            parent_node_ids: &parent_node_ids,
-            parent_pkg_ids: &parent_pkg_ids_chain,
-        };
-        let (own_direct, provider_direct): (Vec<&DirectDep>, Vec<&DirectDep>) = direct
-            .iter()
-            .partition(|dep| !self.opts.hoisted_peer_provider_node_ids.contains(&dep.node_id));
-        for dep in &own_direct {
-            self.remember_parent_context_if_peer_provider(
-                &dep.alias,
-                &dep.node_id,
-                &importer_parent_dep_paths,
-            );
-        }
-        for dep in &own_direct {
-            self.resolve_importer_dep(dep, &importer_walk);
-        }
-        self.drain_pending_canonical_nodes(&importer_parents, &importer_parent_dep_paths);
-        self.resolve_pruned_peer_providers(&provider_direct, &importer_walk);
-        self.drain_pending_canonical_nodes(&importer_parents, &importer_parent_dep_paths);
+        let root = RootWalk::of(&self, &direct);
+        self.walk_direct(&direct, &root);
         self.patch_pending_peer_edges();
         // Recompute depPaths so each resolved peer carries its full
         // suffix (the cycle fallback during the walk collapses peers
         // that are walk-ancestors), then rebuild the graph from the
         // per-node records keyed by the corrected depPaths.
         let final_dep_paths = self.build_final_dep_paths();
-        let anchor = match (self.opts.project_dir.as_deref(), self.opts.lockfile_dir.as_deref()) {
-            (Some(project_dir), Some(lockfile_dir)) => {
-                crate::link_target::ImporterAnchor::new(project_dir, lockfile_dir)
-            }
-            _ => crate::link_target::ImporterAnchor::default(),
-        };
-        for dep in &direct {
-            let dep_path = self.final_dep_path_of(&dep.node_id, &final_dep_paths);
-            let dep_path = importer_relative_link_dep_path(
-                &dep_path,
-                &anchor,
-                self.opts.lockfile_dir.as_deref(),
-                self.opts.project_dir.as_deref(),
-            );
-            direct_by_alias.insert(dep.alias.clone(), dep_path);
-        }
+        let direct_by_alias = self.importer_direct_dep_paths(&direct, &final_dep_paths);
         let graph = self.build_final_graph(&final_dep_paths);
         let paths_by_node_id = self.final_paths_by_node_id(&final_dep_paths);
         ResolvePeersResult {
@@ -636,15 +683,55 @@ impl Walker<'_> {
         }
     }
 
+    /// The importer's own direct deps first, then the pruned peer
+    /// providers at root context, draining the canonical queue after
+    /// each.
+    fn walk_direct(&mut self, direct: &[DirectDep], root: &RootWalk) {
+        let (own_direct, provider_direct): (Vec<&DirectDep>, Vec<&DirectDep>) = direct
+            .iter()
+            .partition(|dep| !self.opts.hoisted_peer_provider_node_ids.contains(&dep.node_id));
+        for dep in &own_direct {
+            self.remember_parent_context_if_peer_provider(
+                &dep.alias,
+                &dep.node_id,
+                &root.parent_dep_paths,
+            );
+        }
+        for dep in &own_direct {
+            self.resolve_importer_dep(dep, &root.context());
+        }
+        self.drain_pending_canonical_nodes(&root.importer_parents, &root.parent_dep_paths);
+        self.resolve_pruned_peer_providers(&provider_direct, &root.context());
+        self.drain_pending_canonical_nodes(&root.importer_parents, &root.parent_dep_paths);
+    }
+
+    fn importer_direct_dep_paths(
+        &self,
+        direct: &[DirectDep],
+        final_dep_paths: &HashMap<NodeId, DepPath>,
+    ) -> BTreeMap<String, DepPath> {
+        let anchor = match (self.opts.project_dir.as_deref(), self.opts.lockfile_dir.as_deref()) {
+            (Some(project_dir), Some(lockfile_dir)) => {
+                crate::link_target::ImporterAnchor::new(project_dir, lockfile_dir)
+            }
+            _ => crate::link_target::ImporterAnchor::default(),
+        };
+        direct
+            .iter()
+            .map(|dep| {
+                let dep_path = importer_relative_link_dep_path(
+                    &self.final_dep_path_of(&dep.node_id, final_dep_paths),
+                    &anchor,
+                    self.opts.lockfile_dir.as_deref(),
+                    self.opts.project_dir.as_deref(),
+                );
+                (dep.alias.clone(), dep_path)
+            })
+            .collect()
+    }
+
     pub(super) fn resolve_importer_dep(&mut self, dep: &DirectDep, walk: &NodeWalkContext<'_>) {
-        let output = self.resolve_node(
-            &dep.node_id,
-            walk.parent_refs,
-            walk.parent_dep_paths,
-            walk.chain_names,
-            walk.parent_node_ids,
-            walk.parent_pkg_ids,
-        );
+        let output = self.resolve_node(&dep.node_id, walk);
         for (peer_alias, peer_node_id) in output.auto_install_resolved_peers {
             self.resolved_peer_providers_by_alias.insert(peer_alias, peer_node_id);
         }
@@ -696,10 +783,6 @@ impl Walker<'_> {
     /// when [`ResolvePeersOptions::exclude_links_from_lockfile`] is on
     /// — keeping the peer-suffix segment stable across machines
     /// regardless of the absolute path of the external link.
-    fn build_importer_parents(&self) -> ParentRefs {
-        self.build_importer_parents_from(&self.tree.direct)
-    }
-
     /// Whether a dependency installed under `alias` can provide a peer:
     /// its alias or its real package name (the two differ for npm-alias
     /// deps like `peer-c1@npm:@pnpm.e2e/peer-c@2.0.0`) is declared as a
@@ -742,18 +825,75 @@ impl Walker<'_> {
     pub(super) fn resolve_node(
         &mut self,
         node_id: &NodeId,
-        parent_parent_refs: &Arc<ParentRefs>,
-        parent_dep_paths: &Arc<HashMap<String, ParentPkgInfo>>,
-        parent_chain_names: &SharedChain<String>,
-        parent_node_ids: &SharedChain<NodeId>,
-        parent_pkg_ids_chain: &SharedChain<String>,
+        walk: &NodeWalkContext<'_>,
     ) -> NodeOutput {
         if let Some(output) =
-            self.enter_node(node_id, parent_parent_refs, parent_chain_names, parent_pkg_ids_chain)
+            self.enter_node(node_id, walk.parent_refs, walk.chain_names, walk.parent_pkg_ids)
         {
             return output;
         }
-        let (pkg_id, tree_node_depth, tree_node_installable) = {
+        let mut entry = self.enter_package(node_id);
+        let refs = self.build_child_parent_refs(
+            node_id,
+            &entry.pkg,
+            walk.parent_refs,
+            &entry.provider_children,
+            walk.parent_node_ids,
+        );
+        let parent_dep_paths = self.record_child_parent_context(
+            &refs.refs,
+            &refs.own,
+            refs.changed,
+            walk.parent_dep_paths,
+        );
+
+        // `peersCache` lookup. When an earlier walk of this same
+        // `pkgIdWithPatchHash` produced a result whose resolved-peer
+        // map and missing-peer set are compatible with the current
+        // parent peer context, reuse the cached `depPath` and external
+        // peer/missing maps without recursing.
+        //
+        // The cache lookup uses the augmented view because a node's
+        // own children count as parents for its own descendants' peer
+        // resolution.
+        if let Some(cached) =
+            self.find_hit(&refs.refs, &entry.pkg.id).map(PeersCacheItem::to_cached_node_output)
+        {
+            return self.finish_cache_hit(
+                cached,
+                CacheHitContext {
+                    node_id,
+                    tree_node_depth: entry.depth,
+                    parent_chain_names: walk.chain_names,
+                    parent_pkg_ids_chain: walk.parent_pkg_ids,
+                    preview_undo: entry.preview_undo,
+                },
+            );
+        }
+        let mut walked =
+            self.walk_children(node_id, &mut entry, &refs.refs, &parent_dep_paths, walk);
+        let settled = self.settle_peers(&entry, &refs.refs, walk, &mut walked);
+        self.record_node(node_id, &entry, walk, &mut walked, &settled);
+
+        let output = NodeOutput {
+            dep_path: settled.dep_path,
+            external_resolved_peers: Arc::new(external_peers_to_report(
+                &settled.all_resolved,
+                &walked.children_map,
+                walked.discovery_children.as_ref(),
+            )),
+            auto_install_resolved_peers: walked.outputs.auto_install_resolved_peers,
+            missing_peers: settled.all_missing,
+            subtree_missing_by_pkg: settled.subtree_missing_by_pkg,
+        };
+        if self.discovery {
+            self.undo_realize(node_id, walked.realize_undo, Some(&output));
+        }
+        output
+    }
+
+    fn enter_package(&mut self, node_id: &NodeId) -> NodeEntry {
+        let (pkg_id, depth, installable) = {
             let tree_node = &self.tree.dependencies_tree[node_id];
             (
                 Arc::<str>::clone(&tree_node.resolved_package_id),
@@ -764,171 +904,149 @@ impl Walker<'_> {
         let pkg = self.owned_package(&pkg_id);
         let (provider_children, preview_undo) = self.preview_peer_provider_children(node_id);
         let (pkg_name, _pkg_version) = pkg_name_version(&pkg.result);
-        let ChildParentRefs {
-            refs: child_parent_refs,
-            own: new_parent_refs,
-            changed: refs_changed,
-        } = self.build_child_parent_refs(
-            node_id,
-            &pkg,
-            parent_parent_refs,
-            &provider_children,
-            parent_node_ids,
-        );
-        let parent_dep_paths = self.record_child_parent_context(
-            &child_parent_refs,
-            &new_parent_refs,
-            refs_changed,
-            parent_dep_paths,
-        );
+        NodeEntry { pkg, pkg_name, depth, installable, provider_children, preview_undo }
+    }
 
-        // `peersCache` lookup. When an earlier walk of this same
-        // `pkgIdWithPatchHash` produced a result whose resolved-peer
-        // map and missing-peer set are compatible with the current
-        // parent peer context, reuse the cached `depPath` and external
-        // peer/missing maps without recursing.
-        //
-        // The cache lookup uses `child_parent_refs` (the augmented
-        // view) because a node's own children count as parents for
-        // its own descendants' peer resolution.
-        let cached =
-            self.find_hit(&child_parent_refs, &pkg.id).map(PeersCacheItem::to_cached_node_output);
-        if let Some(cached) = cached {
-            return self.finish_cache_hit(
-                cached,
-                CacheHitContext {
-                    node_id,
-                    tree_node_depth,
-                    parent_chain_names,
-                    parent_pkg_ids_chain,
-                    preview_undo,
-                },
-            );
-        }
-        let discovery_children = self.discovery_children(node_id, &pkg.id);
+    /// Recurse into children first (post-order). Discovery walks lazy
+    /// children directly so cache hits never need occurrence-tree nodes.
+    fn walk_children(
+        &mut self,
+        node_id: &NodeId,
+        entry: &mut NodeEntry,
+        child_parent_refs: &Arc<ParentRefs>,
+        parent_dep_paths: &Arc<HashMap<String, ParentPkgInfo>>,
+        walk: &NodeWalkContext<'_>,
+    ) -> ChildrenWalk {
+        let discovery_children = self.discovery_children(node_id, &entry.pkg.id);
         let (children_map, realize_undo) = if discovery_children.is_some() {
             (Arc::new(BTreeMap::new()), None)
         } else {
-            self.realize_children_with(node_id, Some(&provider_children))
+            self.realize_children_with(node_id, Some(&entry.provider_children))
         };
-        let realize_undo = merge_realize_undo(preview_undo, realize_undo);
-        let child_walk = NodeWalkContext {
-            parent_refs: &child_parent_refs,
-            parent_dep_paths: &parent_dep_paths,
-            chain_names: &parent_chain_names.pushed(pkg_name.clone()),
-            parent_node_ids: &parent_node_ids.pushed(node_id.clone()),
-            parent_pkg_ids: &chain_with_pkg_id(parent_pkg_ids_chain, &pkg.id),
+        let realize_undo = merge_realize_undo(entry.preview_undo.take(), realize_undo);
+        let chains = ChildChains {
+            names: walk.chain_names.pushed(entry.pkg_name.clone()),
+            node_ids: walk.parent_node_ids.pushed(node_id.clone()),
+            pkg_ids: chain_with_pkg_id(walk.parent_pkg_ids, &entry.pkg.id),
         };
+        let outputs = self.resolve_children_of(
+            entry,
+            discovery_children.as_ref(),
+            &children_map,
+            &chains.context(child_parent_refs, parent_dep_paths),
+        );
+        ChildrenWalk { outputs, children_map, discovery_children, realize_undo, chains }
+    }
 
-        // Recurse into children first (post-order). Discovery walks lazy
-        // children directly so cache hits never need occurrence-tree nodes.
-        let child_outputs = match &discovery_children {
+    fn resolve_children_of(
+        &mut self,
+        entry: &NodeEntry,
+        discovery_children: Option<&(Arc<Vec<ChildEdge>>, AncestorIds)>,
+        children_map: &BTreeMap<String, NodeId>,
+        child_walk: &NodeWalkContext<'_>,
+    ) -> ChildOutputs {
+        match discovery_children {
             Some((children, parent_ids)) => self.resolve_deferred_children(
                 DeferredChildren {
-                    pkg_id: &pkg.id,
+                    pkg_id: &entry.pkg.id,
                     children,
                     parent_ids,
-                    provider_children: &provider_children,
-                    depth: tree_node_depth,
+                    provider_children: &entry.provider_children,
+                    depth: entry.depth,
                 },
-                &child_walk,
+                child_walk,
             ),
-            None => self.resolve_realized_children(&pkg.id, &children_map, &child_walk),
-        };
-        let ChildOutputs {
-            external_peers: external_from_children,
-            mut auto_install_resolved_peers,
-            missing_peers: missing_from_children,
-            dep_paths: child_dep_paths,
-            mut missing_summaries,
-        } = child_outputs;
+            None => self.resolve_realized_children(&entry.pkg.id, children_map, child_walk),
+        }
+    }
 
-        let NodePeers {
-            own_resolved: own_resolved_peers,
-            all_resolved: all_resolved_peers,
-            all_missing: all_missing_peers,
-            dep_path,
-        } = self.resolve_node_peers(NodePeersContext {
-            pkg: &pkg,
-            pkg_name: &pkg_name,
-            parent_refs: &child_parent_refs,
-            chain_names: child_walk.chain_names,
-            ancestor_pkg_ids: parent_pkg_ids_chain,
-            external_from_children,
-            missing_from_children: &missing_from_children,
+    fn settle_peers(
+        &mut self,
+        entry: &NodeEntry,
+        child_parent_refs: &Arc<ParentRefs>,
+        walk: &NodeWalkContext<'_>,
+        walked: &mut ChildrenWalk,
+    ) -> SettledPeers {
+        let peers = self.resolve_node_peers(NodePeersContext {
+            pkg: &entry.pkg,
+            pkg_name: &entry.pkg_name,
+            parent_refs: child_parent_refs,
+            chain_names: &walked.chains.names,
+            ancestor_pkg_ids: walk.parent_pkg_ids,
+            external_from_children: std::mem::take(&mut walked.outputs.external_peers),
+            missing_from_children: &walked.outputs.missing_peers,
         });
-        auto_install_resolved_peers.extend(
-            own_resolved_peers
+        walked.outputs.auto_install_resolved_peers.extend(
+            peers
+                .own_resolved
                 .iter()
                 .map(|(peer_name, peer_node_id)| (peer_name.clone(), peer_node_id.clone())),
         );
-
-        // Register the depPath ↔ NodeId mapping and per-node
-        // propagated state before inserting into the graph (so any
-        // cycle the graph insert hits via `child_dep_paths` can find
-        // this node's depPath).
-        self.remember_resolved_node(node_id, &dep_path);
-
-        let own_missing = (!missing_from_children.is_empty())
-            .then(|| (pkg.id.to_string(), missing_from_children.keys().cloned().collect()));
-        let subtree_missing_by_pkg = match (own_missing, missing_summaries.len()) {
+        let own_missing = (!walked.outputs.missing_peers.is_empty()).then(|| {
+            (entry.pkg.id.to_string(), walked.outputs.missing_peers.keys().cloned().collect())
+        });
+        let subtree_missing_by_pkg = match (own_missing, walked.outputs.missing_summaries.len()) {
             (None, 0) => None,
-            (None, 1) => missing_summaries.pop(),
-            (own, _) => Some(Arc::new(MissingSummary { own, children: missing_summaries })),
+            (None, 1) => walked.outputs.missing_summaries.pop(),
+            (own, _) => Some(Arc::new(MissingSummary {
+                own,
+                children: std::mem::take(&mut walked.outputs.missing_summaries),
+            })),
         };
+        SettledPeers {
+            is_pure: peers.all_resolved.is_empty() && peers.all_missing.is_empty(),
+            dep_path: peers.dep_path,
+            own_resolved: peers.own_resolved,
+            all_resolved: Arc::new(peers.all_resolved),
+            all_missing: Arc::new(peers.all_missing),
+            missing_from_children: Arc::new(std::mem::take(&mut walked.outputs.missing_peers)),
+            subtree_missing_by_pkg,
+        }
+    }
 
-        let is_pure = all_resolved_peers.is_empty() && all_missing_peers.is_empty();
-        let all_resolved_peers = Arc::new(all_resolved_peers);
-        let all_missing_peers = Arc::new(all_missing_peers);
-        let missing_from_children = Arc::new(missing_from_children);
+    /// Register the depPath ↔ `NodeId` mapping and per-node propagated
+    /// state before inserting into the graph (so any cycle the graph
+    /// insert hits via the child dep paths can find this node's
+    /// depPath).
+    fn record_node(
+        &mut self,
+        node_id: &NodeId,
+        entry: &NodeEntry,
+        walk: &NodeWalkContext<'_>,
+        walked: &mut ChildrenWalk,
+        settled: &SettledPeers,
+    ) {
+        self.remember_resolved_node(node_id, &settled.dep_path);
         self.record_walk_result(
             node_id,
-            &pkg.id,
+            &entry.pkg.id,
             &WalkResult {
-                dep_path: &dep_path,
-                all_resolved_peers: &all_resolved_peers,
-                all_missing_peers: &all_missing_peers,
-                missing_peers_of_children: &missing_from_children,
-                subtree_missing_by_pkg: &subtree_missing_by_pkg,
-                is_pure,
+                dep_path: &settled.dep_path,
+                all_resolved_peers: &settled.all_resolved,
+                all_missing_peers: &settled.all_missing,
+                missing_peers_of_children: &settled.missing_from_children,
+                subtree_missing_by_pkg: &settled.subtree_missing_by_pkg,
+                is_pure: settled.is_pure,
             },
         );
-
         if !self.discovery {
             self.record_walked_node(WalkedNode {
                 node_id,
-                pkg: &pkg,
-                dep_path: &dep_path,
-                parent_node_ids,
-                parent_pkg_ids_chain,
-                children: &children_map,
-                child_dep_paths,
-                all_resolved_peers: &all_resolved_peers,
-                all_missing_peers: &all_missing_peers,
-                own_resolved_peers: &own_resolved_peers,
-                depth: tree_node_depth,
-                installable: tree_node_installable,
-                is_pure,
+                pkg: &entry.pkg,
+                dep_path: &settled.dep_path,
+                parent_node_ids: walk.parent_node_ids,
+                parent_pkg_ids_chain: walk.parent_pkg_ids,
+                children: &walked.children_map,
+                child_dep_paths: std::mem::take(&mut walked.outputs.dep_paths),
+                all_resolved_peers: &settled.all_resolved,
+                all_missing_peers: &settled.all_missing,
+                own_resolved_peers: &settled.own_resolved,
+                depth: entry.depth,
+                installable: entry.installable,
+                is_pure: settled.is_pure,
             });
         }
-
         self.in_progress.remove(node_id);
-
-        let output = NodeOutput {
-            dep_path,
-            external_resolved_peers: Arc::new(external_peers_to_report(
-                &all_resolved_peers,
-                &children_map,
-                discovery_children.as_ref(),
-            )),
-            auto_install_resolved_peers,
-            missing_peers: all_missing_peers,
-            subtree_missing_by_pkg,
-        };
-        if self.discovery {
-            self.undo_realize(node_id, realize_undo, Some(&output));
-        }
-        output
     }
 
     /// The node's output when a fast path answers it without a walk, marking
@@ -1108,24 +1226,13 @@ impl Walker<'_> {
         walk: &NodeWalkContext<'_>,
     ) -> NodeOutput {
         if self.tree.dependencies_tree.contains_key(&child_node_id) {
-            return self.resolve_node(
-                &child_node_id,
-                walk.parent_refs,
-                walk.parent_dep_paths,
-                walk.chain_names,
-                walk.parent_node_ids,
-                walk.parent_pkg_ids,
-            );
+            return self.resolve_node(&child_node_id, walk);
         }
         self.resolve_deferred_child(&DeferredChildContext {
             edge,
             node_id: child_node_id,
             parent_ids,
-            parent_refs: walk.parent_refs,
-            parent_dep_paths: walk.parent_dep_paths,
-            chain_names: walk.chain_names,
-            parent_node_ids: walk.parent_node_ids,
-            parent_pkg_ids: walk.parent_pkg_ids,
+            walk,
             depth: parent_depth + 1,
         })
     }
@@ -1156,14 +1263,7 @@ impl Walker<'_> {
                 }) {
                     continue;
                 }
-                let child_output = self.resolve_node(
-                    child_node_id,
-                    walk.parent_refs,
-                    walk.parent_dep_paths,
-                    walk.chain_names,
-                    walk.parent_node_ids,
-                    walk.parent_pkg_ids,
-                );
+                let child_output = self.resolve_node(child_node_id, walk);
                 child_outputs.push(alias, child_output, &child_aliases, !self.discovery);
             }
         }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -1117,7 +1117,7 @@ impl Walker<'_> {
                 walk.parent_pkg_ids,
             );
         }
-        self.resolve_deferred_child(DeferredChildContext {
+        self.resolve_deferred_child(&DeferredChildContext {
             edge,
             node_id: child_node_id,
             parent_ids,
@@ -1302,25 +1302,15 @@ impl Walker<'_> {
     /// children reported, and render the depPath. Empty resolved-peers
     /// ⇒ pure node: depPath = `pkgIdWithPatchHash`.
     fn resolve_node_peers(&mut self, context: NodePeersContext<'_>) -> NodePeers {
-        let NodePeersContext {
-            pkg,
-            pkg_name,
-            parent_refs,
-            chain_names,
-            ancestor_pkg_ids,
-            external_from_children,
-            missing_from_children,
-        } = context;
-
         let mut own_resolved: HashMap<String, NodeId> = HashMap::default();
         let mut own_missing: HashMap<String, MissingPeerInfo> = HashMap::default();
-        for (peer_name, peer_dep) in &pkg.peer_dependencies {
+        for (peer_name, peer_dep) in &context.pkg.peer_dependencies {
             self.resolve_one_peer(
                 peer_name,
                 peer_dep,
-                parent_refs,
-                chain_names,
-                ancestor_pkg_ids,
+                context.parent_refs,
+                context.chain_names,
+                context.ancestor_pkg_ids,
                 &mut own_resolved,
                 &mut own_missing,
             );
@@ -1328,29 +1318,32 @@ impl Walker<'_> {
 
         // A package doesn't peer-depend on itself, so its own name never
         // enters its suffix.
-        let mut all_resolved = external_from_children;
+        let mut all_resolved = context.external_from_children;
         for (peer_alias, peer_node_id) in &own_resolved {
             all_resolved.insert(peer_alias.clone(), peer_node_id.clone());
         }
-        all_resolved.remove(pkg_name);
+        all_resolved.remove(context.pkg_name);
 
-        let mut all_missing = missing_from_children.clone();
+        let mut all_missing = context.missing_from_children.clone();
         for (peer_alias, info) in &own_missing {
             all_missing.insert(peer_alias.clone(), info.clone());
         }
 
-        let dep_path = if all_resolved.is_empty() {
-            DepPath::from(std::sync::Arc::<str>::clone(&pkg.id))
-        } else {
-            let peer_ids: Vec<PeerId> = all_resolved
-                .iter()
-                .map(|(peer_alias, peer_node_id)| self.build_peer_id(peer_alias, peer_node_id))
-                .collect();
-            let suffix = create_peer_dep_graph_hash(&peer_ids, self.opts.peers_suffix_max_length);
-            DepPath::from(format!("{}{}", pkg.id, suffix))
-        };
-
+        let dep_path = self.peer_dep_path(&context.pkg.id, &all_resolved);
         NodePeers { own_resolved, all_resolved, all_missing, dep_path }
+    }
+
+    /// Empty resolved peers ⇒ pure node: depPath = `pkgIdWithPatchHash`.
+    fn peer_dep_path(&self, pkg_id: &Arc<str>, all_resolved: &HashMap<String, NodeId>) -> DepPath {
+        if all_resolved.is_empty() {
+            return DepPath::from(Arc::<str>::clone(pkg_id));
+        }
+        let peer_ids: Vec<PeerId> = all_resolved
+            .iter()
+            .map(|(peer_alias, peer_node_id)| self.build_peer_id(peer_alias, peer_node_id))
+            .collect();
+        let suffix = create_peer_dep_graph_hash(&peer_ids, self.opts.peers_suffix_max_length);
+        DepPath::from(format!("{pkg_id}{suffix}"))
     }
 
     /// The upstream locked-peer-provider reuse block

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -798,11 +798,10 @@ impl Walker<'_> {
         self.tree.all_peer_dep_names.contains(&real_name)
     }
 
-    /// Same as [`Self::build_importer_parents`] but seeds from an
-    /// externally-supplied direct-deps slice — used by the
-    /// multi-importer
+    /// The parent refs an importer's direct deps seed the peer walk with.
+    /// The multi-importer
     /// [`resolve_peers_workspace`](fn@super::resolve_peers_workspace)
-    /// where each importer's `direct` lives outside [`ResolvedTree`].
+    /// supplies each importer's `direct` from outside [`ResolvedTree`].
     pub(super) fn build_importer_parents_from(&self, direct_deps: &[DirectDep]) -> ParentRefs {
         let mut refs = ParentRefs::default();
         for direct in direct_deps {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -29,7 +29,7 @@ use crate::{
 use chrono::{DateTime, Duration, Utc};
 use pnpm_lockfile::RegistryContext;
 use pnpm_package_manifest::{DependencyGroup, PackageManifest};
-use pnpm_resolving_resolver_base::{Resolver, WantedDependency, parse_packument_timestamp};
+use pnpm_resolving_resolver_base::{Resolver, parse_packument_timestamp};
 use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
 
 /// One importer's input to [`fn@resolve_workspace`].
@@ -330,16 +330,8 @@ where
     if !settings.time_based {
         return TimeBasedCutoff { published_by: maximum_published_by, time: BTreeMap::new() };
     }
-    compute_time_based_cutoff(
-        resolver,
-        &sorted.importers,
-        &sorted.opts,
-        dependency_groups,
-        settings.pick_lowest_direct,
-        maximum_published_by,
-        settings.recorded_time.as_ref(),
-    )
-    .await
+    compute_time_based_cutoff(resolver, sorted, dependency_groups, settings, maximum_published_by)
+        .await
 }
 
 struct InitializedImporters<'i, 'a> {
@@ -592,44 +584,25 @@ struct TimeBasedCutoff {
 /// them.
 async fn compute_time_based_cutoff<Chain>(
     resolver: &Chain,
-    importers: &[&WorkspaceImporter<'_>],
-    importer_opts: &[ResolveImporterOptions],
+    sorted: &SortedImporters<'_, '_>,
     dependency_groups: &[DependencyGroup],
-    pick_lowest_direct: bool,
+    settings: &PassSettings,
     maximum_published_by: Option<DateTime<Utc>>,
-    recorded_time: Option<&BTreeMap<String, String>>,
 ) -> TimeBasedCutoff
 where
     Chain: Resolver + ?Sized,
 {
     let mut time = BTreeMap::new();
-    for (importer, opts) in importers.iter().zip(importer_opts) {
-        let Ok(specs) = importer_direct_wanted_specs(
-            importer.manifest,
-            dependency_groups.iter().copied(),
-            opts.auto_install_peers,
-            &opts.catalogs,
-        ) else {
-            continue;
-        };
-        let mut direct_opts = opts.base_opts.clone();
-        direct_opts.pick_lowest_version = pick_lowest_direct;
-        for (alias, bare_specifier, optional, injected) in specs {
-            let wanted = WantedDependency {
-                alias: Some(alias),
-                bare_specifier: Some(bare_specifier),
-                optional: Some(optional),
-                injected: injected.then_some(true),
-                ..WantedDependency::default()
-            };
-            let Ok(Some(result)) = resolver.resolve(&wanted, &direct_opts).await else { continue };
-            let published_at = result.published_at.or_else(|| {
-                recorded_time.and_then(|recorded| recorded.get(result.id.as_str())).cloned()
-            });
-            if let Some(published_at) = published_at {
-                time.insert(result.id.into_inner(), published_at);
-            }
-        }
+    for (importer, opts) in sorted.importers.iter().zip(&sorted.opts) {
+        record_direct_publish_dates(
+            resolver,
+            importer,
+            opts,
+            dependency_groups,
+            settings,
+            &mut time,
+        )
+        .await;
     }
 
     let newest =
@@ -641,6 +614,44 @@ where
         (None, maximum) => maximum,
     };
     TimeBasedCutoff { published_by, time }
+}
+
+/// Resolve one importer's direct deps and record each one's publish
+/// date, falling back to the date the lockfile recorded for it.
+async fn record_direct_publish_dates<Chain>(
+    resolver: &Chain,
+    importer: &WorkspaceImporter<'_>,
+    opts: &ResolveImporterOptions,
+    dependency_groups: &[DependencyGroup],
+    settings: &PassSettings,
+    time: &mut BTreeMap<String, String>,
+) where
+    Chain: Resolver + ?Sized,
+{
+    let Ok(specs) = importer_direct_wanted_specs(
+        importer.manifest,
+        dependency_groups.iter().copied(),
+        opts.auto_install_peers,
+        &opts.catalogs,
+    ) else {
+        return;
+    };
+    let mut direct_opts = opts.base_opts.clone();
+    direct_opts.pick_lowest_version = settings.pick_lowest_direct;
+    for spec in specs {
+        let Ok(Some(result)) = resolver
+            .resolve(&crate::resolve_dependency_tree::wanted_from_spec(spec), &direct_opts)
+            .await
+        else {
+            continue;
+        };
+        let published_at = result
+            .published_at
+            .or_else(|| settings.recorded_time.as_ref()?.get(result.id.as_str()).cloned());
+        if let Some(published_at) = published_at {
+            time.insert(result.id.into_inner(), published_at);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -199,152 +199,212 @@ pub async fn resolve_workspace<'a, Chain, BuildImporterOptions>(
     importers: &[WorkspaceImporter<'a>],
     dependency_groups: &[DependencyGroup],
     opts: WorkspaceResolveOptions,
-    mut per_importer_options: BuildImporterOptions,
+    per_importer_options: BuildImporterOptions,
 ) -> Result<ResolveWorkspaceResult, ResolveImporterError>
 where
     Chain: Resolver + ?Sized,
     BuildImporterOptions: FnMut(&WorkspaceImporter<'a>) -> ResolveImporterOptions,
 {
-    let WorkspaceResolveOptions {
-        dedupe_peers,
-        dedupe_injected_deps,
-        dedupe_peer_dependents,
-        resolve_peers_from_workspace_root,
-        exclude_links_from_lockfile,
-        lockfile_dir,
-        peers_suffix_max_length,
-        share_workspace_resolutions,
-        manifest_hook,
-        overrides_hook,
-        pnpmfile_hook,
-        read_package_log,
-        skipped_optional_log,
-        finalized_package,
-        allowed_deprecated_versions,
-        deprecation_log,
-        pick_lowest_direct,
-        time_based,
-        wanted_lockfile,
-        reuse_lockfile_subtrees,
-        update_reuse_scope,
-        update_reuse_scopes_by_importer,
-        update_depth,
-        auto_install_peers,
-        registry_context,
-    } = opts;
-    // Taken before the lockfile moves into the workspace ctx below, and
-    // only for the pre-pass that reads it — a lockfile is untrusted
-    // input, so an install that will not consult the recorded dates
-    // must not copy them.
-    let recorded_time = time_based
-        .then(|| wanted_lockfile.as_ref().and_then(|lockfile| lockfile.time.clone()))
-        .flatten();
-    let workspace = Arc::new(
-        WorkspaceTreeCtx::default()
-            .with_shared_workspace_resolutions(share_workspace_resolutions)
-            .with_manifest_hook(manifest_hook)
-            .with_overrides_hook(overrides_hook)
-            .with_wanted_lockfile(wanted_lockfile)
-            .with_reuse_lockfile_subtrees(reuse_lockfile_subtrees)
-            .with_update_reuse_scope(update_reuse_scope)
-            .with_update_reuse_scopes_by_importer(update_reuse_scopes_by_importer)
-            .with_update_depth(update_depth)
-            .with_pnpmfile_hook(pnpmfile_hook)
-            .with_read_package_log(read_package_log)
-            .with_skipped_optional_log(skipped_optional_log)
-            .with_finalized_package(finalized_package)
-            .with_allowed_deprecated_versions(allowed_deprecated_versions)
-            .with_deprecation_log(deprecation_log)
-            .with_auto_install_peers(auto_install_peers)
-            .with_registry_context(registry_context),
-    );
+    let (workspace, settings) = opts.split();
+    let sorted = sorted_importers(importers, per_importer_options, &settings);
+    let cutoff = time_cutoff(resolver, &sorted, dependency_groups, &settings).await;
+    let mut initialized =
+        init_importers(resolver, sorted, dependency_groups, &cutoff, &settings, &workspace).await?;
+    run_hoist_rounds(resolver, &mut initialized.states, &workspace).await?;
+    Ok(finish(&settings, workspace, initialized, cutoff.time))
+}
 
-    // Build every importer's options up front so the `time-based`
-    // pre-pass and the resolve loop see the same per-importer wiring.
-    // `auto_install_peers` and `dedupe_peer_dependents` are
-    // workspace-wide (one setting per install), so the workspace-level
-    // values override whatever the per-importer callback set — the
-    // importer hoist loop and the tree walk's shadow pruning must agree.
-    let importer_opts: Vec<ResolveImporterOptions> = importers
+/// What the pass keeps for itself once the shared tree context has
+/// taken the hooks, logs and lockfile.
+struct PassSettings {
+    dedupe_peers: bool,
+    dedupe_injected_deps: bool,
+    dedupe_peer_dependents: bool,
+    resolve_peers_from_workspace_root: bool,
+    exclude_links_from_lockfile: bool,
+    lockfile_dir: PathBuf,
+    peers_suffix_max_length: usize,
+    pick_lowest_direct: bool,
+    time_based: bool,
+    auto_install_peers: bool,
+    /// The lockfile's recorded publish dates, taken only for the
+    /// `time-based` pre-pass that reads them — a lockfile is untrusted
+    /// input, so an install that will not consult the dates must not
+    /// copy them.
+    recorded_time: Option<BTreeMap<String, String>>,
+}
+
+impl WorkspaceResolveOptions {
+    fn split(self) -> (Arc<WorkspaceTreeCtx>, PassSettings) {
+        let recorded_time = self
+            .time_based
+            .then(|| self.wanted_lockfile.as_ref().and_then(|lockfile| lockfile.time.clone()))
+            .flatten();
+        let settings = PassSettings {
+            dedupe_peers: self.dedupe_peers,
+            dedupe_injected_deps: self.dedupe_injected_deps,
+            dedupe_peer_dependents: self.dedupe_peer_dependents,
+            resolve_peers_from_workspace_root: self.resolve_peers_from_workspace_root,
+            exclude_links_from_lockfile: self.exclude_links_from_lockfile,
+            lockfile_dir: self.lockfile_dir,
+            peers_suffix_max_length: self.peers_suffix_max_length,
+            pick_lowest_direct: self.pick_lowest_direct,
+            time_based: self.time_based,
+            auto_install_peers: self.auto_install_peers,
+            recorded_time,
+        };
+        let workspace = WorkspaceTreeCtx::default()
+            .with_shared_workspace_resolutions(self.share_workspace_resolutions)
+            .with_manifest_hook(self.manifest_hook)
+            .with_overrides_hook(self.overrides_hook)
+            .with_wanted_lockfile(self.wanted_lockfile)
+            .with_reuse_lockfile_subtrees(self.reuse_lockfile_subtrees)
+            .with_update_reuse_scope(self.update_reuse_scope)
+            .with_update_reuse_scopes_by_importer(self.update_reuse_scopes_by_importer)
+            .with_update_depth(self.update_depth)
+            .with_pnpmfile_hook(self.pnpmfile_hook)
+            .with_read_package_log(self.read_package_log)
+            .with_skipped_optional_log(self.skipped_optional_log)
+            .with_finalized_package(self.finalized_package)
+            .with_allowed_deprecated_versions(self.allowed_deprecated_versions)
+            .with_deprecation_log(self.deprecation_log)
+            .with_auto_install_peers(self.auto_install_peers)
+            .with_registry_context(self.registry_context);
+        (Arc::new(workspace), settings)
+    }
+}
+
+/// The importers in id order, each with its options.
+struct SortedImporters<'i, 'a> {
+    importers: Vec<&'i WorkspaceImporter<'a>>,
+    opts: Vec<ResolveImporterOptions>,
+}
+
+/// Build every importer's options up front so the `time-based` pre-pass
+/// and the resolve loop see the same per-importer wiring.
+/// `auto_install_peers` and `dedupe_peer_dependents` are workspace-wide
+/// (one setting per install), so the workspace-level values override
+/// whatever the per-importer callback set — the importer hoist loop and
+/// the tree walk's shadow pruning must agree.
+///
+/// Sorted by importer id: children-owner claims are ranked by importer
+/// position and the hoist rounds run sequentially in list order, so a
+/// stable order makes ownership, the first-walk missing scope, and every
+/// auto-install decision a function of the importer set rather than of
+/// the caller's listing order (pnpm/pnpm#13846).
+fn sorted_importers<'i, 'a, BuildImporterOptions>(
+    importers: &'i [WorkspaceImporter<'a>],
+    mut per_importer_options: BuildImporterOptions,
+    settings: &PassSettings,
+) -> SortedImporters<'i, 'a>
+where
+    BuildImporterOptions: FnMut(&WorkspaceImporter<'a>) -> ResolveImporterOptions,
+{
+    let mut paired: Vec<(&WorkspaceImporter<'a>, ResolveImporterOptions)> = importers
         .iter()
-        .map(&mut per_importer_options)
-        .map(|mut opts| {
-            opts.auto_install_peers = auto_install_peers;
-            opts.dedupe_peer_dependents = dedupe_peer_dependents;
-            opts
+        .map(|importer| {
+            let mut opts = per_importer_options(importer);
+            opts.auto_install_peers = settings.auto_install_peers;
+            opts.dedupe_peer_dependents = settings.dedupe_peer_dependents;
+            (importer, opts)
         })
         .collect();
+    paired.sort_by(|(left, _), (right, _)| left.id.cmp(&right.id));
+    let (importers, opts) = paired.into_iter().unzip();
+    SortedImporters { importers, opts }
+}
 
-    // Resolve importers in id order. Children-owner claims are ranked
-    // by importer position and the hoist rounds run sequentially in
-    // list order, so a stable order makes ownership, the first-walk
-    // missing scope, and every auto-install decision a function of the
-    // importer set rather than of the caller's listing order
-    // (pnpm/pnpm#13846).
-    let (importers, importer_opts): (Vec<&WorkspaceImporter<'a>>, Vec<ResolveImporterOptions>) = {
-        let mut paired: Vec<(&WorkspaceImporter<'a>, ResolveImporterOptions)> =
-            importers.iter().zip(importer_opts).collect();
-        paired.sort_by(|(left, _), (right, _)| left.id.cmp(&right.id));
-        paired.into_iter().unzip()
-    };
+/// The `minimumReleaseAge` cutoff is set uniformly on every importer's
+/// `base_opts.published_by` by the install layer; it is the upper bound
+/// on the time-based cutoff.
+async fn time_cutoff<Chain>(
+    resolver: &Chain,
+    sorted: &SortedImporters<'_, '_>,
+    dependency_groups: &[DependencyGroup],
+    settings: &PassSettings,
+) -> TimeBasedCutoff
+where
+    Chain: Resolver + ?Sized,
+{
+    let maximum_published_by = sorted.opts.first().and_then(|opts| opts.base_opts.published_by);
+    if !settings.time_based {
+        return TimeBasedCutoff { published_by: maximum_published_by, time: BTreeMap::new() };
+    }
+    compute_time_based_cutoff(
+        resolver,
+        &sorted.importers,
+        &sorted.opts,
+        dependency_groups,
+        settings.pick_lowest_direct,
+        maximum_published_by,
+        settings.recorded_time.as_ref(),
+    )
+    .await
+}
 
-    // The `minimumReleaseAge` cutoff is set uniformly on every
-    // importer's `base_opts.published_by` by the install layer; it is
-    // the upper bound on the time-based cutoff.
-    let maximum_published_by = importer_opts.first().and_then(|opts| opts.base_opts.published_by);
-    let TimeBasedCutoff { published_by: subdep_published_by, time } = if time_based {
-        compute_time_based_cutoff(
-            resolver,
-            &importers,
-            &importer_opts,
-            dependency_groups,
-            pick_lowest_direct,
-            maximum_published_by,
-            recorded_time.as_ref(),
-        )
-        .await
-    } else {
-        TimeBasedCutoff { published_by: maximum_published_by, time: BTreeMap::new() }
-    };
+struct InitializedImporters<'i, 'a> {
+    importers: Vec<&'i WorkspaceImporter<'a>>,
+    states: Vec<ImporterHoistState>,
+    /// Each importer's project and modules dir, for its peer input.
+    input_dirs: Vec<(PathBuf, Option<PathBuf>)>,
+}
 
-    // Phase 1: every importer's initial wave resolves before any peer
-    // hoist runs, then hoist rounds repeat across all importers until
-    // none hoists — a workspace-wide barrier, so an optional-peer pick
-    // sees every importer's resolved versions.
-    //
-    // The initial waves run concurrently, like the TypeScript resolver's
-    // importer fan-out: the shared context's children-owner claims are
-    // rank-ordered (not arrival-ordered) and the peer-hoist pickers'
-    // preferred-version candidates are derived from the settled
-    // reachable tree (see `WorkspaceTreeCtx::run_preferred_versions`),
-    // so the resolved graph is the same regardless of interleaving, and
-    // a large workspace's walks overlap their resolver and hook waits
-    // instead of paying them importer by importer.
-    let mut input_dirs = Vec::with_capacity(importers.len());
-    let mut states = Vec::with_capacity(importers.len());
+/// Phase 1: every importer's initial wave resolves before any peer
+/// hoist runs, then hoist rounds repeat across all importers until
+/// none hoists — a workspace-wide barrier, so an optional-peer pick
+/// sees every importer's resolved versions.
+///
+/// The initial waves run concurrently, like the TypeScript resolver's
+/// importer fan-out: the shared context's children-owner claims are
+/// rank-ordered (not arrival-ordered) and the peer-hoist pickers'
+/// preferred-version candidates are derived from the settled
+/// reachable tree (see `WorkspaceTreeCtx::run_preferred_versions`),
+/// so the resolved graph is the same regardless of interleaving, and
+/// a large workspace's walks overlap their resolver and hook waits
+/// instead of paying them importer by importer.
+async fn init_importers<'i, 'a, Chain>(
+    resolver: &Chain,
+    sorted: SortedImporters<'i, 'a>,
+    dependency_groups: &[DependencyGroup],
+    cutoff: &TimeBasedCutoff,
+    settings: &PassSettings,
+    workspace: &Arc<WorkspaceTreeCtx>,
+) -> Result<InitializedImporters<'i, 'a>, ResolveImporterError>
+where
+    Chain: Resolver + ?Sized,
+{
+    let mut input_dirs = Vec::with_capacity(sorted.importers.len());
+    let mut states = Vec::with_capacity(sorted.importers.len());
     for (importer_order, (importer, mut importer_opts)) in
-        importers.iter().zip(importer_opts).enumerate()
+        sorted.importers.iter().zip(sorted.opts).enumerate()
     {
-        importer_opts.pick_lowest_direct = pick_lowest_direct;
-        importer_opts.subdep_published_by = subdep_published_by;
+        importer_opts.pick_lowest_direct = settings.pick_lowest_direct;
+        importer_opts.subdep_published_by = cutoff.published_by;
         input_dirs
             .push((importer_opts.base_opts.project_dir.clone(), importer_opts.modules_dir.clone()));
         // Boxed to keep the enclosing install future small: inlining a
         // wave's frame into it trips the workspace's large-future lint.
-        let wave = Box::pin(ImporterHoistState::init(
-            resolver,
-            &importer.id,
-            importer_order,
-            importer.manifest,
-            dependency_groups.iter().copied(),
-            importer_opts,
-            Arc::clone(&workspace),
-        ));
-        states.push(wave.await?);
+        states.push(
+            Box::pin(ImporterHoistState::init(
+                resolver,
+                &importer.id,
+                importer_order,
+                importer.manifest,
+                dependency_groups.iter().copied(),
+                importer_opts,
+                Arc::clone(workspace),
+            ))
+            .await?,
+        );
     }
-    // Computed after the init barrier and shared unchanged: recomputing it
-    // per round would let the root's own hoisted peers become candidates for
-    // the importers hoisted after it.
+    share_root_deps(&mut states)?;
+    Ok(InitializedImporters { importers: sorted.importers, states, input_dirs })
+}
+
+/// Computed after the init barrier and shared unchanged: recomputing it
+/// per round would let the root's own hoisted peers become candidates
+/// for the importers hoisted after it.
+fn share_root_deps(states: &mut [ImporterHoistState]) -> Result<(), ResolveImporterError> {
     let root_deps = Arc::new(
         states
             .iter()
@@ -353,35 +413,40 @@ where
             .transpose()?
             .unwrap_or_default(),
     );
-    for state in &mut states {
+    for state in states.iter_mut() {
         state.set_workspace_root_deps(Arc::clone(&root_deps));
     }
-    // One discovery engine serves every hoist round of the workspace:
-    // its persistent tree view + walker caches are what keep the
-    // barrier below linear in workspace size (each importer's pass
-    // short-circuits on the subtree verdicts recorded by the passes
-    // before it).
-    let mut peer_discovery = PeerHoistDiscovery::new();
-    run_initial_required_rounds(resolver, &mut states, &workspace, &mut peer_discovery).await?;
-    run_hoist_barrier(resolver, &mut states, &mut peer_discovery).await?;
-    // Release the engine's tree view before the merged-tree snapshot
-    // below clones the context again, so the two never coexist at peak.
-    drop(peer_discovery);
-    let mut per_importer_inputs: Vec<ImporterPeerInput> = Vec::with_capacity(importers.len());
-    let mut hoisted_peer_provider_node_ids = std::collections::HashSet::default();
-    for ((importer, state), (project_dir, modules_dir)) in
-        importers.iter().zip(states).zip(input_dirs)
-    {
-        let (direct, importer_provider_node_ids) = state.into_direct();
-        hoisted_peer_provider_node_ids.extend(importer_provider_node_ids);
-        per_importer_inputs.push(ImporterPeerInput {
-            id: importer.id.clone(),
-            direct,
-            root_dir: project_dir,
-            modules_dir,
-        });
-    }
+    Ok(())
+}
 
+/// One discovery engine serves every hoist round of the workspace: its
+/// persistent tree view + walker caches are what keep the barrier
+/// linear in workspace size (each importer's pass short-circuits on the
+/// subtree verdicts recorded by the passes before it). The engine's
+/// tree view is released on return, before the merged-tree snapshot
+/// clones the context again, so the two never coexist at peak.
+async fn run_hoist_rounds<Chain>(
+    resolver: &Chain,
+    states: &mut [ImporterHoistState],
+    workspace: &WorkspaceTreeCtx,
+) -> Result<(), ResolveImporterError>
+where
+    Chain: Resolver + ?Sized,
+{
+    let mut peer_discovery = PeerHoistDiscovery::new();
+    run_initial_required_rounds(resolver, states, workspace, &mut peer_discovery).await?;
+    run_hoist_barrier(resolver, states, &mut peer_discovery).await
+}
+
+/// Fold every importer's direct deps into the peer inputs, reclaim the
+/// tree and run the workspace-wide peer pass.
+fn finish(
+    settings: &PassSettings,
+    workspace: Arc<WorkspaceTreeCtx>,
+    initialized: InitializedImporters<'_, '_>,
+    time: BTreeMap<String, String>,
+) -> ResolveWorkspaceResult {
+    let peer_inputs = importer_peer_inputs(initialized);
     // Reclaim the workspace ctx now that every importer's state has
     // dropped its `Arc<WorkspaceTreeCtx>`. The `try_unwrap` succeeds
     // when this is the sole remaining `Arc` reference (the common
@@ -391,31 +456,60 @@ where
         Ok(ws) => ws.into_resolved_tree(Vec::new()),
         Err(arc) => arc.snapshot(Vec::new()),
     };
+    let peers = resolve_workspace_peers(settings, &mut merged_tree, peer_inputs);
+    ResolveWorkspaceResult { merged_tree, peers, time }
+}
 
-    let peer_opts = ResolvePeersOptions {
-        peers_suffix_max_length,
-        dedupe_peers,
-        exclude_links_from_lockfile,
-        lockfile_dir: Some(lockfile_dir.clone()),
-        project_dir: None,
-        // Per-importer; resolve_peers_workspace swaps the
-        // ImporterPeerInput's modules_dir into walker.opts before each
-        // importer's walk.
-        modules_dir: None,
-        hoist_missing_scope: None,
-        hoisted_peer_provider_node_ids,
-        ..ResolvePeersOptions::default()
-    };
-    let peers = resolve_peers_workspace(
-        &mut merged_tree,
-        &per_importer_inputs,
-        &lockfile_dir,
-        dedupe_injected_deps,
-        dedupe_peer_dependents,
-        resolve_peers_from_workspace_root,
-        peer_opts,
-    );
-    Ok(ResolveWorkspaceResult { merged_tree, peers, time })
+struct PeerInputs {
+    per_importer: Vec<ImporterPeerInput>,
+    hoisted_provider_node_ids: std::collections::HashSet<crate::NodeId, rustc_hash::FxBuildHasher>,
+}
+
+fn importer_peer_inputs(initialized: InitializedImporters<'_, '_>) -> PeerInputs {
+    let mut per_importer = Vec::with_capacity(initialized.importers.len());
+    let mut hoisted_provider_node_ids = std::collections::HashSet::default();
+    for ((importer, state), (project_dir, modules_dir)) in
+        initialized.importers.iter().zip(initialized.states).zip(initialized.input_dirs)
+    {
+        let (direct, importer_provider_node_ids) = state.into_direct();
+        hoisted_provider_node_ids.extend(importer_provider_node_ids);
+        per_importer.push(ImporterPeerInput {
+            id: importer.id.clone(),
+            direct,
+            root_dir: project_dir,
+            modules_dir,
+        });
+    }
+    PeerInputs { per_importer, hoisted_provider_node_ids }
+}
+
+fn resolve_workspace_peers(
+    settings: &PassSettings,
+    tree: &mut ResolvedTree,
+    inputs: PeerInputs,
+) -> WorkspaceResolvePeersResult {
+    resolve_peers_workspace(
+        tree,
+        &inputs.per_importer,
+        &settings.lockfile_dir,
+        settings.dedupe_injected_deps,
+        settings.dedupe_peer_dependents,
+        settings.resolve_peers_from_workspace_root,
+        ResolvePeersOptions {
+            peers_suffix_max_length: settings.peers_suffix_max_length,
+            dedupe_peers: settings.dedupe_peers,
+            exclude_links_from_lockfile: settings.exclude_links_from_lockfile,
+            lockfile_dir: Some(settings.lockfile_dir.clone()),
+            project_dir: None,
+            // Per-importer; resolve_peers_workspace swaps the
+            // ImporterPeerInput's modules_dir into walker.opts before each
+            // importer's walk.
+            modules_dir: None,
+            hoist_missing_scope: None,
+            hoisted_peer_provider_node_ids: inputs.hoisted_provider_node_ids,
+            ..ResolvePeersOptions::default()
+        },
+    )
 }
 
 /// The first required round of every importer, prepared against one quiescent

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -1063,24 +1063,9 @@ impl NpmResolutionVerifier {
         let name_string = name.to_string();
         let url = crate::registry_url::to_registry_url(registry, &name_string);
         let scope = self.auth_headers.metadata_scope(&url, Some(&name_string));
-        cell.get_or_init(|| async {
-            let meta_dir = crate::mirror::scoped_meta_dir(&scope, crate::mirror::FULL_META_DIR);
-            let mirror_path =
-                crate::mirror::get_pkg_mirror_path(cache_dir, &meta_dir, registry, &name_string)
-                    .ok();
-            crate::mirror::load_meta_async(mirror_path.as_deref()).await.and_then(|pkg| {
-                pkg.time.as_ref().map(|raw| {
-                    raw.iter()
-                        .filter_map(|(version, value)| {
-                            value.as_str().map(|ts| (version.clone(), ts.to_string()))
-                        })
-                        .collect::<PublishedAtTimeMap>()
-                        .pipe(Arc::new)
-                })
-            })
-        })
-        .await
-        .clone()
+        cell.get_or_init(|| load_local_meta_time(cache_dir, &scope, registry, &name_string))
+            .await
+            .clone()
     }
 
     async fn fetch_attestation_time(
@@ -1671,6 +1656,25 @@ fn canonical_tarball_url(url: &str) -> String {
         Some((_scheme, rest)) => rest.to_string(),
         None => normalized,
     }
+}
+
+/// The per-version publish times of the scoped on-disk mirror, keyed by
+/// version. `None` without a mirror or a `time` payload.
+async fn load_local_meta_time(
+    cache_dir: &std::path::Path,
+    scope: &pnpm_network::MetadataCacheScope,
+    registry: &str,
+    name: &str,
+) -> Option<Arc<PublishedAtTimeMap>> {
+    let meta_dir = crate::mirror::scoped_meta_dir(scope, crate::mirror::FULL_META_DIR);
+    let mirror_path = crate::mirror::get_pkg_mirror_path(cache_dir, &meta_dir, registry, name).ok();
+    let pkg = crate::mirror::load_meta_async(mirror_path.as_deref()).await?;
+    let raw = pkg.time.as_ref()?;
+    raw.iter()
+        .filter_map(|(version, value)| value.as_str().map(|ts| (version.clone(), ts.to_string())))
+        .collect::<PublishedAtTimeMap>()
+        .pipe(Arc::new)
+        .pipe(Some)
 }
 
 #[cfg(test)]

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -119,22 +119,15 @@ struct FetchAttempt<'a> {
     cache_bypass: AtomicBool,
 }
 
+fn response_etag(response: &reqwest::Response) -> Option<String> {
+    response.headers().get(header::ETAG).and_then(|value| value.to_str().ok()).map(str::to_string)
+}
+
 impl FetchAttempt<'_> {
     async fn run(&self) -> Result<Package, FetchMetadataError> {
         let started_at = Instant::now();
         let opts = self.opts;
-        let request = MetadataRequestOptions {
-            pkg_name: self.pkg_name,
-            url: self.url,
-            accept: if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC },
-            http_client: opts.http_client,
-            auth_headers: opts.auth_headers,
-            priority: opts.priority,
-            etag: self.cache_headers.as_ref().and_then(|headers| headers.etag.as_deref()),
-            modified: self.cache_headers.as_ref().and_then(|headers| headers.modified.as_deref()),
-            bypass_cache: self.cache_bypass.load(Ordering::Relaxed),
-            retry_opts: opts.retry_opts,
-        };
+        let request = self.metadata_request();
         let (client, response) = send_metadata_request(&request).await?;
 
         let (client, response) = if response.status() == StatusCode::NOT_MODIFIED {
@@ -152,11 +145,7 @@ impl FetchAttempt<'_> {
             FetchMetadataError::Network { url: redact_url_credentials(self.url), error }
         })?;
 
-        let etag = response
-            .headers()
-            .get(header::ETAG)
-            .and_then(|value| value.to_str().ok())
-            .map(str::to_string);
+        let etag = response_etag(&response);
         let normalize_to_abbreviated =
             !opts.full_metadata && !is_abbreviated_content_type(response.headers());
         let raw_body = response.text().await.map_err(|error| FetchMetadataError::BodyRead {
@@ -195,6 +184,22 @@ impl FetchAttempt<'_> {
 
         warn_if_request_is_slow(opts.http_client, elapsed, self.url);
         meta.pipe(Ok)
+    }
+
+    fn metadata_request(&self) -> MetadataRequestOptions<'_> {
+        let opts = self.opts;
+        MetadataRequestOptions {
+            pkg_name: self.pkg_name,
+            url: self.url,
+            accept: if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC },
+            http_client: opts.http_client,
+            auth_headers: opts.auth_headers,
+            priority: opts.priority,
+            etag: self.cache_headers.as_ref().and_then(|headers| headers.etag.as_deref()),
+            modified: self.cache_headers.as_ref().and_then(|headers| headers.modified.as_deref()),
+            bypass_cache: self.cache_bypass.load(Ordering::Relaxed),
+            retry_opts: opts.retry_opts,
+        }
     }
 }
 

--- a/pnpm/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror.rs
@@ -645,14 +645,7 @@ fn read_mirror_headers(file: &mut File) -> Option<MetaHeaders> {
     // Magic + two decimal lengths fit well inside this; the headers
     // record is ~100 bytes of etag + timestamp.
     let mut buf = [0u8; 1024];
-    let mut filled = 0usize;
-    while filled < buf.len() {
-        let n = file.read(&mut buf[filled..]).ok()?;
-        if n == 0 {
-            break;
-        }
-        filled += n;
-    }
+    let filled = fill_probe(file, &mut buf)?;
     let chunk = &buf[..filled];
     let newline = chunk.iter().position(|&byte| byte == b'\n')?;
     let line = std::str::from_utf8(&chunk[..newline]).ok()?;
@@ -663,18 +656,39 @@ fn read_mirror_headers(file: &mut File) -> Option<MetaHeaders> {
         return None;
     }
     let headers_start = newline + 1;
-    let headers_end = headers_start.checked_add(headers_len)?;
-    let headers_json: std::borrow::Cow<'_, [u8]> = if headers_end <= chunk.len() {
-        std::borrow::Cow::Borrowed(&chunk[headers_start..headers_end])
-    } else {
-        // Headers record larger than the probe buffer — read the rest.
-        let mut rest = vec![0u8; headers_end - chunk.len()];
-        file.read_exact(&mut rest).ok()?;
-        let mut whole = chunk[headers_start..].to_vec();
-        whole.extend_from_slice(&rest);
-        std::borrow::Cow::Owned(whole)
-    };
+    let headers_json =
+        read_headers_json(file, chunk, headers_start, headers_start.checked_add(headers_len)?)?;
     serde_json::from_slice(&headers_json).ok()
+}
+
+/// Fill `buf` from `file` until it is full or the file ends.
+fn fill_probe(file: &mut File, buf: &mut [u8]) -> Option<usize> {
+    let mut filled = 0usize;
+    while filled < buf.len() {
+        let n = file.read(&mut buf[filled..]).ok()?;
+        if n == 0 {
+            break;
+        }
+        filled += n;
+    }
+    Some(filled)
+}
+
+/// The headers record, read past the probe buffer when it is larger.
+fn read_headers_json<'c>(
+    file: &mut File,
+    chunk: &'c [u8],
+    headers_start: usize,
+    headers_end: usize,
+) -> Option<std::borrow::Cow<'c, [u8]>> {
+    if headers_end <= chunk.len() {
+        return Some(std::borrow::Cow::Borrowed(&chunk[headers_start..headers_end]));
+    }
+    let mut rest = vec![0u8; headers_end - chunk.len()];
+    file.read_exact(&mut rest).ok()?;
+    let mut whole = chunk[headers_start..].to_vec();
+    whole.extend_from_slice(&rest);
+    Some(std::borrow::Cow::Owned(whole))
 }
 
 /// Read just the first line (headers JSON) of a mirror file. The
@@ -715,58 +729,11 @@ fn load_meta_with_hold_cap(pkg_mirror: &Path, hold_cap: usize) -> Option<Package
     // The magic line plus the two length fields fit well inside this.
     let mut prefix = [0u8; 256];
     let filled = read_prefix(&mut file, &mut prefix)?;
-    let prefix = &prefix[..filled];
-    let newline = prefix.iter().position(|&byte| byte == b'\n')?;
-    let line = std::str::from_utf8(&prefix[..newline]).ok()?;
-    let Some((headers_len, index_len)) = parse_mirror_magic(line) else {
+    let Some(layout) = mirror_layout(&prefix[..filled])? else {
         return load_legacy_ndjson_meta(pkg_mirror);
     };
-    // Bound each declared length, then require the whole header +
-    // index region to fit inside the actual file before allocating a
-    // buffer for it.
-    if headers_len > MAX_HEADERS_LEN || index_len > MAX_INDEX_LEN {
-        return None;
-    }
-    let headers_start = newline + 1;
-    let index_start = headers_start.checked_add(headers_len)?;
-    let fragment_base = index_start.checked_add(index_len)?;
-    let file_size = file.metadata().ok()?.len();
-    if u64::try_from(fragment_base).ok()? > file_size {
-        return None;
-    }
-    // Read the rest of the headers + index records; the file's
-    // fragment section is only buffered on the held-handle fallback
-    // below.
-    let mut records = vec![0u8; fragment_base.checked_sub(filled.min(fragment_base))?];
-    file.read_exact(&mut records).ok()?;
-    let mut prefixed = Vec::with_capacity(fragment_base);
-    prefixed.extend_from_slice(&prefix[..filled.min(fragment_base)]);
-    prefixed.extend_from_slice(&records);
-    let headers: MetaHeaders =
-        serde_json::from_slice(prefixed.get(headers_start..index_start)?).ok()?;
-    let index: MirrorIndex =
-        serde_json::from_slice(prefixed.get(index_start..fragment_base)?).ok()?;
-
-    // Rebase the relative spans and reject any that fall outside the
-    // file — a truncated or hand-edited mirror reads as a miss rather
-    // than handing out garbage fragments later.
-    let mut spans = Vec::with_capacity(index.versions.len());
-    for (version, offset, len) in index.versions {
-        // A span past the fragment bound reads as an absent version
-        // (the same contract as an undecodable fragment) rather than
-        // rejecting the whole document: the bound exists to stop a
-        // corrupt index from driving huge hydration allocations, and
-        // the writer never persists such fragments.
-        if len > MAX_FRAGMENT_LEN {
-            continue;
-        }
-        let absolute = (fragment_base as u64).checked_add(offset)?;
-        if absolute.checked_add(u64::from(len))? > file_size {
-            return None;
-        }
-        spans.push((version, absolute, len));
-    }
-
+    let (headers, index, file_size) = read_mirror_records(&mut file, &prefix[..filled], &layout)?;
+    let spans = absolute_spans(index.versions, layout.fragment_base, file_size)?;
     let versions = match MirrorFile::try_hold(file, hold_cap) {
         Ok(held) => PackageVersions::from_file_spans(&held, spans),
         Err(file) => buffer_fragments(&file, spans)?,
@@ -785,6 +752,88 @@ fn load_meta_with_hold_cap(pkg_mirror: &Path, hold_cap: usize) -> Option<Package
     };
     meta.drop_incomplete_publish_times();
     Some(meta)
+}
+
+/// Where the headers and index records sit in a mirror file, per its
+/// magic line.
+struct MirrorLayout {
+    headers_start: usize,
+    index_start: usize,
+    fragment_base: usize,
+}
+
+/// `None` for an unreadable prefix, `Some(None)` for the legacy NDJSON
+/// format. Each declared length is bounded before the layout is
+/// trusted.
+fn mirror_layout(prefix: &[u8]) -> Option<Option<MirrorLayout>> {
+    let newline = prefix.iter().position(|&byte| byte == b'\n')?;
+    let line = std::str::from_utf8(&prefix[..newline]).ok()?;
+    let Some((headers_len, index_len)) = parse_mirror_magic(line) else {
+        return Some(None);
+    };
+    if headers_len > MAX_HEADERS_LEN || index_len > MAX_INDEX_LEN {
+        return None;
+    }
+    let headers_start = newline + 1;
+    let index_start = headers_start.checked_add(headers_len)?;
+    Some(Some(MirrorLayout {
+        headers_start,
+        index_start,
+        fragment_base: index_start.checked_add(index_len)?,
+    }))
+}
+
+/// Read the rest of the headers + index records, requiring the whole
+/// region to fit inside the actual file before allocating a buffer for
+/// it; the file's fragment section is only buffered on the held-handle
+/// fallback.
+fn read_mirror_records(
+    file: &mut File,
+    prefix: &[u8],
+    layout: &MirrorLayout,
+) -> Option<(MetaHeaders, MirrorIndex, u64)> {
+    let file_size = file.metadata().ok()?.len();
+    if u64::try_from(layout.fragment_base).ok()? > file_size {
+        return None;
+    }
+    let mut records =
+        vec![0u8; layout.fragment_base.checked_sub(prefix.len().min(layout.fragment_base))?];
+    file.read_exact(&mut records).ok()?;
+    let mut prefixed = Vec::with_capacity(layout.fragment_base);
+    prefixed.extend_from_slice(&prefix[..prefix.len().min(layout.fragment_base)]);
+    prefixed.extend_from_slice(&records);
+    let headers: MetaHeaders =
+        serde_json::from_slice(prefixed.get(layout.headers_start..layout.index_start)?).ok()?;
+    let index: MirrorIndex =
+        serde_json::from_slice(prefixed.get(layout.index_start..layout.fragment_base)?).ok()?;
+    Some((headers, index, file_size))
+}
+
+/// Rebase the relative spans and reject any that fall outside the file
+/// — a truncated or hand-edited mirror reads as a miss rather than
+/// handing out garbage fragments later.
+fn absolute_spans(
+    versions: Vec<(String, u64, u32)>,
+    fragment_base: usize,
+    file_size: u64,
+) -> Option<Vec<(String, u64, u32)>> {
+    let mut spans = Vec::with_capacity(versions.len());
+    for (version, offset, len) in versions {
+        // A span past the fragment bound reads as an absent version
+        // (the same contract as an undecodable fragment) rather than
+        // rejecting the whole document: the bound exists to stop a
+        // corrupt index from driving huge hydration allocations, and
+        // the writer never persists such fragments.
+        if len > MAX_FRAGMENT_LEN {
+            continue;
+        }
+        let absolute = (fragment_base as u64).checked_add(offset)?;
+        if absolute.checked_add(u64::from(len))? > file_size {
+            return None;
+        }
+        spans.push((version, absolute, len));
+    }
+    Some(spans)
 }
 
 /// Held-handle budget exhausted (an unusually low descriptor limit, or an

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -192,15 +192,7 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
         validate_revision_selector(&spec)?;
 
         let optional = wanted_dependency.optional.unwrap_or(false);
-        let can_keep_workspace_resolution = opts
-            .current_pkg
-            .as_ref()
-            .is_none_or(|current| matches!(current.resolution, LockfileResolution::Directory(_)));
-        let workspace_packages_active = (spec.revision.is_none()
-            && opts.always_try_workspace_packages
-            && (opts.update != UpdateBehavior::Patches || can_keep_workspace_resolution))
-            .then_some(opts.workspace_packages.as_ref())
-            .flatten();
+        let workspace_packages_active = workspace_packages_active(opts, &spec);
 
         if let Some(result) =
             prefer_workspace_pick(workspace_packages_active, &spec, wanted_dependency, opts)
@@ -208,37 +200,16 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
             return Ok(Some(result));
         }
 
-        let pick_result = self.pick_from_registry(&registry, &spec, opts, optional).await;
-        let picked = match pick_result {
+        let picked = match self.pick_from_registry(&registry, &spec, opts, optional).await {
             Ok(RegistryPick::Picked(picked)) => picked,
-            Ok(RegistryPick::NoMatchingVersion(meta)) => {
-                let registry_error = no_matching_version(wanted_dependency, &registry, &meta);
-                // Neither the registry nor the workspace has a matching
-                // version; the workspace mismatch error carries the
-                // available local versions, which is the actionable detail
-                // here (pnpm/pnpm#1379).
-                return workspace_fallback(
+            outcome => {
+                return workspace_fallback_for(
+                    outcome,
+                    wanted_dependency,
+                    &registry,
                     workspace_packages_active,
                     &spec,
-                    wanted_dependency,
                     opts,
-                    registry_error,
-                    true,
-                );
-            }
-            Err(err) => {
-                // Surface the workspace mismatch (with its available
-                // versions) only when the registry said "not found"; auth,
-                // network, and server errors propagate as-is
-                // (pnpm/pnpm#1379).
-                let prefer_workspace_error = is_not_found_error(err.as_ref());
-                return workspace_fallback(
-                    workspace_packages_active,
-                    &spec,
-                    wanted_dependency,
-                    opts,
-                    err,
-                    prefer_workspace_error,
                 );
             }
         };
@@ -266,26 +237,7 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
             published_by: opts.published_by,
             published_by_exclude: opts.published_by_exclude.as_ref(),
             picked_manifest_cache: &self.picked_manifest_cache,
-            calculated_specifier: revision_specifier(
-                wanted_dependency,
-                opts,
-                &spec,
-                None,
-                &spec.name,
-                &picked.version.version,
-            )
-            .or_else(|| {
-                calc_specifier_from(wanted_dependency, opts, &spec).map(
-                    |(bare_specifier, default_pin)| {
-                        crate::calc_specifier(
-                            bare_specifier,
-                            wanted_dependency.alias.as_deref(),
-                            &picked.version,
-                            default_pin,
-                        )
-                    },
-                )
-            }),
+            calculated_specifier: calculated_specifier(wanted_dependency, opts, &spec, &picked),
         })?;
 
         Ok(Some(result))
@@ -765,6 +717,29 @@ pub(crate) struct PickFromRegistryOptions<'a> {
 /// versions, so it only fires on a pathological/hostile packument.
 const GUARD_REPICK_LIMIT: usize = 1000;
 
+fn pick_options<'o>(
+    opts: &'o PickFromRegistryOptions<'o>,
+    blocked_versions: &'o std::collections::HashSet<String>,
+) -> PickPackageOptions<'o> {
+    PickPackageOptions {
+        registry: opts.registry,
+        preferred_version_selectors: opts.preferred_version_selectors,
+        published_by: opts.published_by,
+        published_by_exclude: opts.published_by_exclude,
+        pick_lowest_version: opts.pick_lowest_version,
+        include_latest_tag: opts.include_latest_tag,
+        dry_run: opts.dry_run,
+        optional: opts.optional,
+        update_checksums: opts.update_checksums,
+        trust_policy: opts.trust_policy,
+        blocked_versions: (!blocked_versions.is_empty()).then_some(blocked_versions),
+    }
+}
+
+fn all_versions_blocked(name: String, reason: String) -> ResolveError {
+    Box::new(AllVersionsBlockedError { name, reason })
+}
+
 pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
     ctx: &PickPackageContext<'_, Cache>,
     opts: PickFromRegistryOptions<'_>,
@@ -775,20 +750,7 @@ pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
     // would have returned with no guard at all.
     let mut first_rejected: Option<PickedFromRegistry> = None;
     loop {
-        let pick_opts = PickPackageOptions {
-            registry: opts.registry,
-            preferred_version_selectors: opts.preferred_version_selectors,
-            published_by: opts.published_by,
-            published_by_exclude: opts.published_by_exclude,
-            pick_lowest_version: opts.pick_lowest_version,
-            include_latest_tag: opts.include_latest_tag,
-            dry_run: opts.dry_run,
-            optional: opts.optional,
-            update_checksums: opts.update_checksums,
-            trust_policy: opts.trust_policy,
-            blocked_versions: (!blocked_versions.is_empty()).then_some(&blocked_versions),
-        };
-        let pick_result = pick_package(ctx, opts.spec, &pick_opts)
+        let pick_result = pick_package(ctx, opts.spec, &pick_options(&opts, &blocked_versions))
             .await
             .map_err(|err| map_pick_error(ctx, &opts, err))?;
 
@@ -799,9 +761,7 @@ pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
             // failure names the guard rather than blaming the range the user
             // wrote.
             return match last_rejection {
-                Some(reason) => exhausted(&opts, first_rejected, reason, |name, reason| {
-                    Box::new(AllVersionsBlockedError { name, reason })
-                }),
+                Some(reason) => exhausted(&opts, first_rejected, reason, all_versions_blocked),
                 None => Ok(RegistryPick::NoMatchingVersion(pick_result.meta)),
             };
         };
@@ -986,31 +946,12 @@ pub(crate) struct BuildResolveResult<'a> {
 pub(crate) fn build_resolve_result(
     args: BuildResolveResult<'_>,
 ) -> Result<ResolveResult, ResolveError> {
-    let BuildResolveResult {
-        meta,
-        picked,
-        spec,
-        alias,
-        resolved_via,
-        registry,
-        registry_name,
-        published_by,
-        published_by_exclude,
-        picked_manifest_cache,
-        calculated_specifier,
-    } = args;
-    let picked = select_package_revision(picked, spec, registry)?;
+    let picked = select_package_revision(args.picked, args.spec, args.registry)?;
     let picked = picked.as_ref();
     let pkg_name =
         PkgName::parse(picked.name.as_str()).map_err(|err| Box::new(err) as ResolveError)?;
     let version_str = picked.version.to_string();
     let name_ver = PkgNameVer::new(pkg_name.clone(), picked.version.clone());
-    let id = match registry_name {
-        Some(registry_name) => {
-            PkgResolutionId::from(format!("{}@{registry_name}:{}", picked.name, picked.version))
-        }
-        None => (&name_ver).into(),
-    };
     // The picker always carries a tarball URL on its `dist` payload —
     // every npm registry serves `dist.tarball` on a successful pick
     // and pacquet's deserializer requires it (`dist.tarball: String`,
@@ -1020,6 +961,147 @@ pub(crate) fn build_resolve_result(
     // reconstruction with no payoff: at resolve time we already have
     // the URL the install path needs.
     let integrity = dist_integrity(&picked.dist)?;
+    let revision = tarball_revision(picked, integrity.as_ref(), args.registry)?;
+    let resolution = LockfileResolution::Tarball(TarballResolution {
+        tarball: picked.dist.tarball.clone(),
+        integrity,
+        revision,
+        git_hosted: None,
+        path: None,
+    });
+    let published_at = args.meta.published_at(&version_str).map(str::to_string);
+    let manifest = cached_manifest(
+        args.picked_manifest_cache,
+        format!(
+            "{}\x00{}@{version_str}+r{}",
+            args.registry,
+            picked.name,
+            revision.map_or(0, TarballRevision::get),
+        ),
+        picked,
+    )?;
+    Ok(ResolveResult {
+        id: resolution_id(args.registry_name, picked, &name_ver),
+        name_ver: Some(name_ver),
+        latest: latest_allowed_by_policy(args.meta, args.published_by, args.published_by_exclude)
+            .map(str::to_string),
+        published_at: published_at.clone(),
+        manifest: Some(manifest),
+        policy_violation: detect_min_release_age_violation(
+            &pkg_name,
+            &version_str,
+            published_at.as_deref(),
+            &resolution,
+            args.published_by,
+            args.published_by_exclude,
+        ),
+        resolution,
+        resolved_via: args.resolved_via.to_string(),
+        normalized_bare_specifier: args
+            .spec
+            .normalized_bare_specifier
+            .clone()
+            .or(args.calculated_specifier),
+        alias: args.alias.map(str::to_string),
+    })
+}
+
+/// The workspace packages a pick may prefer over the registry, when the
+/// spec and the update mode allow a workspace resolution to stand.
+fn workspace_packages_active<'o>(
+    opts: &'o ResolveOptions,
+    spec: &RegistryPackageSpec,
+) -> Option<&'o std::sync::Arc<WorkspacePackages>> {
+    let can_keep_workspace_resolution = opts
+        .current_pkg
+        .as_ref()
+        .is_none_or(|current| matches!(current.resolution, LockfileResolution::Directory(_)));
+    (spec.revision.is_none()
+        && opts.always_try_workspace_packages
+        && (opts.update != UpdateBehavior::Patches || can_keep_workspace_resolution))
+        .then_some(opts.workspace_packages.as_ref())
+        .flatten()
+}
+
+/// The workspace's answer when the registry had none. Neither the
+/// registry nor the workspace having a matching version, the workspace
+/// mismatch error carries the available local versions, which is the
+/// actionable detail (pnpm/pnpm#1379); on a registry error the mismatch
+/// is preferred only when the registry said "not found", while auth,
+/// network, and server errors propagate as-is.
+fn workspace_fallback_for(
+    outcome: Result<RegistryPick, ResolveError>,
+    wanted_dependency: &WantedDependency,
+    registry: &str,
+    workspace_packages_active: Option<&std::sync::Arc<WorkspacePackages>>,
+    spec: &RegistryPackageSpec,
+    opts: &ResolveOptions,
+) -> Result<Option<ResolveResult>, ResolveError> {
+    match outcome {
+        Ok(RegistryPick::Picked(_)) => unreachable!("picked outcomes never fall back"),
+        Ok(RegistryPick::NoMatchingVersion(meta)) => workspace_fallback(
+            workspace_packages_active,
+            spec,
+            wanted_dependency,
+            opts,
+            no_matching_version(wanted_dependency, registry, &meta),
+            true,
+        ),
+        Err(err) => {
+            let prefer_workspace_error = is_not_found_error(err.as_ref());
+            workspace_fallback(
+                workspace_packages_active,
+                spec,
+                wanted_dependency,
+                opts,
+                err,
+                prefer_workspace_error,
+            )
+        }
+    }
+}
+
+fn calculated_specifier(
+    wanted_dependency: &WantedDependency,
+    opts: &ResolveOptions,
+    spec: &RegistryPackageSpec,
+    picked: &PickedFromRegistry,
+) -> Option<String> {
+    revision_specifier(wanted_dependency, opts, spec, None, &spec.name, &picked.version.version)
+        .or_else(|| {
+            calc_specifier_from(wanted_dependency, opts, spec).map(
+                |(bare_specifier, default_pin)| {
+                    crate::calc_specifier(
+                        bare_specifier,
+                        wanted_dependency.alias.as_deref(),
+                        &picked.version,
+                        default_pin,
+                    )
+                },
+            )
+        })
+}
+
+fn resolution_id(
+    registry_name: Option<&str>,
+    picked: &PackageVersion,
+    name_ver: &PkgNameVer,
+) -> PkgResolutionId {
+    match registry_name {
+        Some(registry_name) => {
+            PkgResolutionId::from(format!("{}@{registry_name}:{}", picked.name, picked.version))
+        }
+        None => name_ver.into(),
+    }
+}
+
+/// The tarball's revision, when the registry serves one: it must pair
+/// with a URL addressed by the pick's complete sha512 integrity.
+fn tarball_revision(
+    picked: &PackageVersion,
+    integrity: Option<&Integrity>,
+    registry: &str,
+) -> Result<Option<TarballRevision>, ResolveError> {
     let revision = picked
         .dist
         .revision
@@ -1038,7 +1120,7 @@ pub(crate) fn build_resolve_result(
                 as ResolveError
         })?;
     if revision.is_some()
-        && !integrity.as_ref().is_some_and(|integrity| {
+        && !integrity.is_some_and(|integrity| {
             is_integrity_addressed_registry_tarball_url(&picked.dist.tarball, integrity, registry)
         })
     {
@@ -1047,58 +1129,29 @@ pub(crate) fn build_resolve_result(
             "the URL does not match its complete sha512 integrity and registry",
         )));
     }
-    let resolution = LockfileResolution::Tarball(TarballResolution {
-        tarball: picked.dist.tarball.clone(),
-        integrity,
-        revision,
-        git_hosted: None,
-        path: None,
-    });
-    let published_at = meta.published_at(&version_str).map(str::to_string);
-    // Dedupe `serde_json::to_value(picked)` across picks of the
-    // same `(registry, pkg_name, version)` triple — see
-    // [`PickedManifestCache`] for the rationale. The cache is shared
-    // across the npm / JSR / named-registry resolvers, so the key
-    // has to scope by `registry` too; two registries may serve
-    // different artifacts under the same `name@version`, and
-    // collapsing them would hand the second registry's resolver
-    // the first registry's manifest — wrong dependency graph,
-    // wrong peers, wrong lockfile metadata. Matches `meta_cache`'s
-    // `{registry}\x00{name}` scoping shape.
-    let manifest_cache_key = format!(
-        "{registry}\x00{}@{version_str}+r{}",
-        picked.name,
-        revision.map_or(0, TarballRevision::get),
-    );
-    let manifest = if let Some(cached) = picked_manifest_cache.get(&manifest_cache_key) {
-        Some(Arc::clone(cached.value()))
-    } else {
-        let arc =
-            Arc::new(serde_json::to_value(picked).map_err(|err| Box::new(err) as ResolveError)?);
-        picked_manifest_cache.insert(manifest_cache_key, Arc::clone(&arc));
-        Some(arc)
-    };
-    let policy_violation = detect_min_release_age_violation(
-        &pkg_name,
-        &version_str,
-        published_at.as_deref(),
-        &resolution,
-        published_by,
-        published_by_exclude,
-    );
-    Ok(ResolveResult {
-        id,
-        name_ver: Some(name_ver),
-        latest: latest_allowed_by_policy(meta, published_by, published_by_exclude)
-            .map(str::to_string),
-        published_at,
-        manifest,
-        resolution,
-        resolved_via: resolved_via.to_string(),
-        normalized_bare_specifier: spec.normalized_bare_specifier.clone().or(calculated_specifier),
-        alias: alias.map(str::to_string),
-        policy_violation,
-    })
+    Ok(revision)
+}
+
+/// Dedupe `serde_json::to_value(picked)` across picks of the same
+/// `(registry, pkg_name, version)` triple — see [`PickedManifestCache`]
+/// for the rationale. The cache is shared across the npm / JSR /
+/// named-registry resolvers, so the key has to scope by `registry` too;
+/// two registries may serve different artifacts under the same
+/// `name@version`, and collapsing them would hand the second registry's
+/// resolver the first registry's manifest — wrong dependency graph,
+/// wrong peers, wrong lockfile metadata. Matches `meta_cache`'s
+/// `{registry}\x00{name}` scoping shape.
+fn cached_manifest(
+    cache: &crate::PickedManifestCache,
+    key: String,
+    picked: &PackageVersion,
+) -> Result<Arc<serde_json::Value>, ResolveError> {
+    if let Some(cached) = cache.get(&key) {
+        return Ok(Arc::clone(cached.value()));
+    }
+    let arc = Arc::new(serde_json::to_value(picked).map_err(|err| Box::new(err) as ResolveError)?);
+    cache.insert(key, Arc::clone(&arc));
+    Ok(arc)
 }
 
 fn select_package_revision<'a>(

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -1133,7 +1133,7 @@ fn tarball_revision(
 }
 
 /// Dedupe `serde_json::to_value(picked)` across picks of the same
-/// `(registry, pkg_name, version)` triple — see [`PickedManifestCache`]
+/// `(registry, pkg_name, version)` triple — see [`PickedManifestCache`](crate::pick_package::PickedManifestCache)
 /// for the rationale. The cache is shared across the npm / JSR /
 /// named-registry resolvers, so the key has to scope by `registry` too;
 /// two registries may serve different artifacts under the same

--- a/pnpm/crates/tarball/src/download.rs
+++ b/pnpm/crates/tarball/src/download.rs
@@ -633,6 +633,12 @@ impl<'a> BodyProgress<'a> {
         }
     }
 
+    pub(crate) fn on_chunks<Reporter: self::Reporter>(&mut self, chunks: &[bytes::Bytes]) {
+        for chunk in chunks {
+            self.on_chunk::<Reporter>(chunk.len());
+        }
+    }
+
     pub(crate) fn on_chunk<Reporter: self::Reporter>(&mut self, len: usize) {
         self.downloaded = self.downloaded.saturating_add(len as u64);
         let throttle_ready =
@@ -759,22 +765,17 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
     let mut progress = BodyProgress::new(expected_size, package_id);
 
     let (prefix, prefix_len) = read_gzip_prefix(&mut stream, package_url).await?;
-    let is_gzip = {
-        let mut magic = prefix.iter().flat_map(|chunk| chunk.iter().copied());
-        (magic.next(), magic.next()) == (Some(GZIP_MAGIC[0]), Some(GZIP_MAGIC[1]))
-    };
+    let is_gzip = starts_with_gzip_magic(&prefix);
 
     // Take the streaming extractor up front when the advertised size
     // already says the archive is large. Retries stay buffered so their
     // terminal errors retain the whole-archive decode's diagnostics.
     if is_gzip
         && attempt == 0
-        && expected_size.is_some_and(|size| size >= STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD)
+        && advertises_large_body(expected_size)
         && let Ok(streaming_permit) = streaming_extract_semaphore().try_acquire()
     {
-        for chunk in &prefix {
-            progress.on_chunk::<Reporter>(chunk.len());
-        }
+        progress.on_chunks::<Reporter>(&prefix);
         return extract_body_while_downloading::<Reporter, _, _>(
             prefix,
             stream,
@@ -948,17 +949,7 @@ where
     Reporter: self::Reporter,
     Body: Stream<Item = reqwest::Result<bytes::Bytes>> + Unpin,
 {
-    let BufferBody {
-        stream,
-        progress,
-        prefix,
-        prefix_len,
-        expected_size,
-        expected_integrity,
-        is_gzip,
-        package_url,
-        http_client,
-    } = inputs;
+    let BufferBody { stream, progress, .. } = inputs;
 
     // Pre-size from the advertised length, but only as far as this
     // path will ever fill: past the threshold below the body is
@@ -966,14 +957,15 @@ where
     // advertised size would be reserving for bytes that never land
     // here — and would let a server's claim, rather than its body,
     // decide the size of an allocation.
-    let reserve = expected_size.map(|size| size.min(STREAM_EXTRACT_COMPRESSED_THRESHOLD as u64));
-    let mut buf = allocate_tarball_buffer(reserve, package_url)?;
-    for chunk in prefix {
+    let reserve =
+        inputs.expected_size.map(|size| size.min(STREAM_EXTRACT_COMPRESSED_THRESHOLD as u64));
+    let mut buf = allocate_tarball_buffer(reserve, inputs.package_url)?;
+    for chunk in inputs.prefix {
         buf.extend_from_slice(&chunk);
         progress.on_chunk::<Reporter>(chunk.len());
     }
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|error| fetch_error(package_url, error))?;
+        let chunk = chunk.map_err(|error| fetch_error(inputs.package_url, error))?;
         buf.extend_from_slice(&chunk);
         progress.on_chunk::<Reporter>(chunk.len());
         // Nothing above bounds how much body a server may send: a
@@ -984,14 +976,14 @@ where
         if buf.len() < STREAM_EXTRACT_COMPRESSED_THRESHOLD {
             continue;
         }
-        if !is_gzip {
+        if !inputs.is_gzip {
             return Err(drain_non_gzip_body::<Reporter, _>(
                 stream,
                 progress,
                 buf,
-                expected_integrity,
-                package_url,
-                prefix_len,
+                inputs.expected_integrity,
+                inputs.package_url,
+                inputs.prefix_len,
             )
             .await);
         }
@@ -1000,9 +992,18 @@ where
         buf.shrink_to_fit();
         return Ok(Buffered::Overflowed(buf));
     }
-    progress.warn_if_slow(http_client, package_url);
+    progress.warn_if_slow(inputs.http_client, inputs.package_url);
     progress.finish::<Reporter>();
     Ok(Buffered::Complete(buf))
+}
+
+fn starts_with_gzip_magic(prefix: &[bytes::Bytes]) -> bool {
+    let mut magic = prefix.iter().flat_map(|chunk| chunk.iter().copied());
+    (magic.next(), magic.next()) == (Some(GZIP_MAGIC[0]), Some(GZIP_MAGIC[1]))
+}
+
+fn advertises_large_body(expected_size: Option<u64>) -> bool {
+    expected_size.is_some_and(|size| size >= STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD)
 }
 
 /// A body that does not start with the gzip magic fails at the decoder

--- a/pnpm/crates/tarball/src/ingestion.rs
+++ b/pnpm/crates/tarball/src/ingestion.rs
@@ -9,7 +9,8 @@ use crate::{
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pnpm_reporter::Reporter;
 use pnpm_store_dir::{
-    SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreDir, StoreIndexWriter,
+    PackageFilesIndex, SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreDir,
+    StoreIndexWriter,
 };
 use ssri::Integrity;
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
@@ -54,66 +55,62 @@ impl ArchiveIngestion<'_> {
     pub(crate) async fn run<Reporter: self::Reporter>(
         &self,
     ) -> Result<HashMap<String, PathBuf>, TarballError> {
-        let &ArchiveIngestion {
-            store_dir,
-            package_integrity,
-            package_url,
-            package_id,
-            requester,
-            verify_store_integrity,
-            strict_store_pkg_content_check,
-            prefetched_cas_paths,
-            store_projection,
-            ..
-        } = self;
-        let cache_key = store_index_cache_key(package_integrity, package_id, store_projection);
+        let cache_key = self.cache_key();
         let progress_key = self.progress_reported.as_ref().zip(cache_key.as_deref());
-        if let Some(prefetched) = prefetched_cas_paths
+        if let Some(prefetched) = self.prefetched_cas_paths
             && let Some(cache_key) = cache_key.as_deref()
             && let Some(cas_paths) = prefetched.get(cache_key)
         {
             tracing::info!(
                 target: "pacquet::download",
-                ?package_url,
-                ?package_id,
+                package_url = ?self.package_url,
+                package_id = ?self.package_id,
                 "Reusing prefetched CAFS entry — skipping download",
             );
-            emit_progress_found_in_store::<Reporter>(package_id, requester, progress_key);
+            emit_progress_found_in_store::<Reporter>(self.package_id, self.requester, progress_key);
             return Ok((**cas_paths).clone());
         }
         if let Some(cache_key) = cache_key.clone() {
             let cached = load_cached_cas_paths::<Reporter>(
                 self.store_index.clone(),
-                store_dir,
+                self.store_dir,
                 cache_key,
-                verify_store_integrity,
-                store_projection.package_content_check(strict_store_pkg_content_check),
+                self.verify_store_integrity,
+                self.store_projection.package_content_check(self.strict_store_pkg_content_check),
                 Arc::clone(self.verified_files_cache),
             )
             .await?;
             if let Some(cas_paths) = cached {
-                tracing::info!(target: "pacquet::download", ?package_url, ?package_id, "Reusing cached CAFS entry — skipping download");
-                emit_progress_found_in_store::<Reporter>(package_id, requester, progress_key);
+                tracing::info!(target: "pacquet::download", package_url = ?self.package_url, package_id = ?self.package_id, "Reusing cached CAFS entry — skipping download");
+                emit_progress_found_in_store::<Reporter>(
+                    self.package_id,
+                    self.requester,
+                    progress_key,
+                );
                 return Ok(cas_paths);
             }
             if let (
                 Some(package_integrity),
                 ArchiveStoreProjection::Package { append_manifest: Some(_) },
-            ) = (package_integrity, store_projection)
+            ) = (self.package_integrity, self.store_projection)
             {
                 let cached = load_legacy_synthesized_cas_paths::<Reporter>(
                     self.store_index.clone(),
-                    store_dir,
+                    self.store_dir,
                     &package_integrity.to_string(),
-                    package_id,
-                    verify_store_integrity,
+                    self.package_id,
+                    self.verify_store_integrity,
                     Arc::clone(self.verified_files_cache),
-                    store_projection,
+                    self.store_projection,
                 )
                 .await?;
                 if let Some(cas_paths) = cached {
-                    tracing::info!(target: "pacquet::download", ?package_url, ?package_id, "Reusing compatible legacy CAFS entry — skipping download");
-                    emit_progress_found_in_store::<Reporter>(package_id, requester, progress_key);
+                    tracing::info!(target: "pacquet::download", package_url = ?self.package_url, package_id = ?self.package_id, "Reusing compatible legacy CAFS entry — skipping download");
+                    emit_progress_found_in_store::<Reporter>(
+                        self.package_id,
+                        self.requester,
+                        progress_key,
+                    );
                     return Ok(cas_paths);
                 }
             }
@@ -121,107 +118,125 @@ impl ArchiveIngestion<'_> {
         self.fetch::<Reporter>(false).await.map(|result| result.files_map)
     }
 
+    fn cache_key(&self) -> Option<String> {
+        store_index_cache_key(self.package_integrity, self.package_id, self.store_projection)
+    }
+
     pub(crate) async fn fetch<Reporter: self::Reporter>(
         &self,
         record_computed_integrity: bool,
     ) -> Result<FetchedTarball, TarballError> {
-        let &ArchiveIngestion {
-            http_client,
-            store_dir,
-            package_integrity,
-            format,
-            package_url,
-            package_id,
-            requester,
-            retry_opts,
-            auth_headers,
-            store_projection,
-            ..
-        } = self;
-        let cache_key = store_index_cache_key(package_integrity, package_id, store_projection);
-        let progress_key = self.progress_reported.as_ref().zip(cache_key.as_deref());
-        let store_index_writer = self.store_index_writer.clone();
-        let ignore_file_pattern = self.ignore_file_pattern.clone();
-        if self.offline && !format.is_local(package_url) {
+        let cache_key = self.cache_key();
+        if self.offline && !self.format.is_local(self.package_url) {
             tracing::warn!(
                 target: "pacquet::download",
-                ?package_url,
-                ?package_id,
+                package_url = ?self.package_url,
+                package_id = ?self.package_id,
                 "offline mode: tarball missing from local store; refusing network fetch",
             );
             return Err(TarballError::NoOfflineTarball {
-                package_id: package_id.to_string(),
-                url: package_url.to_string(),
+                package_id: self.package_id.to_string(),
+                url: self.package_url.to_string(),
             });
         }
 
-        tracing::info!(target: "pacquet::download", ?package_url, "New cache");
+        tracing::info!(target: "pacquet::download", package_url = ?self.package_url, "New cache");
 
-        let (computed_integrity, mut cas_paths, mut pkg_files_idx) = match format {
-            ArchiveFormat::TarGz { unpacked_size, file_count, revision_addressed } => {
-                fetch_and_extract_with_retry::<Reporter>(
-                    http_client,
-                    package_url,
-                    package_integrity,
-                    unpacked_size,
-                    download_priority(unpacked_size, file_count),
-                    package_id,
-                    requester,
-                    store_dir,
-                    retry_opts,
-                    auth_headers,
-                    ignore_file_pattern,
-                    progress_key,
-                    revision_addressed,
-                )
-                .await?
-            }
-            ArchiveFormat::Zip { integrity, prefix } => {
-                let (paths, index) = fetch_and_extract_zip_with_retry::<Reporter>(
-                    http_client,
-                    package_url,
-                    integrity,
-                    package_id,
-                    requester,
-                    store_dir,
-                    retry_opts,
-                    auth_headers,
-                    prefix,
-                    ignore_file_pattern,
-                )
-                .await?;
-                (integrity.clone(), paths, index)
-            }
-        };
-
-        match store_projection {
-            ArchiveStoreProjection::Package { append_manifest } => {
-                if let Some(manifest_bytes) = append_manifest {
-                    apply_append_manifest(
-                        store_dir,
-                        manifest_bytes,
-                        &mut cas_paths,
-                        &mut pkg_files_idx,
-                    )?;
-                }
-                apply_placeholder_manifest(store_dir, &mut cas_paths, &mut pkg_files_idx)?;
-            }
-            ArchiveStoreProjection::RawArchive => {}
-        }
+        let (computed_integrity, mut cas_paths, mut pkg_files_idx) = self
+            .fetch_archive::<Reporter>(self.progress_reported.as_ref().zip(cache_key.as_deref()))
+            .await?;
+        self.project_files(&mut cas_paths, &mut pkg_files_idx)?;
 
         let manifest = pkg_files_idx.manifest.clone();
-        let requires_build = match format {
+        let requires_build = match self.format {
             ArchiveFormat::TarGz { .. } => pkg_files_idx
                 .requires_build
                 .expect("fresh tarball extraction records build requirement"),
             ArchiveFormat::Zip { .. } => pkg_files_idx.requires_build.unwrap_or(false),
         };
-        let cache_key = cache_key.or_else(|| {
-            record_computed_integrity.then(|| {
-                store_projection.store_index_key(&computed_integrity.to_string(), package_id)
-            })
-        });
-        match (cache_key, store_index_writer) {
+        self.queue_index_row(
+            cache_key.or_else(|| {
+                record_computed_integrity.then(|| {
+                    self.store_projection
+                        .store_index_key(&computed_integrity.to_string(), self.package_id)
+                })
+            }),
+            pkg_files_idx,
+        );
+
+        Ok(FetchedTarball {
+            integrity: computed_integrity,
+            files_map: cas_paths,
+            manifest,
+            requires_build,
+        })
+    }
+
+    async fn fetch_archive<Reporter: self::Reporter>(
+        &self,
+        progress_key: Option<(&SharedReportedProgressKeys, &str)>,
+    ) -> Result<(Integrity, HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
+        match self.format {
+            ArchiveFormat::TarGz { unpacked_size, file_count, revision_addressed } => {
+                fetch_and_extract_with_retry::<Reporter>(
+                    self.http_client,
+                    self.package_url,
+                    self.package_integrity,
+                    unpacked_size,
+                    download_priority(unpacked_size, file_count),
+                    self.package_id,
+                    self.requester,
+                    self.store_dir,
+                    self.retry_opts,
+                    self.auth_headers,
+                    self.ignore_file_pattern.clone(),
+                    progress_key,
+                    revision_addressed,
+                )
+                .await
+            }
+            ArchiveFormat::Zip { integrity, prefix } => {
+                let (paths, index) = fetch_and_extract_zip_with_retry::<Reporter>(
+                    self.http_client,
+                    self.package_url,
+                    integrity,
+                    self.package_id,
+                    self.requester,
+                    self.store_dir,
+                    self.retry_opts,
+                    self.auth_headers,
+                    prefix,
+                    self.ignore_file_pattern.clone(),
+                )
+                .await?;
+                Ok((integrity.clone(), paths, index))
+            }
+        }
+    }
+
+    fn project_files(
+        &self,
+        cas_paths: &mut HashMap<String, PathBuf>,
+        pkg_files_idx: &mut PackageFilesIndex,
+    ) -> Result<(), TarballError> {
+        match self.store_projection {
+            ArchiveStoreProjection::Package { append_manifest } => {
+                if let Some(manifest_bytes) = append_manifest {
+                    apply_append_manifest(
+                        self.store_dir,
+                        manifest_bytes,
+                        cas_paths,
+                        pkg_files_idx,
+                    )?;
+                }
+                apply_placeholder_manifest(self.store_dir, cas_paths, pkg_files_idx)
+            }
+            ArchiveStoreProjection::RawArchive => Ok(()),
+        }
+    }
+
+    fn queue_index_row(&self, cache_key: Option<String>, pkg_files_idx: PackageFilesIndex) {
+        match (cache_key, self.store_index_writer) {
             (Some(index_key), Some(writer)) => writer.queue(index_key, pkg_files_idx),
             (Some(index_key), None) => tracing::warn!(
                 target: "pacquet::download",
@@ -230,17 +245,10 @@ impl ArchiveIngestion<'_> {
             ),
             (None, _) => tracing::debug!(
                 target: "pacquet::download",
-                ?package_url,
-                ?package_id,
+                package_url = ?self.package_url,
+                package_id = ?self.package_id,
                 "resolution carries no integrity; skipping index row for this archive",
             ),
         }
-
-        Ok(FetchedTarball {
-            integrity: computed_integrity,
-            files_map: cas_paths,
-            manifest,
-            requires_build,
-        })
     }
 }

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -234,19 +234,13 @@ impl<'a> IngestTarballToStore<'a> {
         mem_cache: &'a MemCache,
         revision_addressed: bool,
     ) -> Result<Arc<HashMap<String, PathBuf>>, TarballError> {
-        let &IngestTarballToStore {
-            package_url,
-            package_id,
-            package_integrity,
-            prefetched_cas_paths,
-            store_projection,
-            ..
-        } = &self;
-        let mem_cache_key = store_projection.mem_cache_key(package_url, revision_addressed);
-        let cache_key = store_index_cache_key(package_integrity, package_id, store_projection);
+        let mem_cache_key =
+            self.store_projection.mem_cache_key(self.package_url, revision_addressed);
+        let cache_key =
+            store_index_cache_key(self.package_integrity, self.package_id, self.store_projection);
         let progress_key = self.progress_reported.as_ref().zip(cache_key.as_deref());
 
-        if let Some(prefetched) = prefetched_cas_paths
+        if let Some(prefetched) = self.prefetched_cas_paths
             && let Some(cache_key) = cache_key.as_deref()
             && let Some(cas_paths) = prefetched.get(cache_key)
         {
@@ -545,40 +539,29 @@ impl FetchTarballForResolution<'_> {
         self,
         mem_cache: Option<&MemCache>,
     ) -> Result<ResolvedTarball, TarballError> {
-        let FetchTarballForResolution {
-            http_client,
-            store_dir,
-            store_index_writer,
-            package_url,
-            package_id,
-            auth_headers,
-            retry_opts,
-            manifest_subdir,
-        } = self;
-
         // Resolve-time tarball fetches compute integrity from bytes and
         // gate the dependency walk, so they use the same priority class as
         // packument requests instead of queuing behind sized downloads.
         let (integrity, mut cas_paths, mut pkg_files_idx) =
             fetch_and_extract_with_retry::<Reporter>(
-                http_client,
-                package_url,
+                self.http_client,
+                self.package_url,
                 None,
                 None,
                 UNPRIORITIZED,
-                package_id,
-                package_url,
-                store_dir,
-                retry_opts,
-                auth_headers,
+                self.package_id,
+                self.package_url,
+                self.store_dir,
+                self.retry_opts,
+                self.auth_headers,
                 None,
                 None,
                 false,
             )
             .await?;
-        apply_placeholder_manifest(store_dir, &mut cas_paths, &mut pkg_files_idx)?;
+        apply_placeholder_manifest(self.store_dir, &mut cas_paths, &mut pkg_files_idx)?;
 
-        let manifest = match manifest_subdir {
+        let manifest = match self.manifest_subdir {
             Some(subdir) => read_subdir_manifest(&cas_paths, subdir).await?,
             None => pkg_files_idx.manifest.clone(),
         };
@@ -594,15 +577,15 @@ impl FetchTarballForResolution<'_> {
         // `git_hosted_store_index_key` once the install pass has run
         // `prepare` over it, and both the graph prefetch and the
         // warm-store reuse map skip git-hosted entries.
-        if manifest_subdir.is_none() {
+        if self.manifest_subdir.is_none() {
             // Key the row by the caller's `package_id` — the same
             // `pkg_id` the install pass derives from the lockfile entry.
             // Deriving a `name@version` from the bundled manifest instead
             // would file a remote tarball under a key nothing ever reads,
             // leaving the install pass to write a second row for the same
             // content.
-            let index_key = store_index_key(&integrity.to_string(), package_id);
-            if let Some(writer) = store_index_writer {
+            let index_key = store_index_key(&integrity.to_string(), self.package_id);
+            if let Some(writer) = self.store_index_writer {
                 writer.queue(index_key, pkg_files_idx);
             } else {
                 tracing::warn!(
@@ -615,7 +598,7 @@ impl FetchTarballForResolution<'_> {
 
         if let Some(mem_cache) = mem_cache {
             let cache_lock = Arc::new(RwLock::new(CacheValue::Available(Arc::new(cas_paths))));
-            mem_cache.insert(package_url.to_string(), cache_lock);
+            mem_cache.insert(self.package_url.to_string(), cache_lock);
         }
 
         Ok(ResolvedTarball { integrity, manifest })

--- a/pnpm/crates/tarball/src/zip_archive.rs
+++ b/pnpm/crates/tarball/src/zip_archive.rs
@@ -40,16 +40,7 @@ pub(crate) fn extract_zip_entries(
     ignore_file_pattern: Option<&IgnoreEntryFilter>,
 ) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
     let entry_count = archive.len();
-    let mut cas_paths = HashMap::<String, PathBuf>::with_capacity(entry_count);
-    let mut pkg_files_idx = PackageFilesIndex {
-        manifest: None,
-        requires_build: None,
-        requires_prepare: None,
-        algo: "sha512".to_string(),
-        files: HashMap::with_capacity(entry_count),
-        side_effects: None,
-        remote_side_effects_quarantine: None,
-    };
+    let mut extracted = ExtractedEntries::with_capacity(entry_count);
 
     // Build the `{prefix}/` slice once. Treat `Some("")` as `None`,
     // keeping entry paths verbatim when there is no prefix. The
@@ -68,45 +59,80 @@ pub(crate) fn extract_zip_entries(
         else {
             continue;
         };
+        let stored = store_zip_entry(&mut entry, package_url, &cleaned, store_dir)?;
+        extracted.insert(cleaned, stored);
+    }
 
-        // Central-directory record carries a Unix mode only when
-        // the archive was built by a Unix tool; Windows-built
-        // archives omit it. Fall back to `0o644` so the executable
-        // bit defaults to off. Mask off the high `st_mode` bits
-        // (e.g. `0o100000` for a regular file) so `CafsFileInfo.mode`
-        // stays permission-only, matching the convention
-        // `add_files_from_dir.rs` enforces for tar / on-disk imports.
-        let file_mode = entry.unix_mode().unwrap_or(0o644) & 0o777;
-        let file_is_executable = file_mode::is_executable(file_mode);
-        let declared_size = entry.size();
+    Ok((extracted.cas_paths, extracted.files_index))
+}
 
-        let (file_path, file_hash, file_size) = write_zip_entry_to_cas(
-            &mut entry,
-            declared_size,
-            package_url,
-            &cleaned,
-            store_dir,
-            file_is_executable,
-        )?;
+/// The CAS paths and index rows of the entries extracted so far.
+struct ExtractedEntries {
+    cas_paths: HashMap<String, PathBuf>,
+    files_index: PackageFilesIndex,
+}
 
-        let checked_at =
-            UNIX_EPOCH.elapsed().ok().and_then(|elapsed| u64::try_from(elapsed.as_millis()).ok());
-        let file_attrs = CafsFileInfo {
+impl ExtractedEntries {
+    fn with_capacity(entry_count: usize) -> Self {
+        Self {
+            cas_paths: HashMap::with_capacity(entry_count),
+            files_index: PackageFilesIndex {
+                manifest: None,
+                requires_build: None,
+                requires_prepare: None,
+                algo: "sha512".to_string(),
+                files: HashMap::with_capacity(entry_count),
+                side_effects: None,
+                remote_side_effects_quarantine: None,
+            },
+        }
+    }
+
+    fn insert(&mut self, entry_path: String, (file_path, file_attrs): (PathBuf, CafsFileInfo)) {
+        if let Some(previous) = self.cas_paths.insert(entry_path.clone(), file_path) {
+            tracing::warn!(?previous, "Duplication detected. Old entry has been ejected");
+        }
+        if let Some(previous) = self.files_index.files.insert(entry_path, file_attrs) {
+            tracing::warn!(?previous, "Duplication detected. Old entry has been ejected");
+        }
+    }
+}
+
+/// Write one entry into the CAS and describe it for the files index.
+///
+/// The central-directory record carries a Unix mode only when the
+/// archive was built by a Unix tool; Windows-built archives omit it.
+/// Fall back to `0o644` so the executable bit defaults to off. Mask off
+/// the high `st_mode` bits (e.g. `0o100000` for a regular file) so
+/// `CafsFileInfo.mode` stays permission-only, matching the convention
+/// `add_files_from_dir.rs` enforces for tar / on-disk imports.
+fn store_zip_entry(
+    entry: &mut zip::read::ZipFile<'_, Cursor<Vec<u8>>>,
+    package_url: &str,
+    entry_path: &str,
+    store_dir: &StoreDir,
+) -> Result<(PathBuf, CafsFileInfo), TarballError> {
+    let file_mode = entry.unix_mode().unwrap_or(0o644) & 0o777;
+    let declared_size = entry.size();
+    let (file_path, file_hash, file_size) = write_zip_entry_to_cas(
+        entry,
+        declared_size,
+        package_url,
+        entry_path,
+        store_dir,
+        file_mode::is_executable(file_mode),
+    )?;
+    let checked_at =
+        UNIX_EPOCH.elapsed().ok().and_then(|elapsed| u64::try_from(elapsed.as_millis()).ok());
+    Ok((
+        file_path,
+        CafsFileInfo {
             digest: format!("{file_hash:x}"),
             mode: file_mode,
             size: file_size,
             checked_at,
-        };
-
-        if let Some(previous) = cas_paths.insert(cleaned.clone(), file_path) {
-            tracing::warn!(?previous, "Duplication detected. Old entry has been ejected");
-        }
-        if let Some(previous) = pkg_files_idx.files.insert(cleaned, file_attrs) {
-            tracing::warn!(?previous, "Duplication detected. Old entry has been ejected");
-        }
-    }
-
-    Ok((cas_paths, pkg_files_idx))
+        },
+    ))
 }
 
 /// The canonical, prefix-stripped path of one zip entry, or `None` when the
@@ -283,8 +309,6 @@ pub(crate) async fn fetch_and_extract_zip_once<Reporter: self::Reporter>(
     archive_prefix: Option<&str>,
     ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
 ) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
-    let network_error = |error| TarballError::FetchTarball(NetworkError::new(package_url, error));
-
     let (client, response_head) = crate::archive_request::request_archive::<Reporter>(
         http_client,
         package_url,
@@ -295,23 +319,7 @@ pub(crate) async fn fetch_and_extract_zip_once<Reporter: self::Reporter>(
         false,
     )
     .await?;
-
-    let expected_size = response_head.content_length();
-
-    let buffer = {
-        use futures_util::StreamExt;
-        let mut buf = allocate_tarball_buffer(expected_size, package_url)?;
-        let mut stream = response_head.bytes_stream();
-
-        let mut progress = crate::download::BodyProgress::new(expected_size, package_id);
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk.map_err(network_error)?;
-            buf.extend_from_slice(&chunk);
-            progress.on_chunk::<Reporter>(chunk.len());
-        }
-        progress.finish::<Reporter>();
-        buf
-    };
+    let buffer = download_zip_body::<Reporter>(response_head, package_url, package_id).await?;
     drop(client);
 
     let post_download_permit = post_download_semaphore()
@@ -321,44 +329,77 @@ pub(crate) async fn fetch_and_extract_zip_once<Reporter: self::Reporter>(
 
     tracing::info!(target: "pacquet::download", ?package_url, "Download completed");
 
-    let package_integrity = package_integrity.clone();
-    let package_url_owned = package_url.to_string();
-    let archive_prefix_owned: Option<String> = archive_prefix.map(str::to_string);
-    let result = crate::extraction_task::spawn_extraction(
-        post_download_permit,
-        move || -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
-            crate::download::verify_tarball_integrity(
-                &buffer,
-                Some(package_integrity),
-                package_url_owned.clone(),
-            )?;
-
-            // Open the archive in a scope so the buffer + ZipArchive
-            // are released before we return — large runtime archives
-            // (Node.js for Windows is ~30 MB) keep the buffer alive
-            // through the whole read otherwise.
-            let (cas_paths, pkg_files_idx) = {
-                let cursor = Cursor::new(buffer);
-                let mut archive = zip::ZipArchive::new(cursor).map_err(|source| {
-                    TarballError::ReadZipArchive { url: package_url_owned.clone(), source }
-                })?;
-                extract_zip_entries(
-                    &mut archive,
-                    &package_url_owned,
-                    store_dir,
-                    archive_prefix_owned.as_deref(),
-                    ignore_file_pattern.as_deref(),
-                )?
-            };
-            Ok((cas_paths, pkg_files_idx))
-        },
-    )
+    let extraction = ZipExtraction {
+        buffer,
+        package_integrity: package_integrity.clone(),
+        package_url: package_url.to_string(),
+        archive_prefix: archive_prefix.map(str::to_string),
+        ignore_file_pattern,
+    };
+    let result = crate::extraction_task::spawn_extraction(post_download_permit, move || {
+        extraction.extract(store_dir)
+    })
     .await
     .map_err(TarballError::TaskJoin)??;
 
     tracing::info!(target: "pacquet::download", ?package_url, "Checksum verified");
 
     Ok(result)
+}
+
+async fn download_zip_body<Reporter: self::Reporter>(
+    response_head: reqwest::Response,
+    package_url: &str,
+    package_id: &str,
+) -> Result<Vec<u8>, TarballError> {
+    use futures_util::StreamExt;
+    let expected_size = response_head.content_length();
+    let mut buf = allocate_tarball_buffer(expected_size, package_url)?;
+    let mut stream = response_head.bytes_stream();
+    let mut progress = crate::download::BodyProgress::new(expected_size, package_id);
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk
+            .map_err(|error| TarballError::FetchTarball(NetworkError::new(package_url, error)))?;
+        buf.extend_from_slice(&chunk);
+        progress.on_chunk::<Reporter>(chunk.len());
+    }
+    progress.finish::<Reporter>();
+    Ok(buf)
+}
+
+/// A downloaded archive with what its extraction task owns.
+struct ZipExtraction {
+    buffer: Vec<u8>,
+    package_integrity: Integrity,
+    package_url: String,
+    archive_prefix: Option<String>,
+    ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
+}
+
+impl ZipExtraction {
+    fn extract(
+        self,
+        store_dir: &'static StoreDir,
+    ) -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
+        crate::download::verify_tarball_integrity(
+            &self.buffer,
+            Some(self.package_integrity),
+            self.package_url.clone(),
+        )?;
+        // The buffer + ZipArchive are released on return — large runtime
+        // archives (Node.js for Windows is ~30 MB) would otherwise keep
+        // the buffer alive through the whole read.
+        let mut archive = zip::ZipArchive::new(Cursor::new(self.buffer)).map_err(|source| {
+            TarballError::ReadZipArchive { url: self.package_url.clone(), source }
+        })?;
+        extract_zip_entries(
+            &mut archive,
+            &self.package_url,
+            store_dir,
+            self.archive_prefix.as_deref(),
+            self.ignore_file_pattern.as_deref(),
+        )
+    }
 }
 
 /// Run [`fetch_and_extract_zip_once`] under pnpm's retry policy.

--- a/pnpm/crates/versioning/src/ledger.rs
+++ b/pnpm/crates/versioning/src/ledger.rs
@@ -269,33 +269,17 @@ pub fn build_consumption_index(
     let mut stable_ids_by_dir: HashMap<String, HashSet<String>> = HashMap::new();
     let mut prerelease_ids_by_dir: HashMap<String, HashSet<String>> = HashMap::new();
     for (key, entry) in ledger {
-        let Some(at_index) = key.rfind('@').filter(|&index| index > 0) else {
+        let Some((pkg_name, version)) = split_ledger_key(key) else {
             continue;
         };
-        let version = &key[at_index + 1..];
-        let dir = match entry {
-            LedgerEntry::Attributed { dir, .. } => normalize_project_dir(dir),
-            LedgerEntry::Ids(_) => {
-                let pkg_name = &key[..at_index];
-                let dirs = resolve_name_dirs(pkg_name);
-                match dirs.len() {
-                    0 => continue,
-                    1 => dirs.into_iter().next().expect("one element"),
-                    _ => {
-                        return Err(VersioningError::AmbiguousLedgerEntry {
-                            key: key.clone(),
-                            pkg_name: pkg_name.to_string(),
-                            dirs,
-                        });
-                    }
-                }
-            }
+        let Some(dir) = entry_project_dir(key, pkg_name, entry, &resolve_name_dirs)? else {
+            continue;
         };
-        // Build metadata (after "+") may itself contain hyphens and never
-        // makes a version a prerelease.
-        let is_prerelease = version.split('+').next().is_some_and(|core| core.contains('-'));
-        let by_dir =
-            if is_prerelease { &mut prerelease_ids_by_dir } else { &mut stable_ids_by_dir };
+        let by_dir = if is_prerelease_version(version) {
+            &mut prerelease_ids_by_dir
+        } else {
+            &mut stable_ids_by_dir
+        };
         by_dir.entry(dir).or_default().extend(entry.intent_ids().iter().cloned());
     }
 
@@ -313,6 +297,47 @@ pub fn build_consumption_index(
             (dir, consumption)
         })
         .collect())
+}
+
+/// The `name@version` halves of a ledger key.
+fn split_ledger_key(key: &str) -> Option<(&str, &str)> {
+    let at_index = key.rfind('@').filter(|&index| index > 0)?;
+    Some((&key[..at_index], &key[at_index + 1..]))
+}
+
+/// The project directory a ledger entry belongs to: the attributed one, or
+/// the one directory `pkg_name` resolves to. `None` when the name resolves
+/// to no project.
+fn entry_project_dir(
+    key: &str,
+    pkg_name: &str,
+    entry: &LedgerEntry,
+    resolve_name_dirs: &impl Fn(&str) -> Vec<String>,
+) -> Result<Option<String>, VersioningError> {
+    let dir = match entry {
+        LedgerEntry::Attributed { dir, .. } => normalize_project_dir(dir),
+        LedgerEntry::Ids(_) => {
+            let dirs = resolve_name_dirs(pkg_name);
+            match dirs.len() {
+                0 => return Ok(None),
+                1 => dirs.into_iter().next().expect("one element"),
+                _ => {
+                    return Err(VersioningError::AmbiguousLedgerEntry {
+                        key: key.to_string(),
+                        pkg_name: pkg_name.to_string(),
+                        dirs,
+                    });
+                }
+            }
+        }
+    };
+    Ok(Some(dir))
+}
+
+/// Build metadata (after "+") may itself contain hyphens and never
+/// makes a version a prerelease.
+fn is_prerelease_version(version: &str) -> bool {
+    version.split('+').next().is_some_and(|core| core.contains('-'))
 }
 
 /// The canonical spelling of a workspace-relative project directory:

--- a/pnpm/crates/versioning/src/plan.rs
+++ b/pnpm/crates/versioning/src/plan.rs
@@ -176,24 +176,18 @@ pub fn assemble_release_plan(
     versioning: Option<&VersioningSettings>,
     opts: &AssembleReleasePlanOptions,
 ) -> Result<ReleasePlan, VersioningError> {
-    let refs = index_project_refs(projects, workspace_dir);
-    let participants = collect_participants(projects, workspace_dir, &refs, versioning)?;
-    let lanes_by_dir = resolve_lanes(&refs, versioning)?;
-    let fixed_groups = resolve_fixed_groups(&refs, &participants, versioning)?;
-    validate_fixed_group_lanes(&fixed_groups, &lanes_by_dir, versioning)?;
-    let epics = resolve_epics(&refs, &participants, versioning)?;
-    validate_epics(&epics, &fixed_groups)?;
-    let intent_bumps = resolve_intents(intents, &refs, &participants)?;
+    let workspace = resolve_workspace(projects, workspace_dir, versioning)?;
+    let intent_bumps = resolve_intents(intents, &workspace.refs, &workspace.participants)?;
     if opts.enforce_workspace_protocol {
-        assert_internal_deps_use_workspace_protocol(&participants)?;
+        assert_internal_deps_use_workspace_protocol(&workspace.participants)?;
     }
-    let consumption = build_consumption_index(ledger, |name| refs.name_to_dirs(name))?;
+    let consumption = build_consumption_index(ledger, |name| workspace.refs.name_to_dirs(name))?;
 
     let ctx = AssembleContext {
-        participants: &participants,
-        lanes_by_dir: &lanes_by_dir,
-        fixed_groups: &fixed_groups,
-        epics: &epics,
+        participants: &workspace.participants,
+        lanes_by_dir: &workspace.lanes_by_dir,
+        fixed_groups: &workspace.fixed_groups,
+        epics: &workspace.epics,
         intent_bumps: &intent_bumps,
         consumption: &consumption,
         intents,
@@ -212,6 +206,31 @@ pub fn assemble_release_plan(
             return Ok(plan);
         }
     }
+}
+
+/// The workspace's release structure the plan and the invariant check share:
+/// its projects, lanes, fixed groups and epics, validated against each other.
+struct ResolvedWorkspace<'a> {
+    refs: ProjectRefIndex,
+    participants: BTreeMap<String, Participant<'a>>,
+    lanes_by_dir: BTreeMap<String, String>,
+    fixed_groups: Vec<Vec<String>>,
+    epics: Vec<ResolvedEpic>,
+}
+
+fn resolve_workspace<'a>(
+    projects: &'a [WorkspaceProject],
+    workspace_dir: &Path,
+    versioning: Option<&VersioningSettings>,
+) -> Result<ResolvedWorkspace<'a>, VersioningError> {
+    let refs = index_project_refs(projects, workspace_dir);
+    let participants = collect_participants(projects, workspace_dir, &refs, versioning)?;
+    let lanes_by_dir = resolve_lanes(&refs, versioning)?;
+    let fixed_groups = resolve_fixed_groups(&refs, &participants, versioning)?;
+    validate_fixed_group_lanes(&fixed_groups, &lanes_by_dir, versioning)?;
+    let epics = resolve_epics(&refs, &participants, versioning)?;
+    validate_epics(&epics, &fixed_groups)?;
+    Ok(ResolvedWorkspace { refs, participants, lanes_by_dir, fixed_groups, epics })
 }
 
 /// The kind of committed-version invariant [`check_versioning_invariants`]
@@ -246,24 +265,27 @@ pub fn check_versioning_invariants(
     workspace_dir: &Path,
     versioning: Option<&VersioningSettings>,
 ) -> Result<Vec<VersioningInvariantViolation>, VersioningError> {
-    let refs = index_project_refs(projects, workspace_dir);
-    let participants = collect_participants(projects, workspace_dir, &refs, versioning)?;
-    let lanes_by_dir = resolve_lanes(&refs, versioning)?;
-    let fixed_groups = resolve_fixed_groups(&refs, &participants, versioning)?;
-    validate_fixed_group_lanes(&fixed_groups, &lanes_by_dir, versioning)?;
-    let epics = resolve_epics(&refs, &participants, versioning)?;
-    validate_epics(&epics, &fixed_groups)?;
+    let workspace = resolve_workspace(projects, workspace_dir, versioning)?;
 
-    // With no plan (no new versions), the band derives from the lead's current
-    // major, and members are checked against their current versions.
-    let empty_new_versions = BTreeMap::new();
     let mut violations = Vec::new();
-    for epic in &epics {
-        let band = epic_band(epic, &participants, &empty_new_versions);
+    push_epic_band_violations(&workspace, &mut violations);
+    push_fixed_group_violations(&workspace, versioning, &mut violations);
+    Ok(violations)
+}
+
+/// With no plan (no new versions), the band derives from the lead's current
+/// major, and members are checked against their current versions.
+fn push_epic_band_violations(
+    workspace: &ResolvedWorkspace<'_>,
+    violations: &mut Vec<VersioningInvariantViolation>,
+) {
+    let empty_new_versions = BTreeMap::new();
+    for epic in &workspace.epics {
+        let band = epic_band(epic, &workspace.participants, &empty_new_versions);
         let mut member_dirs: Vec<&String> = epic.member_dirs.iter().collect();
         member_dirs.sort();
         for member_dir in member_dirs {
-            let member = &participants[member_dir.as_str()];
+            let member = &workspace.participants[member_dir.as_str()];
             let member_major = Version::parse(member.current_version)
                 .expect("participants have valid versions")
                 .major;
@@ -278,14 +300,21 @@ pub fn check_versioning_invariants(
             }
         }
     }
-    for (index, group) in fixed_groups.iter().enumerate() {
+}
+
+fn push_fixed_group_violations(
+    workspace: &ResolvedWorkspace<'_>,
+    versioning: Option<&VersioningSettings>,
+    violations: &mut Vec<VersioningInvariantViolation>,
+) {
+    for (index, group) in workspace.fixed_groups.iter().enumerate() {
         let distinct: BTreeSet<&str> =
-            group.iter().map(|dir| participants[dir.as_str()].current_version).collect();
+            group.iter().map(|dir| workspace.participants[dir.as_str()].current_version).collect();
         if distinct.len() > 1 {
             let detail = group
                 .iter()
                 .map(|dir| {
-                    let member = &participants[dir.as_str()];
+                    let member = &workspace.participants[dir.as_str()];
                     format!("{}@{}", member.name, member.current_version)
                 })
                 .collect::<Vec<_>>()
@@ -298,7 +327,6 @@ pub fn check_versioning_invariants(
             });
         }
     }
-    Ok(violations)
 }
 
 struct Participant<'a> {

--- a/pnpm/crates/workspace-manifest-writer/src/edit.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/edit.rs
@@ -621,13 +621,7 @@ fn set_exclude_list(manifest: &mut Manifest, list: ExcludeList, items: &[String]
 
     let rendered = render_top_level_sequence(block, items);
     if let Some(span) = top_level_span(text, block) {
-        // Preserve a trailing blank line before the next block, since the
-        // span includes it but the freshly rendered block does not.
-        let had_trailing_blank = text[span.key_line_start..span.block_end].ends_with("\n\n");
-        let mut out = text.to_string();
-        let replacement = if had_trailing_blank { format!("{rendered}\n") } else { rendered };
-        out.replace_range(span.key_line_start..span.block_end, &replacement);
-        manifest.set_text(out);
+        manifest.set_text(replace_top_level_block(text, &span, rendered));
     } else {
         let new_text = insert_top_level_block(manifest, block, &rendered);
         manifest.set_text(new_text);
@@ -636,6 +630,16 @@ fn set_exclude_list(manifest: &mut Manifest, list: ExcludeList, items: &[String]
     }
     *decoded(manifest) = Some(items.to_vec());
     true
+}
+
+/// Preserve a trailing blank line before the next block, since the
+/// span includes it but the freshly rendered block does not.
+fn replace_top_level_block(text: &str, span: &TopLevelSpan, rendered: String) -> String {
+    let had_trailing_blank = text[span.key_line_start..span.block_end].ends_with("\n\n");
+    let mut out = text.to_string();
+    let replacement = if had_trailing_blank { format!("{rendered}\n") } else { rendered };
+    out.replace_range(span.key_line_start..span.block_end, &replacement);
+    out
 }
 
 /// The `minimumReleaseAgeExcludePrune` pass over `minimumReleaseAgeExclude:`.
@@ -717,9 +721,20 @@ fn upsert_sequence_entry(text: &str, block_name: &str, key: &str, items: &[Strin
         return flow::upsert(text, &collection, key, &flow::render_sequence(&rendered_items));
     }
     let mapping = locate(text, &[block_name]).expect("block exists");
-    let item_indent = mapping.entry_indent + 2;
+    let rendered = render_block_sequence_entry(mapping.entry_indent, key, items);
+
+    if let Some(entry) = mapping.entries.iter().find(|entry| entry.key == key) {
+        let mut out = text.to_string();
+        out.replace_range(entry.line_start..entry.block_end, &rendered);
+        return out;
+    }
+    splice(text, insertion_offset(&mapping, key), &rendered)
+}
+
+fn render_block_sequence_entry(entry_indent: usize, key: &str, items: &[String]) -> String {
+    let item_indent = entry_indent + 2;
     let mut rendered = String::new();
-    rendered.push_str(&" ".repeat(mapping.entry_indent));
+    rendered.push_str(&" ".repeat(entry_indent));
     rendered.push_str(&render::render_value(key));
     rendered.push_str(":\n");
     for item in items {
@@ -728,29 +743,26 @@ fn upsert_sequence_entry(text: &str, block_name: &str, key: &str, items: &[Strin
         rendered.push_str(&render::render_value(item));
         rendered.push('\n');
     }
+    rendered
+}
 
-    if let Some(entry) = mapping.entries.iter().find(|entry| entry.key == key) {
-        let mut out = text.to_string();
-        out.replace_range(entry.line_start..entry.block_end, &rendered);
-        return out;
-    }
-
+/// Where a new `key` entry goes in `mapping` so the keys keep their target
+/// order: right after its predecessor, or at the body start when first.
+fn insertion_offset(mapping: &Mapping, key: &str) -> usize {
     let existing: Vec<String> = mapping.entries.iter().map(|entry| entry.key.clone()).collect();
     let order = render::target_order(&existing, &[key.to_string()]);
     let position =
         order.iter().position(|order_key| order_key == key).expect("key is in the order");
-    let offset = if position == 0 {
-        mapping.body_start
-    } else {
-        let predecessor = &order[position - 1];
-        mapping
-            .entries
-            .iter()
-            .find(|entry| &entry.key == predecessor)
-            .expect("predecessor entry exists")
-            .block_end
-    };
-    splice(text, offset, &rendered)
+    if position == 0 {
+        return mapping.body_start;
+    }
+    let predecessor = &order[position - 1];
+    mapping
+        .entries
+        .iter()
+        .find(|entry| &entry.key == predecessor)
+        .expect("predecessor entry exists")
+        .block_end
 }
 
 fn upsert_top_level_entry(
@@ -1655,23 +1667,11 @@ fn locate(text: &str, path: &[&str]) -> Option<Mapping> {
         })?;
         // The block ends at the next structural line indented at or below
         // `base_indent`.
-        let block_end_idx = ((key_idx + 1)..hi)
-            .find(|&idx| {
-                structural_indent(all[idx].content).is_some_and(|indent| indent <= base_indent)
-            })
-            .unwrap_or(hi);
-
-        // The child indent is whatever the block's first structural line
-        // uses, not a hard-coded two spaces — so a manifest written with a
-        // wider indent is still traversed correctly.
-        let child_indent = (key_idx + 1..block_end_idx)
-            .find_map(|idx| structural_indent(all[idx].content))
-            .unwrap_or(base_indent + 2);
+        let block_end_idx = block_end(&all, key_idx, hi, base_indent);
+        let child_indent = child_indent(&all, key_idx, block_end_idx, base_indent);
 
         if depth + 1 == path.len() {
-            let body_start = all.get(key_idx + 1).map_or(all[key_idx].end, |line| line.start);
-            let entries = collect_entries(&all, key_idx + 1, block_end_idx, child_indent);
-            return Some(Mapping { body_start, entry_indent: child_indent, entries });
+            return Some(mapping_at(&all, key_idx, block_end_idx, child_indent));
         }
 
         lo = key_idx + 1;
@@ -1679,6 +1679,39 @@ fn locate(text: &str, path: &[&str]) -> Option<Mapping> {
         base_indent = child_indent;
     }
     None
+}
+
+fn block_end(all: &[Line<'_>], key_idx: usize, hi: usize, base_indent: usize) -> usize {
+    ((key_idx + 1)..hi)
+        .find(|&idx| {
+            structural_indent(all[idx].content).is_some_and(|indent| indent <= base_indent)
+        })
+        .unwrap_or(hi)
+}
+
+/// The child indent is whatever the block's first structural line
+/// uses, not a hard-coded two spaces — so a manifest written with a
+/// wider indent is still traversed correctly.
+fn child_indent(
+    all: &[Line<'_>],
+    key_idx: usize,
+    block_end_idx: usize,
+    base_indent: usize,
+) -> usize {
+    (key_idx + 1..block_end_idx)
+        .find_map(|idx| structural_indent(all[idx].content))
+        .unwrap_or(base_indent + 2)
+}
+
+fn mapping_at(
+    all: &[Line<'_>],
+    key_idx: usize,
+    block_end_idx: usize,
+    child_indent: usize,
+) -> Mapping {
+    let body_start = all.get(key_idx + 1).map_or(all[key_idx].end, |line| line.start);
+    let entries = collect_entries(all, key_idx + 1, block_end_idx, child_indent);
+    Mapping { body_start, entry_indent: child_indent, entries }
 }
 
 /// Collect the direct child entries (key lines at `entry_indent`) within

--- a/pnpm/crates/workspace-manifest-writer/src/edit.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/edit.rs
@@ -621,7 +621,7 @@ fn set_exclude_list(manifest: &mut Manifest, list: ExcludeList, items: &[String]
 
     let rendered = render_top_level_sequence(block, items);
     if let Some(span) = top_level_span(text, block) {
-        manifest.set_text(replace_top_level_block(text, &span, rendered));
+        manifest.set_text(replace_top_level_block(text, &span, &rendered));
     } else {
         let new_text = insert_top_level_block(manifest, block, &rendered);
         manifest.set_text(new_text);
@@ -634,11 +634,14 @@ fn set_exclude_list(manifest: &mut Manifest, list: ExcludeList, items: &[String]
 
 /// Preserve a trailing blank line before the next block, since the
 /// span includes it but the freshly rendered block does not.
-fn replace_top_level_block(text: &str, span: &TopLevelSpan, rendered: String) -> String {
+fn replace_top_level_block(text: &str, span: &TopLevelSpan, rendered: &str) -> String {
     let had_trailing_blank = text[span.key_line_start..span.block_end].ends_with("\n\n");
     let mut out = text.to_string();
-    let replacement = if had_trailing_blank { format!("{rendered}\n") } else { rendered };
-    out.replace_range(span.key_line_start..span.block_end, &replacement);
+    if had_trailing_blank {
+        out.replace_range(span.key_line_start..span.block_end, &format!("{rendered}\n"));
+    } else {
+        out.replace_range(span.key_line_start..span.block_end, rendered);
+    }
     out
 }
 

--- a/pnpm/crates/workspace-manifest-writer/src/model.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/model.rs
@@ -158,40 +158,7 @@ impl Manifest {
         let blank_line_style = crate::edit::uses_blank_line_style(&text, &top_level_keys);
 
         let data: CatalogData = serde_saphyr::from_str(&text).map_err(Box::new)?;
-        let config_dependencies = data.config_dependencies.map(|entries| {
-            entries
-                .into_iter()
-                .filter_map(|(name, value)| match value {
-                    ConfigDepValue::Clean(specifier) => Some((name, specifier)),
-                    ConfigDepValue::Other(_) => None,
-                })
-                .collect()
-        });
-        let allow_builds = data.allow_builds.map(|entries| {
-            entries
-                .into_iter()
-                .filter_map(|(name, value)| match value {
-                    AllowBuildValue::Bool(allowed) => Some((name, AllowBuildValue::Bool(allowed))),
-                    AllowBuildValue::String(s) => Some((name, AllowBuildValue::String(s))),
-                    AllowBuildValue::Other(_) => None,
-                })
-                .collect()
-        });
-        let mut non_scalar_overrides = HashSet::new();
-        let overrides = data.overrides.map(|entries| {
-            entries
-                .into_iter()
-                .filter_map(|(name, value)| match value {
-                    OverrideValue::String(specifier) => Some((name, specifier)),
-                    OverrideValue::Other(_) => {
-                        non_scalar_overrides.insert(name);
-                        None
-                    }
-                })
-                .collect()
-        });
-        let audit_ignore_ghsas = data.audit_config.and_then(|config| config.ignore_ghsas);
-        let audit_ignore = data.audit.and_then(|audit| audit.ignore);
+        let (overrides, non_scalar_overrides) = split_overrides(data.overrides);
 
         Ok(Manifest {
             text,
@@ -199,13 +166,13 @@ impl Manifest {
             blank_line_style,
             catalog: data.catalog,
             catalogs: data.catalogs,
-            config_dependencies,
-            allow_builds,
+            config_dependencies: data.config_dependencies.map(clean_config_dependencies),
+            allow_builds: data.allow_builds.map(clean_allow_builds),
             patched_dependencies: data.patched_dependencies,
             overrides,
             non_scalar_overrides,
-            audit_ignore_ghsas,
-            audit_ignore,
+            audit_ignore_ghsas: data.audit_config.and_then(|config| config.ignore_ghsas),
+            audit_ignore: data.audit.and_then(|audit| audit.ignore),
             minimum_release_age_exclude: data.minimum_release_age_exclude,
             trust_policy_exclude: data.trust_policy_exclude,
         })
@@ -222,4 +189,50 @@ impl Manifest {
     pub(crate) fn into_text(self) -> String {
         self.text
     }
+}
+
+fn clean_config_dependencies(
+    entries: IndexMap<String, ConfigDepValue>,
+) -> IndexMap<String, String> {
+    entries
+        .into_iter()
+        .filter_map(|(name, value)| match value {
+            ConfigDepValue::Clean(specifier) => Some((name, specifier)),
+            ConfigDepValue::Other(_) => None,
+        })
+        .collect()
+}
+
+fn clean_allow_builds(
+    entries: IndexMap<String, AllowBuildValue>,
+) -> IndexMap<String, AllowBuildValue> {
+    entries
+        .into_iter()
+        .filter_map(|(name, value)| match value {
+            AllowBuildValue::Bool(allowed) => Some((name, AllowBuildValue::Bool(allowed))),
+            AllowBuildValue::String(s) => Some((name, AllowBuildValue::String(s))),
+            AllowBuildValue::Other(_) => None,
+        })
+        .collect()
+}
+
+/// The clean string overrides, and the names of the ones written in a
+/// non-scalar form.
+fn split_overrides(
+    entries: Option<IndexMap<String, OverrideValue>>,
+) -> (Option<IndexMap<String, String>>, HashSet<String>) {
+    let mut non_scalar_overrides = HashSet::new();
+    let overrides = entries.map(|entries| {
+        entries
+            .into_iter()
+            .filter_map(|(name, value)| match value {
+                OverrideValue::String(specifier) => Some((name, specifier)),
+                OverrideValue::Other(_) => {
+                    non_scalar_overrides.insert(name);
+                    None
+                }
+            })
+            .collect()
+    });
+    (overrides, non_scalar_overrides)
 }

--- a/pnpm/crates/workspace-projects-filter/src/filter.rs
+++ b/pnpm/crates/workspace-projects-filter/src/filter.rs
@@ -156,12 +156,12 @@ where
     let mut walk = WalkState::default();
     let mut unmatched_filters: Vec<String> = Vec::new();
 
-    let forward = |id: &Path| projects_graph.get(id).map(|node| node.dependencies.clone());
+    let forward = |id: &Path| Some(projects_graph.get(id)?.dependencies.clone());
     let reversed_graph = selectors
         .iter()
         .any(|selector| selector.include_dependents)
         .then(|| reverse_graph(projects_graph));
-    let reverse = |id: &Path| reversed_graph.as_ref().and_then(|graph| graph.get(id).cloned());
+    let reverse = |id: &Path| reversed_graph.as_ref()?.get(id).cloned();
 
     for selector in selectors {
         let mut entry_projects: Option<Vec<PathBuf>> = None;
@@ -191,8 +191,10 @@ where
         }
 
         if let Some(name_pattern) = &selector.name_pattern {
-            let candidates = name_candidates(projects_graph, entry_projects.as_deref());
-            entry_projects = Some(match_projects(&candidates, name_pattern));
+            entry_projects = Some(match_projects(
+                &name_candidates(projects_graph, entry_projects.as_deref()),
+                name_pattern,
+            ));
         }
 
         let Some(entry_projects) = entry_projects else {

--- a/pnpm/crates/workspace-projects-filter/src/get_changed_projects.rs
+++ b/pnpm/crates/workspace-projects-filter/src/get_changed_projects.rs
@@ -98,23 +98,7 @@ fn get_changed_dirs_since_commit(
     commit: &str,
     opts: &GetChangedProjectsOptions<'_>,
 ) -> Result<IndexMap<PathBuf, ChangeType>, FilterError> {
-    // `--end-of-options` keeps an option-like `<since>` (`--output=...`)
-    // from being parsed as a git option — git rejects it as a bad
-    // revision instead.
-    let output = Command::new("git")
-        .args(["diff", "--name-only", "--end-of-options", commit, "--"])
-        .arg(opts.workspace_dir)
-        .current_dir(opts.workspace_dir)
-        .output()
-        .map_err(|err| FilterError::FilterChanged { stderr: err.to_string() })?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(FilterError::FilterChanged {
-            stderr: strip_final_newline(&stderr).to_string(),
-        });
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stdout = git_diff_names(commit, opts.workspace_dir)?;
     let diff = strip_final_newline(&stdout);
     if diff.is_empty() {
         return Ok(IndexMap::new());
@@ -143,6 +127,27 @@ fn get_changed_dirs_since_commit(
         changed_dirs.insert(dir, change_type);
     }
     Ok(changed_dirs)
+}
+
+/// The paths `git diff --name-only <commit>` lists under `workspace_dir`.
+fn git_diff_names(commit: &str, workspace_dir: &Path) -> Result<String, FilterError> {
+    // `--end-of-options` keeps an option-like `<since>` (`--output=...`)
+    // from being parsed as a git option — git rejects it as a bad
+    // revision instead.
+    let output = Command::new("git")
+        .args(["diff", "--name-only", "--end-of-options", commit, "--"])
+        .arg(workspace_dir)
+        .current_dir(workspace_dir)
+        .output()
+        .map_err(|err| FilterError::FilterChanged { stderr: err.to_string() })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(FilterError::FilterChanged {
+            stderr: strip_final_newline(&stderr).to_string(),
+        });
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
 /// Strip one final `\n` (and a preceding `\r`, if any) — execa's

--- a/pnpm/crates/workspace-task-scheduler/src/graph_sequencer.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/graph_sequencer.rs
@@ -61,15 +61,15 @@ pub fn graph_sequencer<Node>(
 where
     Node: Eq + Hash + Clone,
 {
-    let Indexed { interner, included_count, adjacency, reverse_graph, out_degree } =
-        index_graph(graph, included);
+    let indexed = index_graph(graph, included);
+    let included_count = indexed.included_count;
 
     let mut sweep = Sweep {
-        reverse_graph: &reverse_graph,
+        reverse_graph: &indexed.reverse_graph,
         // A non-included node is born removed: the order never contains it
         // and the cycle search does not walk through it.
-        removed: (0..adjacency.len()).map(|id| id >= included_count).collect(),
-        out_degree,
+        removed: (0..indexed.adjacency.len()).map(|id| id >= included_count).collect(),
+        out_degree: indexed.out_degree,
         next: Vec::new(),
     };
 
@@ -83,10 +83,10 @@ where
         (0..included_count).filter(|&id| sweep.out_degree[id] == 0).collect();
     while remaining > 0 {
         if current.is_empty() {
-            for cycle in sweep.break_cycles(&adjacency, included_count) {
+            for cycle in sweep.break_cycles(&indexed.adjacency, included_count) {
                 remaining -= cycle.len();
                 order.extend(&cycle);
-                cycles.push(interner.to_nodes(&cycle));
+                cycles.push(indexed.interner.to_nodes(&cycle));
             }
         } else {
             for &id in &current {
@@ -105,7 +105,7 @@ where
         current = next;
     }
 
-    GraphSequencerResult { order: interner.to_nodes(&order), cycles }
+    GraphSequencerResult { order: indexed.interner.to_nodes(&order), cycles }
 }
 
 /// The interned graph the sort runs on. Ids below `included_count` are the

--- a/pnpm/crates/workspace-task-scheduler/src/lib.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/lib.rs
@@ -190,7 +190,7 @@ where
                 existing.requested |= requested;
                 continue;
             }
-            let settings = self.tasks.and_then(|tasks| tasks.get(task_name.as_str()));
+            let settings = self.task_settings(&task_name);
             let dependencies = self.dependency_keys(&project, &task_name, settings);
             queue.extend(dependencies.iter().map(|dependency| {
                 (dependency.project.clone(), dependency.task_name.clone(), false)
@@ -201,11 +201,7 @@ where
                 TaskNode {
                     project,
                     task_name,
-                    concurrency: settings.and_then(|settings| {
-                        settings
-                            .concurrency
-                            .map(|concurrency| usize::try_from(concurrency).unwrap_or(usize::MAX))
-                    }),
+                    concurrency: settings.and_then(task_concurrency),
                     scripts,
                     requested,
                     dependencies,
@@ -213,6 +209,10 @@ where
             );
         }
         graph
+    }
+
+    fn task_settings(&self, task_name: &str) -> Option<&TaskSettings> {
+        self.tasks.and_then(|tasks| tasks.get(task_name))
     }
 
     /// Every requested task of every seed project, which is either the
@@ -883,10 +883,7 @@ where
 }
 
 fn node_edges<Node: Clone + Eq + std::hash::Hash>(graph: &IndexMap<Node, Vec<Node>>) -> NodeEdges {
-    let included: Vec<Node> = graph.keys().cloned().collect();
-    let edges: HashMap<Node, Vec<Node>> =
-        graph.iter().map(|(node, dependencies)| (node.clone(), dependencies.clone())).collect();
-    let order = graph_sequencer(&edges, &included).order;
+    let order = sequenced_order(graph);
     let order_index: HashMap<&Node, usize> =
         order.iter().enumerate().map(|(index, node)| (node, index)).collect();
     let index_of: HashMap<&Node, usize> =
@@ -906,6 +903,19 @@ fn node_edges<Node: Clone + Eq + std::hash::Hash>(graph: &IndexMap<Node, Vec<Nod
         }
     }
     NodeEdges { dependents, pending_dependencies }
+}
+
+fn task_concurrency(settings: &TaskSettings) -> Option<usize> {
+    settings.concurrency.map(|concurrency| usize::try_from(concurrency).unwrap_or(usize::MAX))
+}
+
+fn sequenced_order<Node: Clone + Eq + std::hash::Hash>(
+    graph: &IndexMap<Node, Vec<Node>>,
+) -> Vec<Node> {
+    let included: Vec<Node> = graph.keys().cloned().collect();
+    let edges: HashMap<Node, Vec<Node>> =
+        graph.iter().map(|(node, dependencies)| (node.clone(), dependencies.clone())).collect();
+    graph_sequencer(&edges, &included).order
 }
 
 fn initial_scheduler_state(

--- a/pnpm/crates/workspace/src/inventory.rs
+++ b/pnpm/crates/workspace/src/inventory.rs
@@ -88,24 +88,10 @@ fn find_workspace_inventory_with(
     let canonical_root = fs::canonicalize(workspace_root).map_err(|source| {
         FindWorkspaceInventoryError::ReadDirectory { path: workspace_root.to_path_buf(), source }
     })?;
-    let mut paths = BTreeSet::new();
-    for path in ignored_directories {
-        let path = workspace_root.join(path);
-        let canonical = match fs::canonicalize(&path) {
-            Ok(path) => path,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
-            Err(source) => {
-                return Err(FindWorkspaceInventoryError::InspectCandidate { path, source });
-            }
-        };
-        if let Ok(relative) = canonical.strip_prefix(&canonical_root) {
-            paths.insert(relative.to_path_buf());
-        }
-    }
     let ignored = IgnoredDirectories {
         root: workspace_root,
         basenames: ignored_directory_basenames.iter().map(OsStr::new).collect(),
-        paths,
+        paths: ignored_paths_under(workspace_root, &canonical_root, ignored_directories)?,
     };
     let mut manifests: BTreeMap<String, Vec<PathBuf>> =
         manifest_basenames.iter().map(|basename| ((*basename).to_string(), Vec::new())).collect();
@@ -129,6 +115,29 @@ fn find_workspace_inventory_with(
         manifest_paths.sort();
     }
     Ok(WorkspaceInventory { manifests })
+}
+
+/// The ignored directories that exist, relative to the canonical root.
+fn ignored_paths_under(
+    workspace_root: &Path,
+    canonical_root: &Path,
+    ignored_directories: &[PathBuf],
+) -> Result<BTreeSet<PathBuf>, FindWorkspaceInventoryError> {
+    let mut paths = BTreeSet::new();
+    for path in ignored_directories {
+        let path = workspace_root.join(path);
+        let canonical = match fs::canonicalize(&path) {
+            Ok(path) => path,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(source) => {
+                return Err(FindWorkspaceInventoryError::InspectCandidate { path, source });
+            }
+        };
+        if let Ok(relative) = canonical.strip_prefix(canonical_root) {
+            paths.insert(relative.to_path_buf());
+        }
+    }
+    Ok(paths)
 }
 
 struct IgnoredDirectories<'a> {

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -121,28 +121,8 @@ pub fn find_workspace_projects_no_check(
 
     let (include_patterns, user_negation_globs) = split_include_and_negation(patterns)?;
 
-    // wax's `not` takes a single pattern; combine the ignores with
-    // `wax::any` so the walk filters them all in one pass. Built once
-    // outside the per-pattern loop to avoid reparsing the constant
-    // ignores.
-    let build_ignores = |patterns: &mut dyn Iterator<Item = &'static str>| {
-        wax::any(patterns).map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
-            pattern: "<built-in ignore>".to_string(),
-            message: err.to_string(),
-        })
-    };
-    let dot_pruning_ignore_template =
-        build_ignores(&mut IGNORE_PATTERNS.iter().copied().chain([DOT_COMPONENT_IGNORE_PATTERN]))?;
-
-    // User negations are written relative to the workspace root, while a
-    // parent-relative include walks from an ancestor of it, so they are
-    // matched against the path each entry has *from the workspace root*
-    // rather than handed to `Walk::not` alongside the built-in ignores.
-    let user_negations = wax::any(user_negation_globs.iter().map(std::string::String::as_str))
-        .map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
-            pattern: "<negated pattern>".to_string(),
-            message: err.to_string(),
-        })?;
+    let dot_pruning_ignore_template = dot_pruning_ignore_template()?;
+    let user_negations = compile_user_negations(&user_negation_globs)?;
 
     parse_check_walk_patterns(&include_patterns, workspace_root)?;
 
@@ -165,7 +145,36 @@ pub fn find_workspace_projects_no_check(
         }
     }
 
-    let root_groups = group_manifests_by_root(manifest_paths, workspace_root);
+    read_projects(group_manifests_by_root(manifest_paths, workspace_root))
+}
+
+/// wax's `not` takes a single pattern; combine the ignores with
+/// `wax::any` so the walk filters them all in one pass.
+fn dot_pruning_ignore_template() -> Result<wax::Any<'static>, FindWorkspaceProjectsError> {
+    wax::any(IGNORE_PATTERNS.iter().copied().chain([DOT_COMPONENT_IGNORE_PATTERN])).map_err(|err| {
+        FindWorkspaceProjectsError::InvalidGlob {
+            pattern: "<built-in ignore>".to_string(),
+            message: err.to_string(),
+        }
+    })
+}
+
+/// User negations are written relative to the workspace root, while a
+/// parent-relative include walks from an ancestor of it, so they are
+/// matched against the path each entry has *from the workspace root*
+/// rather than handed to `Walk::not` alongside the built-in ignores.
+fn compile_user_negations(globs: &[String]) -> Result<wax::Any<'_>, FindWorkspaceProjectsError> {
+    wax::any(globs.iter().map(String::as_str)).map_err(|err| {
+        FindWorkspaceProjectsError::InvalidGlob {
+            pattern: "<negated pattern>".to_string(),
+            message: err.to_string(),
+        }
+    })
+}
+
+fn read_projects(
+    root_groups: Vec<(PathBuf, Vec<PathBuf>)>,
+) -> Result<Vec<Project>, FindWorkspaceProjectsError> {
     let read_results: Vec<Result<Option<Project>, FindWorkspaceProjectsError>> = root_groups
         .into_par_iter()
         .map(|(root_dir, candidates)| read_first_project_manifest(root_dir, candidates))
@@ -176,7 +185,6 @@ pub fn find_workspace_projects_no_check(
             projects.push(project);
         }
     }
-
     Ok(projects)
 }
 

--- a/pnpm/tasks/ecosystem-e2e/src/main.rs
+++ b/pnpm/tasks/ecosystem-e2e/src/main.rs
@@ -7,7 +7,11 @@ mod stacks;
 
 use cli_args::{Binary, CliArgs, Layout};
 use runner::{Cell, Outcome, run_cell, scaffold_template};
-use std::{fs, path::Path, process::ExitCode};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::ExitCode,
+};
 use which::which;
 
 fn main() -> ExitCode {
@@ -28,16 +32,7 @@ fn main() -> ExitCode {
         ensure_program(&args.pacquet);
     }
 
-    let work_dir = &args.work_dir;
-    if !args.keep && work_dir.exists() {
-        fs::remove_dir_all(work_dir).unwrap_or_else(|error| panic!("wipe {work_dir:?}: {error}"));
-    }
-    let template_root = work_dir.join("templates");
-    let cells_root = work_dir.join("cells");
-    fs::create_dir_all(&template_root)
-        .unwrap_or_else(|error| panic!("create {template_root:?}: {error}"));
-    fs::create_dir_all(&cells_root)
-        .unwrap_or_else(|error| panic!("create {cells_root:?}: {error}"));
+    let (template_root, cells_root) = prepare_work_dir(&args);
 
     let mut report: Vec<(String, Outcome)> = Vec::new();
     for stack in &selected {
@@ -50,6 +45,21 @@ fn main() -> ExitCode {
     } else {
         ExitCode::FAILURE
     }
+}
+
+/// The template and cell roots under a fresh work dir (kept with `--keep`).
+fn prepare_work_dir(args: &CliArgs) -> (PathBuf, PathBuf) {
+    let work_dir = &args.work_dir;
+    if !args.keep && work_dir.exists() {
+        fs::remove_dir_all(work_dir).unwrap_or_else(|error| panic!("wipe {work_dir:?}: {error}"));
+    }
+    let template_root = work_dir.join("templates");
+    let cells_root = work_dir.join("cells");
+    fs::create_dir_all(&template_root)
+        .unwrap_or_else(|error| panic!("create {template_root:?}: {error}"));
+    fs::create_dir_all(&cells_root)
+        .unwrap_or_else(|error| panic!("create {cells_root:?}: {error}"));
+    (template_root, cells_root)
 }
 
 /// Scaffold one stack's template, then run every binary × layout cell

--- a/pnpm/tasks/ecosystem-e2e/src/runner.rs
+++ b/pnpm/tasks/ecosystem-e2e/src/runner.rs
@@ -105,13 +105,9 @@ pub fn run_cell(
         return failed;
     }
 
-    let install_binary = match cell.binary {
-        Binary::Pnpm => pnpm,
-        Binary::Pacquet => pacquet,
-    };
-    let mut install = sandboxed_command(install_binary);
-    install.current_dir(&project_dir).arg("install");
-    if let Some(failed) = outcome("install", run("install", &mut install, &log_path)) {
+    if let Some(failed) =
+        outcome("install", run_install(cell, &project_dir, &log_path, pnpm, pacquet))
+    {
         return failed;
     }
 
@@ -135,6 +131,22 @@ pub fn run_cell(
         message: String::new(),
         log_path,
     }
+}
+
+fn run_install(
+    cell: &Cell,
+    project_dir: &Path,
+    log_path: &Path,
+    pnpm: &str,
+    pacquet: &str,
+) -> Result<(), String> {
+    let install_binary = match cell.binary {
+        Binary::Pnpm => pnpm,
+        Binary::Pacquet => pacquet,
+    };
+    let mut install = sandboxed_command(install_binary);
+    install.current_dir(project_dir).arg("install");
+    run("install", &mut install, log_path)
 }
 
 fn prepare_cell(

--- a/pnpm/tasks/integrated-benchmark/src/main.rs
+++ b/pnpm/tasks/integrated-benchmark/src/main.rs
@@ -17,107 +17,108 @@ use std::{
 
 #[tokio::main]
 async fn main() {
-    let cli_args::CliArgs {
-        scenario,
-        registry_port,
-        registry: registry_mode,
-        repository,
-        pnpm_repository,
-        fixture_dir,
-        hyperfine_options,
-        work_env,
-        with_pnpm,
-        pnpr_latency_ms,
-        registry_latency_ms,
-        pnpr_server_registry_latency_ms,
-        registry_bandwidth_mbps,
-        registry_slow_start,
-        reuse_prebuilt_binaries,
-        serve_timing,
-        build_only,
-        targets,
-    } = clap::Parser::parse();
+    let args: cli_args::CliArgs = clap::Parser::parse();
 
-    let repository = std::fs::canonicalize(&repository).expect("get absolute path to repository");
-    let pnpm_repository = pnpm_repository
+    let repository =
+        std::fs::canonicalize(&args.repository).expect("get absolute path to repository");
+    let pnpm_repository = args
+        .pnpm_repository
         .as_ref()
         .map(|path| std::fs::canonicalize(path).expect("get absolute path to pnpm repository"));
-    let work_env = prepared_work_env(&work_env);
-    let registry = registry_url(registry_mode, registry_port);
-    let registry_rate_limit = mbps_to_bytes_per_sec(registry_bandwidth_mbps);
-    let proxy_spawned_registry = !build_only
-        && matches!(registry_mode, RegistryMode::Verdaccio)
-        && (registry_latency_ms > 0 || registry_rate_limit.is_some());
-    let (spawned_registry_port, registry_cache_populator) =
-        upstream_registry(proxy_spawned_registry, registry_port, &registry);
-    let registry_public_url = registry.trim_end_matches('/').to_string();
+    let work_env = prepared_work_env(&args.work_env);
+    let registry = RegistryLink::plan(&args);
 
-    if !build_only {
-        seed_scenario_fixture(scenario, registry_mode);
+    if !args.build_only {
+        seed_scenario_fixture(args.scenario, args.registry);
     }
 
-    let verdaccio = if build_only {
+    let verdaccio = if args.build_only {
         None
     } else {
         spawn_registry(SpawnRegistry {
-            registry_mode,
-            registry: &registry,
+            registry_mode: args.registry,
+            registry: &registry.url,
             work_env: &work_env,
-            spawned_registry_port,
-            public_url: proxy_spawned_registry.then_some(registry_public_url.as_str()),
+            spawned_registry_port: registry.spawned_port,
+            public_url: registry.proxied.then_some(registry.public_url.as_str()),
         })
         .await
     };
-    let registry_proxy = proxy_spawned_registry.then(|| {
+    let registry_proxy = registry.proxied.then(|| {
         spawn_registry_proxy(
-            registry_port,
-            spawned_registry_port,
+            args.registry_port,
+            registry.spawned_port,
             LinkProfile {
-                one_way: Duration::from_millis(registry_latency_ms) / 2,
-                rate_limit: registry_rate_limit,
-                slow_start: registry_slow_start,
+                one_way: Duration::from_millis(args.registry_latency_ms) / 2,
+                rate_limit: registry.rate_limit,
+                slow_start: args.registry_slow_start,
             },
-            registry_latency_ms,
-            registry_bandwidth_mbps,
+            args.registry_latency_ms,
+            args.registry_bandwidth_mbps,
         )
     });
 
     verify_prerequisites(
-        &targets,
+        &args.targets,
         &repository,
         pnpm_repository.as_deref(),
-        with_pnpm,
-        registry_mode,
+        args.with_pnpm,
+        args.registry,
     );
 
     let env = work_env::WorkEnv {
         root: work_env,
-        with_pnpm,
-        targets,
-        registry,
-        registry_cache_populator,
-        registry_mode,
+        with_pnpm: args.with_pnpm,
+        targets: args.targets,
+        registry: registry.url,
+        registry_cache_populator: registry.cache_populator,
+        registry_mode: args.registry,
         repository,
         pnpm_repository,
-        scenario,
-        hyperfine_options,
-        fixture_dir,
-        pnpr_latency_ms,
-        registry_latency_ms,
-        pnpr_server_registry_latency_ms,
-        registry_bandwidth_mbps,
-        registry_slow_start,
-        registry_port: spawned_registry_port,
-        reuse_prebuilt_binaries,
-        serve_timing,
+        scenario: args.scenario,
+        hyperfine_options: args.hyperfine_options,
+        fixture_dir: args.fixture_dir,
+        pnpr_latency_ms: args.pnpr_latency_ms,
+        registry_latency_ms: args.registry_latency_ms,
+        pnpr_server_registry_latency_ms: args.pnpr_server_registry_latency_ms,
+        registry_bandwidth_mbps: args.registry_bandwidth_mbps,
+        registry_slow_start: args.registry_slow_start,
+        registry_port: registry.spawned_port,
+        reuse_prebuilt_binaries: args.reuse_prebuilt_binaries,
+        serve_timing: args.serve_timing,
     };
-    if build_only {
+    if args.build_only {
         env.build();
     } else {
         env.run();
     }
     drop(registry_proxy);
     drop(verdaccio); // terminate verdaccio if exists
+}
+
+/// Where the clients are pointed, and the mock behind the latency proxy
+/// when one fronts it.
+struct RegistryLink {
+    url: String,
+    rate_limit: Option<u64>,
+    /// A latency or bandwidth profile puts a proxy in front of the mock.
+    proxied: bool,
+    spawned_port: u16,
+    cache_populator: String,
+    public_url: String,
+}
+
+impl RegistryLink {
+    fn plan(args: &cli_args::CliArgs) -> Self {
+        let url = registry_url(args.registry, args.registry_port);
+        let rate_limit = mbps_to_bytes_per_sec(args.registry_bandwidth_mbps);
+        let proxied = !args.build_only
+            && matches!(args.registry, RegistryMode::Verdaccio)
+            && (args.registry_latency_ms > 0 || rate_limit.is_some());
+        let (spawned_port, cache_populator) = upstream_registry(proxied, args.registry_port, &url);
+        let public_url = url.trim_end_matches('/').to_string();
+        RegistryLink { url, rate_limit, proxied, spawned_port, cache_populator, public_url }
+    }
 }
 
 /// What the mock registry needs to come up.

--- a/pnpm/tasks/integrated-benchmark/src/work_env.rs
+++ b/pnpm/tasks/integrated-benchmark/src/work_env.rs
@@ -918,7 +918,7 @@ impl WorkEnv {
         eprintln!(
             "Starting pnpr server for {} on 127.0.0.1:{}...",
             paths.bench_dir.display(),
-            paths.port
+            paths.port,
         );
         let stdout = File::create(paths.bench_dir.join("pnpr-server.stdout.log"))
             .expect("create pnpr server stdout log");

--- a/pnpm/tasks/integrated-benchmark/src/work_env.rs
+++ b/pnpm/tasks/integrated-benchmark/src/work_env.rs
@@ -793,29 +793,8 @@ impl WorkEnv {
 
         let mut server = PnprServer { process, latency_proxy: None };
         wait_for_pnpr_ready(mock_port);
-
-        // Front the mock with the same latency + bandwidth profile the shared
-        // registry proxy uses, serving the socket reserved at planning time
-        // (and baked into this revision's `.npmrc`) so the port can't have
-        // been stolen during the build.
-        let upstream = SocketAddr::from((Ipv4Addr::LOCALHOST, mock_port));
-        let profile = LinkProfile {
-            one_way: Duration::from_millis(self.registry_latency_ms) / 2,
-            rate_limit: mbps_to_bytes_per_sec(self.registry_bandwidth_mbps),
-            slow_start: self.registry_slow_start,
-        };
-        let proxy = LatencyProxy::spawn_with_listener(registry.listener, upstream, profile)
-            .expect("spawn revision mock latency proxy");
-        eprintln!(
-            "Fronting mock for {revision} with {}ms round-trip latency + {} download cap (proxy at {})",
-            self.registry_latency_ms,
-            match self.registry_bandwidth_mbps {
-                mbps if mbps > 0.0 => format!("{mbps} Mbit/s"),
-                _ => "no".to_string(),
-            },
-            proxy.addr,
-        );
-        server.latency_proxy = Some(proxy);
+        server.latency_proxy =
+            Some(self.front_revision_mock(revision, registry.listener, mock_port));
         server
     }
 
@@ -829,6 +808,35 @@ impl WorkEnv {
             .filter(|id| id.is_pnpr())
             .map(|id| self.start_pnpr_server(id, pnpr_server_registry))
             .collect()
+    }
+    /// Front the mock with the same latency + bandwidth profile the shared
+    /// registry proxy uses, serving the socket reserved at planning time
+    /// (and baked into this revision's `.npmrc`) so the port can't have
+    /// been stolen during the build.
+    fn front_revision_mock(
+        &self,
+        revision: &str,
+        listener: TcpListener,
+        mock_port: u16,
+    ) -> LatencyProxy {
+        let upstream = SocketAddr::from((Ipv4Addr::LOCALHOST, mock_port));
+        let profile = LinkProfile {
+            one_way: Duration::from_millis(self.registry_latency_ms) / 2,
+            rate_limit: mbps_to_bytes_per_sec(self.registry_bandwidth_mbps),
+            slow_start: self.registry_slow_start,
+        };
+        let proxy = LatencyProxy::spawn_with_listener(listener, upstream, profile)
+            .expect("spawn revision mock latency proxy");
+        eprintln!(
+            "Fronting mock for {revision} with {}ms round-trip latency + {} download cap (proxy at {})",
+            self.registry_latency_ms,
+            match self.registry_bandwidth_mbps {
+                mbps if mbps > 0.0 => format!("{mbps} Mbit/s"),
+                _ => "no".to_string(),
+            },
+            proxy.addr,
+        );
+        proxy
     }
 
     fn start_pnpr_server(&self, id: BenchId, pnpr_server_registry: &str) -> PnprServer {
@@ -849,38 +857,20 @@ impl WorkEnv {
             write_pnpr_benchmark_config(&bench_dir, &pnpr_storage, &public_route_registries);
         let port = pick_unused_port().expect("pick an unused port for the pnpr server");
 
-        eprintln!("Starting pnpr server for {id} on 127.0.0.1:{port}...");
-        let stdout = File::create(bench_dir.join("pnpr-server.stdout.log"))
-            .expect("create pnpr server stdout log");
-        let stderr = File::create(bench_dir.join("pnpr-server.stderr.log"))
-            .expect("create pnpr server stderr log");
-        let mut command = Command::new(&binary);
-        command
-            .arg("--config")
-            .arg(&pnpr_config)
-            .arg("--listen")
-            .arg(format!("127.0.0.1:{port}"))
-            .arg("--storage")
-            .arg(&pnpr_storage)
-            // The resolver resolves against the registry the client
-            // sends, caching packuments in its own store. A long TTL keeps
-            // those cached packuments authoritative across the run, the
-            // same value the registry-mock pins for the same reason.
-            .arg("--packument-ttl-secs")
-            .arg("31536000");
-        self.apply_serve_timing(&mut command);
-        let process = command
-            .stdin(Stdio::null())
-            .stdout(stdout)
-            .stderr(stderr)
-            .spawn()
-            .expect("spawn pnpr server");
-
         // Wrap the child in its guard *before* anything that can panic
         // (readiness wait, `.pnpr-env` write), so an early failure unwinds
         // through `PnprServer::drop` and kills the process instead of
         // leaking an orphaned server.
-        let mut server = PnprServer { process, latency_proxy: None };
+        let mut server = PnprServer {
+            process: self.spawn_pnpr_server_process(&PnprServerPaths {
+                bench_dir: &bench_dir,
+                binary: &binary,
+                config: &pnpr_config,
+                storage: &pnpr_storage,
+                port,
+            }),
+            latency_proxy: None,
+        };
 
         wait_for_pnpr_ready(port);
         // Log in as the seeded benchmark user to mint a bearer token. Real
@@ -896,27 +886,7 @@ impl WorkEnv {
         // measures pnpr as the remote service it is in production. The
         // proxy guard rides along in `PnprServer` so it's torn down with
         // the server.
-        let client_url = if self.pnpr_latency_ms > 0 {
-            let upstream = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
-            // Latency only: the pnpr resolve protocol exchanges small
-            // metadata payloads, so the round trip (not throughput) is the
-            // cost that matters for the client↔server link.
-            let profile = LinkProfile {
-                one_way: Duration::from_millis(self.pnpr_latency_ms) / 2,
-                rate_limit: None,
-                slow_start: false,
-            };
-            let proxy = LatencyProxy::spawn(upstream, profile).expect("spawn pnpr latency proxy");
-            let proxy_url = format!("http://{}", proxy.addr);
-            eprintln!(
-                "Injecting {}ms round-trip latency in front of {id}'s server (proxy at {})",
-                self.pnpr_latency_ms, proxy.addr,
-            );
-            server.latency_proxy = Some(proxy);
-            proxy_url
-        } else {
-            format!("http://127.0.0.1:{port}")
-        };
+        let client_url = self.pnpr_client_url(id, port, &mut server);
 
         // Must be `PNPM_CONFIG_PNPR_SERVER`, not a bare `PNPR_SERVER`:
         // pacquet reads config env vars only under the `PNPM_CONFIG_*` /
@@ -942,6 +912,64 @@ impl WorkEnv {
         .expect("write .pnpr-env");
 
         server
+    }
+
+    fn spawn_pnpr_server_process(&self, paths: &PnprServerPaths<'_>) -> Child {
+        eprintln!(
+            "Starting pnpr server for {} on 127.0.0.1:{}...",
+            paths.bench_dir.display(),
+            paths.port
+        );
+        let stdout = File::create(paths.bench_dir.join("pnpr-server.stdout.log"))
+            .expect("create pnpr server stdout log");
+        let stderr = File::create(paths.bench_dir.join("pnpr-server.stderr.log"))
+            .expect("create pnpr server stderr log");
+        let mut command = Command::new(paths.binary);
+        command
+            .arg("--config")
+            .arg(paths.config)
+            .arg("--listen")
+            .arg(format!("127.0.0.1:{}", paths.port))
+            .arg("--storage")
+            .arg(paths.storage)
+            // The resolver resolves against the registry the client
+            // sends, caching packuments in its own store. A long TTL keeps
+            // those cached packuments authoritative across the run, the
+            // same value the registry-mock pins for the same reason.
+            .arg("--packument-ttl-secs")
+            .arg("31536000");
+        self.apply_serve_timing(&mut command);
+        command
+            .stdin(Stdio::null())
+            .stdout(stdout)
+            .stderr(stderr)
+            .spawn()
+            .expect("spawn pnpr server")
+    }
+
+    /// The URL the client reaches the server at: a latency-injecting proxy
+    /// when `--pnpr-latency-ms` is set, the server itself otherwise.
+    fn pnpr_client_url(&self, id: BenchId, port: u16, server: &mut PnprServer) -> String {
+        if self.pnpr_latency_ms == 0 {
+            return format!("http://127.0.0.1:{port}");
+        }
+        let upstream = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+        // Latency only: the pnpr resolve protocol exchanges small
+        // metadata payloads, so the round trip (not throughput) is the
+        // cost that matters for the client↔server link.
+        let profile = LinkProfile {
+            one_way: Duration::from_millis(self.pnpr_latency_ms) / 2,
+            rate_limit: None,
+            slow_start: false,
+        };
+        let proxy = LatencyProxy::spawn(upstream, profile).expect("spawn pnpr latency proxy");
+        let proxy_url = format!("http://{}", proxy.addr);
+        eprintln!(
+            "Injecting {}ms round-trip latency in front of {id}'s server (proxy at {})",
+            self.pnpr_latency_ms, proxy.addr,
+        );
+        server.latency_proxy = Some(proxy);
+        proxy_url
     }
 
     pub fn run(&self) {
@@ -1587,6 +1615,15 @@ struct RevisionMockRegistry {
 
 /// A pnpr resolver server spawned for one `pnpr@<rev>`
 /// target. Killed on drop so it never outlives the benchmark run.
+/// Where one benchmark's pnpr server binary, config and storage live.
+struct PnprServerPaths<'a> {
+    bench_dir: &'a Path,
+    binary: &'a Path,
+    config: &'a Path,
+    storage: &'a Path,
+    port: u16,
+}
+
 struct PnprServer {
     process: Child,
     /// The latency proxy fronting this server, when `--pnpr-latency-ms`

--- a/pnpr/crates/auth/src/oidc.rs
+++ b/pnpr/crates/auth/src/oidc.rs
@@ -8,7 +8,7 @@ use openidconnect::{
     OAuth2TokenResponse, PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, TokenResponse,
     core::{
         CoreAuthenticationFlow, CoreClient, CoreClientAuthMethod, CoreIdToken, CoreIdTokenVerifier,
-        CoreJwsSigningAlgorithm, CoreProviderMetadata,
+        CoreJwsSigningAlgorithm, CoreProviderMetadata, CoreTokenResponse,
     },
 };
 use p256::ecdsa::{
@@ -197,11 +197,10 @@ impl OidcState {
         }
         let _exchange = self.exchanges.try_acquire().map_err(|_| unavailable())?;
         self.record_attempt(&login.state_hash)?;
-        let nonce = Nonce::new(login.nonce);
         let provider = self.providers.get(provider_name).ok_or_else(rejected)?;
         let metadata = self.metadata(provider, false).await?;
-        let client = self.login_client(provider, metadata.clone())?;
-        let response = client
+        let response = self
+            .login_client(provider, metadata.clone())?
             .exchange_code(AuthorizationCode::new(code.to_string()))
             .map_err(|_| rejected())?
             .set_pkce_verifier(PkceCodeVerifier::new(login.verifier))
@@ -209,11 +208,40 @@ impl OidcState {
             .await
             .map_err(|_| rejected())?;
         let token = response.id_token().ok_or_else(rejected)?;
-        let mut verifier = token_verifier(&provider.config, &metadata)?;
-        if token.claims(&verifier, &nonce).is_err() {
+        let expiration = self
+            .verified_expiration(provider, &metadata, &response, token, &Nonce::new(login.nonce))
+            .await?;
+        let binding = bound_user(&provider.config, token)?;
+        let now = Utc::now().timestamp();
+        if login.expires <= now {
+            return Err(rejected());
+        }
+        let mut consumed = self.consumed.lock().expect("OIDC consumed mutex poisoned");
+        consumed.retain(|_, expires| *expires > now);
+        if consumed.contains_key(&login.state_hash) || consumed.len() >= MAX_ENTRIES {
+            return Err(rejected());
+        }
+        let session = self.issue_session(&binding.username, expiration)?;
+        consumed.insert(login.state_hash, login.expires);
+        Ok(session)
+    }
+
+    /// Verify the ID token against the provider's keys, refreshing them once
+    /// when the cached keys reject it, and check the access token hash it
+    /// carries. Returns the verified claims' expiration.
+    async fn verified_expiration(
+        &self,
+        provider: &Provider,
+        metadata: &CoreProviderMetadata,
+        response: &CoreTokenResponse,
+        token: &CoreIdToken,
+        nonce: &Nonce,
+    ) -> Result<i64> {
+        let mut verifier = token_verifier(&provider.config, metadata)?;
+        if token.claims(&verifier, nonce).is_err() {
             verifier = token_verifier(&provider.config, &self.metadata(provider, true).await?)?;
         }
-        let claims = token.claims(&verifier, &nonce).map_err(|_| rejected())?;
+        let claims = token.claims(&verifier, nonce).map_err(|_| rejected())?;
         if let Some(expected) = claims.access_token_hash() {
             let actual = AccessTokenHash::from_token(
                 response.access_token(),
@@ -225,22 +253,7 @@ impl OidcState {
                 return Err(rejected());
             }
         }
-        let payload = token_payload(&token.to_string())?;
-        validate_claims(&provider.config, &payload)?;
-        let users = &provider.config.login.as_ref().ok_or_else(rejected)?.users;
-        let binding = unique_binding(users.iter(), &payload)?;
-        let now = Utc::now().timestamp();
-        if login.expires <= now {
-            return Err(rejected());
-        }
-        let mut consumed = self.consumed.lock().expect("OIDC consumed mutex poisoned");
-        consumed.retain(|_, expires| *expires > now);
-        if consumed.contains_key(&login.state_hash) || consumed.len() >= MAX_ENTRIES {
-            return Err(rejected());
-        }
-        let session = self.issue_session(&binding.username, claims.expiration().timestamp())?;
-        consumed.insert(login.state_hash, login.expires);
-        Ok(session)
+        Ok(claims.expiration().timestamp())
     }
 
     fn record_attempt(&self, state_hash: &str) -> Result<()> {
@@ -473,6 +486,14 @@ fn verify_workload(
     let verifier = token_verifier(config, metadata)?;
     token.claims(&verifier, |_: Option<&Nonce>| Ok(())).map_err(|_| rejected())?;
     validate_claims(config, &token_payload(raw)?)
+}
+
+/// The one configured user the token's claims bind to.
+fn bound_user<'p>(config: &'p OidcProvider, token: &CoreIdToken) -> Result<&'p OidcBinding> {
+    let payload = token_payload(&token.to_string())?;
+    validate_claims(config, &payload)?;
+    let users = &config.login.as_ref().ok_or_else(rejected)?.users;
+    unique_binding(users.iter(), &payload)
 }
 
 fn token_verifier(

--- a/pnpr/crates/config/src/lib.rs
+++ b/pnpr/crates/config/src/lib.rs
@@ -1659,110 +1659,49 @@ impl Config {
         public_url: Option<String>,
         overrides: FeatureOverrides,
     ) -> Result<Self, RegistryError> {
-        let (substituted, unresolved) = env_replace_lossy::<SystemEnv>(raw);
-        if !unresolved.is_empty() {
-            tracing::warn!(?unresolved, "config references unset environment variables");
-        }
-        let file: ConfigFile = serde_saphyr::from_str(&substituted)
-            .map_err(|err| RegistryError::InvalidConfig { reason: err.to_string() })?;
-        if file.oci.max_blob_bytes == 0 || file.oci.max_manifest_bytes == 0 {
-            return Err(RegistryError::InvalidConfig {
-                reason: "oci size limits must be greater than zero".to_string(),
-            });
-        }
+        let file = parse_config_file(raw)?;
         let storage = resolve_relative(&file.storage, base_dir);
         let cache_storage = file
             .cache
             .as_deref()
             .map_or_else(|| default_cache_dir(&storage), |raw| resolve_relative(raw, base_dir));
-        let hosted_store = match &file.s3 {
-            Some(s3) => HostedStoreConfig::S3(s3.clone()),
-            None => HostedStoreConfig::Fs,
-        };
         let backend = build_backend_config(file.backend, base_dir)?;
-        let public_url = public_url.unwrap_or_else(|| format!("http://{listen}"));
         let cors = build_cors_config(file.cors)?;
-        let auth = build_auth_config(&file.auth, base_dir);
-        let logs = build_log_config(file.log.as_ref());
-        // The global ACL and group blocks are gone, not ignorable: they used
-        // to *enforce* and *grant* access, so dropping either like an unknown
-        // verdaccio key would silently change who may reach what on upgrade.
-        // Fail loudly instead, naming the replacement.
-        if file.packages.is_some() {
-            return Err(RegistryError::InvalidConfig {
-                reason: "the top-level `packages:` block was removed: declare per-package rules \
-                         on the registry that serves them, as `registries.<name>.packages` \
-                         (pattern keys, `access`/`publish`/`unpublish` values)"
-                    .to_string(),
-            });
-        }
-        if file.groups.is_some() {
-            return Err(RegistryError::InvalidConfig {
-                reason: "the top-level `groups:` block was removed: declare teams on the \
-                         registry that uses them, as `registries.<name>.teams` (team-name keys, \
-                         member-list values), and reference them from that registry's access \
-                         lists as `team:<name>`"
-                    .to_string(),
-            });
-        }
-        let osv = build_osv_config(&file.osv, base_dir);
-        // The npm-registry surface is derived, not configured: served iff
-        // at least one registry is declared (no registries ⇒ nothing to serve),
-        // minus the per-tier `--disable-registry` override. Folding the
-        // override in here lets the registry-only work below (upstream
-        // credential resolution) key off effective enablement.
-        let registry =
-            RegistryFeature { enabled: !file.registries.is_empty() && !overrides.disable_registry };
-        let resolver_file = file.resolver.unwrap_or_default();
-        let resolver =
-            ResolverFeature { enabled: resolver_file.enabled && !overrides.disable_resolver };
-        let artifacts_file = file.artifacts.unwrap_or_default();
-        let artifacts = ArtifactsFeature {
-            enabled: artifacts_file.enabled && !overrides.disable_artifacts,
-            compiler_caches: parse_storage_access(artifacts_file.compiler_caches)?,
-        };
-        let pipeline_file = file.pipeline.unwrap_or_default();
-        let pipeline = PipelineFeature {
-            enabled: pipeline_file.enabled,
-            workspaces: parse_storage_access(pipeline_file.workspaces)?,
-        };
-        // Upstream registries (and the credentials some carry) are resolved by
-        // `build_registries` below into this map. Resolving an upstream registry's
-        // `auth` is strict — an unresolvable token is a config error — so a
-        // resolver-only server (which serves no registry routes) skips the
-        // credential resolution rather than carry upstream secrets it never
-        // uses. The registry *graph* is still built and validated either way, so
-        // a misconfigured router or org fails startup on every tier, not only
-        // when the registry surface happens to be enabled.
+        reject_removed_blocks(file.packages.is_some(), file.groups.is_some())?;
+        let features = build_features(
+            !file.registries.is_empty(),
+            file.resolver,
+            file.artifacts,
+            file.pipeline,
+            overrides,
+        )?;
         let mut upstreams: IndexMap<String, UpstreamConfig> = IndexMap::new();
         let (hosted, registries) = build_registries(
             &mut upstreams,
             file.registries,
             file.default_registry,
-            registry.enabled,
+            features.registry.enabled,
         )?;
-        let route_policy = build_route_policy(file.routes);
-        let resolution_cache_secret = resolution_secret(file.secret.as_deref())?;
         let config = Self {
             listen,
-            public_url,
+            public_url: public_url.unwrap_or_else(|| format!("http://{listen}")),
             cors,
             oci: file.oci,
             storage,
             cache_storage,
             upstreams,
             packument_ttl: Self::DEFAULT_PACKUMENT_TTL,
-            auth,
-            logs,
-            hosted_store,
+            auth: build_auth_config(&file.auth, base_dir),
+            logs: build_log_config(file.log.as_ref()),
+            hosted_store: file.s3.map_or(HostedStoreConfig::Fs, HostedStoreConfig::S3),
             backend,
-            osv,
-            registry,
-            resolver,
-            artifacts,
-            pipeline,
-            route_policy,
-            resolution_cache_secret,
+            osv: build_osv_config(&file.osv, base_dir),
+            registry: features.registry,
+            resolver: features.resolver,
+            artifacts: features.artifacts,
+            pipeline: features.pipeline,
+            route_policy: build_route_policy(file.routes),
+            resolution_cache_secret: resolution_secret(file.secret.as_deref())?,
             registries,
             hosted,
         };
@@ -1916,6 +1855,83 @@ impl Config {
         }
         Ok(())
     }
+}
+
+fn parse_config_file(raw: &str) -> Result<ConfigFile, RegistryError> {
+    let (substituted, unresolved) = env_replace_lossy::<SystemEnv>(raw);
+    if !unresolved.is_empty() {
+        tracing::warn!(?unresolved, "config references unset environment variables");
+    }
+    let file: ConfigFile = serde_saphyr::from_str(&substituted)
+        .map_err(|err| RegistryError::InvalidConfig { reason: err.to_string() })?;
+    if file.oci.max_blob_bytes == 0 || file.oci.max_manifest_bytes == 0 {
+        return Err(RegistryError::InvalidConfig {
+            reason: "oci size limits must be greater than zero".to_string(),
+        });
+    }
+    Ok(file)
+}
+
+/// The global ACL and group blocks are gone, not ignorable: they used
+/// to *enforce* and *grant* access, so dropping either like an unknown
+/// verdaccio key would silently change who may reach what on upgrade.
+/// Fail loudly instead, naming the replacement.
+fn reject_removed_blocks(has_packages: bool, has_groups: bool) -> Result<(), RegistryError> {
+    if has_packages {
+        return Err(RegistryError::InvalidConfig {
+            reason: "the top-level `packages:` block was removed: declare per-package rules \
+                     on the registry that serves them, as `registries.<name>.packages` \
+                     (pattern keys, `access`/`publish`/`unpublish` values)"
+                .to_string(),
+        });
+    }
+    if has_groups {
+        return Err(RegistryError::InvalidConfig {
+            reason: "the top-level `groups:` block was removed: declare teams on the \
+                     registry that uses them, as `registries.<name>.teams` (team-name keys, \
+                     member-list values), and reference them from that registry's access \
+                     lists as `team:<name>`"
+                .to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// The feature toggles the file declares, with the CLI overrides folded in.
+struct Features {
+    registry: RegistryFeature,
+    resolver: ResolverFeature,
+    artifacts: ArtifactsFeature,
+    pipeline: PipelineFeature,
+}
+
+/// The npm-registry surface is derived, not configured: served iff
+/// at least one registry is declared (no registries ⇒ nothing to serve),
+/// minus the per-tier `--disable-registry` override. Folding the
+/// override in here lets the registry-only work below (upstream
+/// credential resolution) key off effective enablement.
+fn build_features(
+    registry_declared: bool,
+    resolver: Option<FeatureFile>,
+    artifacts: Option<ArtifactsFeatureFile>,
+    pipeline: Option<PipelineFeatureFile>,
+    overrides: FeatureOverrides,
+) -> Result<Features, RegistryError> {
+    let resolver_file = resolver.unwrap_or_default();
+    let artifacts_file = artifacts.unwrap_or_default();
+    let pipeline_file = pipeline.unwrap_or_default();
+    Ok(Features {
+        registry: RegistryFeature { enabled: registry_declared && !overrides.disable_registry },
+        resolver: ResolverFeature { enabled: resolver_file.enabled && !overrides.disable_resolver },
+        artifacts: ArtifactsFeature {
+            enabled: artifacts_file.enabled && !overrides.disable_artifacts,
+            compiler_caches: parse_storage_access(artifacts_file.compiler_caches)?,
+        },
+        pipeline: PipelineFeature {
+            enabled: pipeline_file.enabled,
+            workspaces: parse_storage_access(pipeline_file.workspaces)?,
+        },
+    })
 }
 
 fn build_cors_config(file: CorsFile) -> Result<CorsConfig, RegistryError> {
@@ -2081,8 +2097,35 @@ fn build_registries(
     resolve_upstreams: bool,
 ) -> Result<(IndexMap<String, HostedConfig>, Registries), RegistryError> {
     let registry_files = flatten_registry_groups(registry_files)?;
-    let (default_registry, defaults) = match default_registry {
-        Some(DefaultRegistryFile::Shared(name)) => (Some(name), IndexMap::new()),
+    let (default_registry, defaults) = resolve_default_registry(default_registry)?;
+    let mut builder = RegistryGraphBuilder::default();
+    // Every configured upstream is, by definition, an upstream registry addressable
+    // at `/~<name>/`. No declared patterns ⇒ it serves every name.
+    for name in upstreams.keys() {
+        validate_registry_name(name)?;
+        builder.graph.insert(name.clone(), Registry::Upstream { patterns: Vec::new() });
+    }
+    for (name, file) in registry_files {
+        builder.add(name, file, upstreams, resolve_upstreams)?;
+    }
+    let registries =
+        builder.ecosystems.iter().filter(|(_, ecosystem)| **ecosystem != Ecosystem::Npm).fold(
+            Registries::new(builder.graph, default_registry),
+            |registries, (name, ecosystem)| registries.with_ecosystem(name, *ecosystem),
+        );
+    let defaults = addressed_defaults(defaults, &registries);
+    let registries = registries.with_defaults(defaults);
+    registries.validate().map_err(|err| registry_err(&err))?;
+    Ok((builder.hosted, registries))
+}
+
+/// The shared default registry, or the per-ecosystem defaults qualified
+/// by their ecosystem.
+fn resolve_default_registry(
+    default_registry: Option<DefaultRegistryFile>,
+) -> Result<(Option<String>, IndexMap<Ecosystem, String>), RegistryError> {
+    match default_registry {
+        Some(DefaultRegistryFile::Shared(name)) => Ok((Some(name), IndexMap::new())),
         Some(DefaultRegistryFile::Ecosystems(defaults)) => {
             let defaults = defaults
                 .into_iter()
@@ -2091,22 +2134,31 @@ fn build_registries(
                     Ok((ecosystem, format!("{ecosystem}/{name}")))
                 })
                 .collect::<Result<IndexMap<_, _>, RegistryError>>()?;
-            (None, defaults)
+            Ok((None, defaults))
         }
-        None => (None, IndexMap::new()),
-    };
-    let mut hosted: IndexMap<String, HostedConfig> = IndexMap::new();
-    let mut graph: IndexMap<String, Registry> = IndexMap::new();
-    let mut ecosystems: IndexMap<String, Ecosystem> = IndexMap::new();
-    // Every configured upstream is, by definition, an upstream registry addressable
-    // at `/~<name>/`. No declared patterns ⇒ it serves every name.
-    for name in upstreams.keys() {
-        validate_registry_name(name)?;
-        graph.insert(name.clone(), Registry::Upstream { patterns: Vec::new() });
+        None => Ok((None, IndexMap::new())),
     }
-    for (name, file) in registry_files {
+}
+
+/// The registry graph under construction: the hosted registries' configs,
+/// every registry's routing entry and the ecosystem each serves.
+#[derive(Default)]
+struct RegistryGraphBuilder {
+    hosted: IndexMap<String, HostedConfig>,
+    graph: IndexMap<String, Registry>,
+    ecosystems: IndexMap<String, Ecosystem>,
+}
+
+impl RegistryGraphBuilder {
+    fn add(
+        &mut self,
+        name: String,
+        file: RegistryFile,
+        upstreams: &mut IndexMap<String, UpstreamConfig>,
+        resolve_upstreams: bool,
+    ) -> Result<(), RegistryError> {
         validate_registry_key(&name)?;
-        if graph.contains_key(&name) {
+        if self.graph.contains_key(&name) {
             return Err(RegistryError::InvalidConfig {
                 reason: format!(
                     "registry {name:?} collides with another registry or upstream of the same name",
@@ -2115,42 +2167,42 @@ fn build_registries(
         }
         match file {
             RegistryFile::Hosted(registry) => {
-                let (config, ecosystem, patterns) = build_hosted_entry(&name, registry, &hosted)?;
-                hosted.insert(name.clone(), config);
-                ecosystems.insert(name.clone(), ecosystem);
-                graph.insert(name, Registry::Hosted { patterns });
+                let (config, ecosystem, patterns) =
+                    build_hosted_entry(&name, registry, &self.hosted)?;
+                self.hosted.insert(name.clone(), config);
+                self.ecosystems.insert(name.clone(), ecosystem);
+                self.graph.insert(name, Registry::Hosted { patterns });
             }
             RegistryFile::Upstream(upstream) => {
                 let (resolved, ecosystem, patterns) =
                     build_upstream_entry(&name, *upstream, resolve_upstreams)?;
-                ecosystems.insert(name.clone(), ecosystem);
+                self.ecosystems.insert(name.clone(), ecosystem);
                 if let Some(resolved) = resolved {
                     upstreams.insert(name.clone(), resolved);
                 }
-                graph.insert(name, Registry::Upstream { patterns });
+                self.graph.insert(name, Registry::Upstream { patterns });
             }
             RegistryFile::Router(router) => {
-                graph.insert(name, Registry::Router { sources: router.sources });
+                self.graph.insert(name, Registry::Router { sources: router.sources });
             }
         }
+        Ok(())
     }
-    let registries = ecosystems
-        .iter()
-        .filter(|(_, ecosystem)| **ecosystem != Ecosystem::Npm)
-        .fold(Registries::new(graph, default_registry), |registries, (name, ecosystem)| {
-            registries.with_ecosystem(name, *ecosystem)
-        });
-    let defaults = defaults
+}
+
+/// Each ecosystem's default, addressed the way the registries name it.
+fn addressed_defaults(
+    defaults: IndexMap<Ecosystem, String>,
+    registries: &Registries,
+) -> IndexMap<Ecosystem, String> {
+    defaults
         .into_iter()
         .map(|(ecosystem, target)| {
             let local = Registries::local_name(&target);
             let key = registries.addressed(local, ecosystem).unwrap_or(&target).to_string();
             (ecosystem, key)
         })
-        .collect();
-    let registries = registries.with_defaults(defaults);
-    registries.validate().map_err(|err| registry_err(&err))?;
-    Ok((hosted, registries))
+        .collect()
 }
 
 /// The serving config, ecosystem and claimed patterns of one `hosted:` registry.

--- a/pnpr/crates/config/src/upstream.rs
+++ b/pnpr/crates/config/src/upstream.rs
@@ -255,36 +255,7 @@ pub(super) fn resolve_upstream_config<Sys: EnvVar>(
     file: UpstreamConfigFile,
     teams: &Teams,
 ) -> Result<UpstreamConfig, RegistryError> {
-    let mut headers = HeaderMap::new();
-    if let Some(auth) = &file.auth {
-        let token =
-            resolve_upstream_token::<Sys>(auth).ok_or_else(|| RegistryError::InvalidConfig {
-                reason: format!(
-                    "upstream {name:?} has an auth block but no token could be resolved \
-                     (set auth.token or point auth.token_env at a set env var)",
-                ),
-            })?;
-        let value = match auth.r#type {
-            UpstreamAuthType::Bearer => format!("Bearer {token}"),
-            UpstreamAuthType::Basic => format!("Basic {token}"),
-        };
-        let value = HeaderValue::from_str(&value).map_err(|_| RegistryError::InvalidConfig {
-            reason: format!("upstream {name:?} auth token is not a valid header value"),
-        })?;
-        headers.insert(AUTHORIZATION, value);
-    }
-    for (raw_name, raw_value) in &file.headers {
-        let header_name = HeaderName::from_bytes(raw_name.as_bytes()).map_err(|_| {
-            RegistryError::InvalidConfig {
-                reason: format!("upstream {name:?} has an invalid header name {raw_name:?}"),
-            }
-        })?;
-        let header_value =
-            HeaderValue::from_str(raw_value).map_err(|_| RegistryError::InvalidConfig {
-                reason: format!("upstream {name:?} header {raw_name:?} has an invalid value"),
-            })?;
-        headers.insert(header_name, header_value);
-    }
+    let headers = upstream_headers::<Sys>(name, &file)?;
 
     // Parse the verdaccio interval knobs, turning a typo'd value into a
     // config error (named for the offending field) rather than silently
@@ -325,6 +296,45 @@ pub(super) fn resolve_upstream_config<Sys: EnvVar>(
         // knobs shared with programmatic construction.
         rules: PackageRules::default(),
     })
+}
+
+/// The upstream's request headers: the resolved auth header, then the
+/// declared ones.
+fn upstream_headers<Sys: EnvVar>(
+    name: &str,
+    file: &UpstreamConfigFile,
+) -> Result<HeaderMap, RegistryError> {
+    let mut headers = HeaderMap::new();
+    if let Some(auth) = &file.auth {
+        let token =
+            resolve_upstream_token::<Sys>(auth).ok_or_else(|| RegistryError::InvalidConfig {
+                reason: format!(
+                    "upstream {name:?} has an auth block but no token could be resolved \
+                     (set auth.token or point auth.token_env at a set env var)",
+                ),
+            })?;
+        let value = match auth.r#type {
+            UpstreamAuthType::Bearer => format!("Bearer {token}"),
+            UpstreamAuthType::Basic => format!("Basic {token}"),
+        };
+        let value = HeaderValue::from_str(&value).map_err(|_| RegistryError::InvalidConfig {
+            reason: format!("upstream {name:?} auth token is not a valid header value"),
+        })?;
+        headers.insert(AUTHORIZATION, value);
+    }
+    for (raw_name, raw_value) in &file.headers {
+        let header_name = HeaderName::from_bytes(raw_name.as_bytes()).map_err(|_| {
+            RegistryError::InvalidConfig {
+                reason: format!("upstream {name:?} has an invalid header name {raw_name:?}"),
+            }
+        })?;
+        let header_value =
+            HeaderValue::from_str(raw_value).map_err(|_| RegistryError::InvalidConfig {
+                reason: format!("upstream {name:?} header {raw_name:?} has an invalid value"),
+            })?;
+        headers.insert(header_name, header_value);
+    }
+    Ok(headers)
 }
 
 /// Parse a verdaccio-style interval string into a [`Duration`].

--- a/pnpr/crates/pnpr-fixtures/src/lib.rs
+++ b/pnpr/crates/pnpr-fixtures/src/lib.rs
@@ -311,38 +311,17 @@ struct PackageVersion {
 impl PackageVersion {
     fn load(root: &Path, manifest_path: &Path, substitutions: &[(&str, &str)]) -> Self {
         let package_dir = manifest_path.parent().expect("manifest has parent");
-        let manifest_text = substitutions.iter().fold(
-            fs::read_to_string(manifest_path).expect("read fixture package.json"),
-            |manifest, (from, to)| manifest.replace(from, to),
-        );
+        let manifest_text = substituted_manifest_text(manifest_path, substitutions);
         let manifest: Value =
             serde_json::from_str(&manifest_text).expect("parse fixture package.json");
-        let name = manifest
-            .get("name")
-            .and_then(Value::as_str)
-            .expect("fixture package.json has string name")
-            .to_string();
-        let version = manifest
-            .get("version")
-            .and_then(Value::as_str)
-            .expect("fixture package.json has string version")
-            .to_string();
+        let name = manifest_string(&manifest, "name");
+        let version = manifest_string(&manifest, "version");
         let tarball = build_tarball(root, package_dir, &manifest, &manifest_text);
         let integrity =
             format!("sha512-{}", general_purpose::STANDARD.encode(Sha512::digest(&tarball)));
         let tarball_name = format!("{}-{version}.tgz", tarball_basename(&name));
         let tarball_url = format!("http://example.test/{name}/-/{tarball_name}");
-        let mut packument_manifest = manifest;
-        let manifest_object =
-            packument_manifest.as_object_mut().expect("fixture package.json is an object");
-        manifest_object
-            .insert("dist".to_string(), json!({ "tarball": tarball_url, "integrity": integrity }));
-        // Verdaccio's abbreviated metadata exposes `bundleDependencies` (no "d"),
-        // and that is the key pnpm reads, so mirror `bundledDependencies` onto it
-        // when only the longer spelling is present in the fixture manifest.
-        if let Some(bundled) = manifest_object.get("bundledDependencies").cloned() {
-            manifest_object.entry("bundleDependencies").or_insert(bundled);
-        }
+        let packument_manifest = with_dist(manifest, &tarball_url, &integrity);
         Self { name, version, packument_manifest, tarball_name, tarball }
     }
 }
@@ -356,6 +335,37 @@ fn fixture_manifests(root: &Path) -> Vec<PathBuf> {
                 && is_version_dir(path.parent())
         })
         .collect()
+}
+
+fn substituted_manifest_text(manifest_path: &Path, substitutions: &[(&str, &str)]) -> String {
+    substitutions.iter().fold(
+        fs::read_to_string(manifest_path).expect("read fixture package.json"),
+        |manifest, (from, to)| manifest.replace(from, to),
+    )
+}
+
+fn manifest_string(manifest: &Value, key: &str) -> String {
+    manifest
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("fixture package.json has string {key}"))
+        .to_string()
+}
+
+/// The manifest as a packument version entry: with its `dist` block, and
+/// with `bundleDependencies` mirrored from `bundledDependencies`.
+fn with_dist(mut packument_manifest: Value, tarball_url: &str, integrity: &str) -> Value {
+    let manifest_object =
+        packument_manifest.as_object_mut().expect("fixture package.json is an object");
+    manifest_object
+        .insert("dist".to_string(), json!({ "tarball": tarball_url, "integrity": integrity }));
+    // Verdaccio's abbreviated metadata exposes `bundleDependencies` (no "d"),
+    // and that is the key pnpm reads, so mirror `bundledDependencies` onto it
+    // when only the longer spelling is present in the fixture manifest.
+    if let Some(bundled) = manifest_object.get("bundledDependencies").cloned() {
+        manifest_object.entry("bundleDependencies").or_insert(bundled);
+    }
+    packument_manifest
 }
 
 // A `package.json` is a package manifest only when it sits directly inside a

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -7,6 +7,10 @@
 //!
 //! See <https://github.com/pnpm/pnpm> for the parent project.
 
+// The streamed resolve spawns the engine's whole resolve-and-fetch future
+// graph; proving it `Send` walks deeper than rustc's default limit.
+#![recursion_limit = "256"]
+
 pub mod oci_maintenance;
 
 pub use pnpr_auth::{

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -347,33 +347,8 @@ fn intern_config(
     let registry = if registry.ends_with('/') { registry } else { format!("{registry}/") };
     let overrides: Option<IndexMap<String, String>> =
         request.overrides.as_ref().and_then(|value| serde_json::from_value(value.clone()).ok());
-    // Key on a sorted view of `overrides`: serde_json preserves insertion order
-    // and `IndexMap` is insertion-ordered, so the same overrides sent with a
-    // different key order would otherwise hash to distinct cache keys and intern
-    // duplicate leaked configs — defeating dedup and burning the cap faster.
-    let overrides_key: Option<std::collections::BTreeMap<&str, &str>> = overrides
-        .as_ref()
-        .map(|overrides| overrides.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect());
-
     let resolver_settings = EffectiveResolverSettings::for_request(request);
-
-    let key = serde_json::json!({
-        "registry": registry,
-        "resolverSettings": resolver_settings,
-        "registries": &request.registries,
-        "overrides": overrides_key,
-        "patchedDependencies": &request.patched_dependencies,
-        "packageExtensions": &request.package_extensions,
-        "allowUnusedPatches": request.allow_unused_patches,
-        "resolutionMode": request.resolution_mode,
-        "minimumReleaseAge": request.minimum_release_age,
-        "minimumReleaseAgeExclude": request.minimum_release_age_exclude,
-        "minimumReleaseAgeIgnoreMissingTime": request.minimum_release_age_ignore_missing_time,
-        "trustPolicy": request.trust_policy,
-        "trustPolicyExclude": request.trust_policy_exclude,
-        "trustPolicyIgnoreAfter": request.trust_policy_ignore_after,
-    })
-    .to_string();
+    let key = config_cache_key(request, &registry, overrides.as_ref(), &resolver_settings);
     if key.len() > max_key_bytes {
         return None;
     }
@@ -429,6 +404,38 @@ fn intern_config(
     let config: &'static PacquetConfig = config.leak();
     configs.insert(key, config);
     Some(config)
+}
+
+/// Key on a sorted view of `overrides`: `serde_json` preserves insertion order
+/// and `IndexMap` is insertion-ordered, so the same overrides sent with a
+/// different key order would otherwise hash to distinct cache keys and intern
+/// duplicate leaked configs — defeating dedup and burning the cap faster.
+fn config_cache_key(
+    request: &ResolveRequest,
+    registry: &str,
+    overrides: Option<&IndexMap<String, String>>,
+    resolver_settings: &EffectiveResolverSettings,
+) -> String {
+    let overrides_key: Option<std::collections::BTreeMap<&str, &str>> = overrides
+        .map(|overrides| overrides.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect());
+
+    serde_json::json!({
+        "registry": registry,
+        "resolverSettings": resolver_settings,
+        "registries": &request.registries,
+        "overrides": overrides_key,
+        "patchedDependencies": &request.patched_dependencies,
+        "packageExtensions": &request.package_extensions,
+        "allowUnusedPatches": request.allow_unused_patches,
+        "resolutionMode": request.resolution_mode,
+        "minimumReleaseAge": request.minimum_release_age,
+        "minimumReleaseAgeExclude": request.minimum_release_age_exclude,
+        "minimumReleaseAgeIgnoreMissingTime": request.minimum_release_age_ignore_missing_time,
+        "trustPolicy": request.trust_policy,
+        "trustPolicyExclude": request.trust_policy_exclude,
+        "trustPolicyIgnoreAfter": request.trust_policy_ignore_after,
+    })
+    .to_string()
 }
 
 /// Whether `/-/pnpr/v0/resolve` resolves this ecosystem.
@@ -499,9 +506,6 @@ async fn handle_npm_resolve(runtime: &Resolver, identity: Identity, body: &[u8])
     let Some(config) = runtime.config_for(&request) else {
         return json_error(StatusCode::SERVICE_UNAVAILABLE, TOO_MANY_CONFIGS_MESSAGE);
     };
-    let package_version_guard =
-        runtime.osv_index.as_ref().map(|index| Arc::clone(index) as Arc<dyn PackageVersionGuard>);
-
     // Auth is selected by this server's route policy for the caller, not
     // forwarded from the client. Every metadata/tarball fetch the
     // resolve+verify performs records its route into `footprint`, which
@@ -554,29 +558,55 @@ async fn handle_npm_resolve(runtime: &Resolver, identity: Identity, body: &[u8])
         return response;
     }
 
-    // Streaming resolve. Run it in a detached task that pushes one
-    // `package` frame per resolved tarball into the channel via the
-    // observer, then a terminal `done` / `error` frame. The response
-    // body drains the channel as frames arrive.
+    stream_resolve_response(
+        runtime,
+        StreamedResolveInputs {
+            config,
+            request,
+            request_auth,
+            tarball_router,
+            footprint,
+            cache_key: resolution_cache_key,
+        },
+    )
+}
+
+/// What one streamed resolve carries out of the request handling.
+struct StreamedResolveInputs {
+    config: &'static PacquetConfig,
+    request: ResolveRequest,
+    request_auth: Arc<AuthHeaders>,
+    tarball_router: TarballRouter,
+    footprint: Arc<Mutex<Footprint>>,
+    cache_key: Option<String>,
+}
+
+/// Streaming resolve. Run it in a detached task that pushes one
+/// `package` frame per resolved tarball into the channel via the
+/// observer, then a terminal `done` / `error` frame. The response
+/// body drains the channel as frames arrive.
+fn stream_resolve_response(runtime: &Resolver, inputs: StreamedResolveInputs) -> Response {
+    let package_version_guard =
+        runtime.osv_index.as_ref().map(|index| Arc::clone(index) as Arc<dyn PackageVersionGuard>);
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
     let observer: Arc<dyn pnpm_package_manager::ResolutionObserver> = Arc::new(StreamObserver {
         tx: tx.clone(),
-        package_version_guard: package_version_guard.clone(),
-        tarball_router: tarball_router.clone(),
+        package_version_guard,
+        tarball_router: inputs.tarball_router.clone(),
     });
     tokio::spawn(stream_resolution(StreamedResolve {
-        config,
+        config: inputs.config,
         client: Arc::clone(&runtime.client),
-        request,
-        request_auth,
+        request: inputs.request,
+        request_auth: inputs.request_auth,
         observer,
-        tarball_router,
+        tarball_router: inputs.tarball_router,
         osv_index: runtime.osv_index.clone(),
         cache: Arc::clone(&runtime.resolution_cache),
         cache_ttl: runtime.resolution_cache_ttl,
-        cache_key: resolution_cache_key,
+        cache_key: inputs.cache_key,
         cache_secret: Arc::clone(&runtime.resolution_cache_secret),
-        footprint,
+        footprint: inputs.footprint,
         tx,
     }));
     ndjson_stream_response(rx)
@@ -883,17 +913,8 @@ async fn verify_input_lockfile(
         VerifyFailure::Internal(json_error(StatusCode::INTERNAL_SERVER_ERROR, &err.to_string()))
     })?;
 
-    // Whole-lockfile verdict cache: an O(1) hit when this exact lockfile
-    // already passed under a policy we still trust skips the whole fan-out
-    // (the dominant win for a shared pnpr — CI re-runs, a fleet building
-    // the same repo).
     let hash = hash_lockfile(lockfile);
-    if let Some(cache) = runtime.verdict_cache.as_ref()
-        && cache.is_verified(&hash, |policy| {
-            verifiers.iter().all(|verifier| verifier.can_trust_past_check(policy))
-                && runtime.osv_index.as_ref().is_none_or(|index| index.can_trust_policy(policy))
-        })
-    {
+    if past_verdict_trusted(runtime, &hash, &verifiers) {
         return Ok(None);
     }
 
@@ -917,6 +938,30 @@ async fn verify_input_lockfile(
         return Ok(Some(dist_stats));
     }
 
+    Err(VerifyFailure::Violations(render_violations(&violations, osv_violations)))
+}
+
+/// Whole-lockfile verdict cache: an O(1) hit when this exact lockfile
+/// already passed under a policy we still trust skips the whole fan-out
+/// (the dominant win for a shared pnpr — CI re-runs, a fleet building
+/// the same repo).
+fn past_verdict_trusted(
+    runtime: &Resolver,
+    hash: &str,
+    verifiers: &[Arc<dyn ResolutionVerifier>],
+) -> bool {
+    runtime.verdict_cache.as_ref().is_some_and(|cache| {
+        cache.is_verified(hash, |policy| {
+            verifiers.iter().all(|verifier| verifier.can_trust_past_check(policy))
+                && runtime.osv_index.as_ref().is_none_or(|index| index.can_trust_policy(policy))
+        })
+    })
+}
+
+fn render_violations(
+    violations: &[pnpm_resolving_resolver_base::ResolutionPolicyViolation],
+    osv_violations: Vec<serde_json::Value>,
+) -> Vec<serde_json::Value> {
     let mut rendered: Vec<serde_json::Value> = violations
         .iter()
         .map(|violation| {
@@ -929,7 +974,7 @@ async fn verify_input_lockfile(
         })
         .collect();
     rendered.extend(osv_violations);
-    Err(VerifyFailure::Violations(rendered))
+    rendered
 }
 
 /// Merge every active verifier's policy snapshot into one bag, the key

--- a/pnpr/crates/pnpr/src/resolver/resolve.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve.rs
@@ -6,11 +6,7 @@
 //! never populated with package contents — the client fetches every
 //! tarball itself.
 
-use std::{
-    collections::HashSet,
-    path::Path,
-    sync::{Arc, atomic::AtomicU8},
-};
+use std::{collections::HashSet, path::Path, sync::Arc};
 
 use dashmap::DashMap;
 use pnpm_catalogs_types::Catalogs;
@@ -86,28 +82,8 @@ pub async fn resolve(
     let Workspace { member_dirs, wrote_root } = write_importer_manifests(dir, &projects).await?;
     write_workspace_manifest(dir, &member_dirs).await?;
 
-    let manifest_path = dir.join("package.json");
-    let manifest = if wrote_root {
-        PackageManifest::from_path(manifest_path)
-            .map_err(|err| ResolveError::Manifest(err.to_string()))?
-    } else {
-        // Install needs an active manifest, but keeping this stand-in in
-        // memory prevents workspace discovery from inventing a `.` importer
-        // that the client did not request.
-        PackageManifest::from_value(
-            manifest_path,
-            serde_json::json!({ "name": "pnpr-resolve", "version": "0.0.0" }),
-        )
-    };
+    let manifest = root_manifest(dir, wrote_root)?;
 
-    // Seed resolution from the client's lockfile when present, matching
-    // pnpm's resolution-reuse: frozen → use it as-is (already verified
-    // by the caller before this point); non-frozen → reuse its pins for
-    // unchanged entries and resolve only what's new/changed
-    // (`preferFrozenLockfile` + `update: false`). With no lockfile it's a
-    // fresh resolve. `frozen_lockfile` is passed through unchanged so a
-    // `--frozen-lockfile` request with no lockfile surfaces pacquet's
-    // frozen-lockfile error rather than silently synthesizing one.
     let input_lockfile = request.lockfile.as_ref();
     let lockfile_path = dir.join(Lockfile::FILE_NAME);
     if let Some(lockfile) = input_lockfile {
@@ -115,14 +91,10 @@ pub async fn resolve(
             .save_to_path(&lockfile_path)
             .map_err(|err| ResolveError::Install(err.to_string()))?;
     }
-    let frozen_lockfile = request.frozen_lockfile;
 
     let resolved_packages: ResolvedPackages = DashMap::new();
-    let tarball_mem_cache: Arc<MemCache> = Arc::new(MemCache::default());
-    let _logged = AtomicU8::new(0);
-
     Install {
-        tarball_mem_cache,
+        tarball_mem_cache: Arc::new(MemCache::default()),
         resolved_packages: &resolved_packages,
         http_client: client,
         http_client_arc: Arc::clone(client),
@@ -136,7 +108,7 @@ pub async fn resolve(
             DependencyGroup::Dev,
             DependencyGroup::Optional,
         ],
-        frozen_lockfile,
+        frozen_lockfile: request.frozen_lockfile,
         // Default to reuse so unchanged entries keep their pins; an explicit
         // metadata refresh always re-resolves the pinned registry versions.
         prefer_frozen_lockfile: if request.update_patches || request.fix_lockfile {
@@ -193,6 +165,21 @@ pub async fn resolve(
         .ok_or(ResolveError::NoLockfile)?;
 
     Ok(lockfile)
+}
+
+/// Install needs an active manifest, but keeping this stand-in in
+/// memory prevents workspace discovery from inventing a `.` importer
+/// that the client did not request.
+fn root_manifest(dir: &Path, wrote_root: bool) -> Result<PackageManifest, ResolveError> {
+    let manifest_path = dir.join("package.json");
+    if wrote_root {
+        return PackageManifest::from_path(manifest_path)
+            .map_err(|err| ResolveError::Manifest(err.to_string()));
+    }
+    Ok(PackageManifest::from_value(
+        manifest_path,
+        serde_json::json!({ "name": "pnpr-resolve", "version": "0.0.0" }),
+    ))
 }
 
 /// Declare the workspace, but only when there are members: a lone root
@@ -301,22 +288,7 @@ pub fn fresh_frozen_input_lockfile(config: &Config, request: &ResolveRequest) ->
     {
         return None;
     }
-    if request.overrides.as_ref().is_some_and(|value| match value {
-        serde_json::Value::Object(map) => !map.is_empty(),
-        serde_json::Value::Null => false,
-        _ => true,
-    }) {
-        return None;
-    }
-    if config.package_extensions.as_ref().is_some_and(|extensions| !extensions.is_empty())
-        || config
-            .ignored_optional_dependencies
-            .as_ref()
-            .is_some_and(|patterns| !patterns.is_empty())
-        || config.patched_dependencies.as_ref().is_some_and(|map| !map.is_empty())
-        || config.patched_dependency_hashes_override.as_ref().is_some_and(|map| !map.is_empty())
-        || config.inject_workspace_packages
-    {
+    if request_has_overrides(request) || config_transforms_lockfile(config) {
         return None;
     }
 
@@ -380,6 +352,27 @@ pub fn fresh_frozen_input_lockfile(config: &Config, request: &ResolveRequest) ->
     satisfies_package_manifest(importer, &manifest, true, &|_: &str| false).ok()?;
 
     Some(lockfile.clone())
+}
+
+fn request_has_overrides(request: &ResolveRequest) -> bool {
+    request.overrides.as_ref().is_some_and(|value| match value {
+        serde_json::Value::Object(map) => !map.is_empty(),
+        serde_json::Value::Null => false,
+        _ => true,
+    })
+}
+
+/// Whether the config rewrites the dependency graph in a way a lockfile
+/// cannot be checked against without a resolve.
+fn config_transforms_lockfile(config: &Config) -> bool {
+    config.package_extensions.as_ref().is_some_and(|extensions| !extensions.is_empty())
+        || config
+            .ignored_optional_dependencies
+            .as_ref()
+            .is_some_and(|patterns| !patterns.is_empty())
+        || config.patched_dependencies.as_ref().is_some_and(|map| !map.is_empty())
+        || config.patched_dependency_hashes_override.as_ref().is_some_and(|map| !map.is_empty())
+        || config.inject_workspace_packages
 }
 
 /// Validate a client-supplied importer dir before joining it onto the

--- a/pnpr/crates/pnpr/src/resolver/wire.rs
+++ b/pnpr/crates/pnpr/src/resolver/wire.rs
@@ -7,8 +7,8 @@ use axum::{
 };
 use pnpm_config::Config as PacquetConfig;
 use pnpm_lockfile::{
-    Lockfile, LockfileResolution, TarballResolution, TarballRevision, is_git_hosted_tarball_url,
-    pick_registry_for_package,
+    Lockfile, LockfileResolution, PackageKey, PackageMetadata, TarballResolution, TarballRevision,
+    is_git_hosted_tarball_url, pick_registry_for_package,
 };
 use pnpm_package_manager::{ResolvedPackageHint, tarball_url_and_integrity};
 use pnpm_resolving_npm_resolver::ObservedDistStats;
@@ -287,53 +287,75 @@ pub(super) fn frozen_package_frames(
     let mut seen_urls = std::collections::HashSet::new();
     let mut frames = Vec::new();
     for (package_key, snapshot) in packages {
-        if !matches!(
-            snapshot.resolution,
-            LockfileResolution::Registry(_) | LockfileResolution::Tarball(_),
+        if let Some(line) = frozen_package_frame(
+            FrozenFrameInputs { config, router, dist_stats, package_key, snapshot },
+            &mut seen_urls,
         ) {
-            continue;
-        }
-        // The frame carries the integrity the client prefetches against;
-        // an entry that pins none has no frame to announce.
-        let Ok((tarball_url, Some(integrity))) =
-            tarball_url_and_integrity(&snapshot.resolution, package_key, config)
-        else {
-            continue;
-        };
-        let name = package_key.name.to_string();
-        let version = package_key.suffix.version().to_string();
-        let upstream_tarball_url = tarball_url;
-        let tarball_url = router.route_url(&name, &version, &upstream_tarball_url);
-        if !seen_urls.insert(tarball_url.clone()) {
-            continue;
-        }
-        let id = format!("{name}@{version}");
-        let integrity = integrity.to_string();
-        let revision =
-            pnpr_served_revision(&snapshot.resolution, &tarball_url, &upstream_tarball_url);
-        let stats = dist_stats.get(&(name.clone(), version.clone())).map(|entry| *entry.value());
-        let frame = package_frame(
-            router,
-            &ResolvedPackageHint {
-                id: &id,
-                name: &name,
-                version: &version,
-                integrity: &integrity,
-                tarball_url: &tarball_url,
-                unpacked_size: stats.and_then(|stats| stats.unpacked_size),
-                file_count: stats.and_then(|stats| stats.file_count),
-                revision,
-                // The URL is already routed (canonical → endpoint above), so
-                // re-routing by registry would be redundant; route_url is a
-                // no-op on an already-routed URL.
-                from_registry: false,
-            },
-        );
-        if let Ok(line) = ndjson_line(&frame) {
             frames.push(line);
         }
     }
     frames
+}
+
+#[derive(Clone, Copy)]
+struct FrozenFrameInputs<'a> {
+    config: &'a PacquetConfig,
+    router: &'a TarballRouter,
+    dist_stats: &'a ObservedDistStats,
+    package_key: &'a PackageKey,
+    snapshot: &'a PackageMetadata,
+}
+
+/// The `package` frame for one frozen lockfile entry, or `None` when the
+/// entry is not a registry or tarball package or its URL was announced
+/// already.
+fn frozen_package_frame(
+    inputs: FrozenFrameInputs<'_>,
+    seen_urls: &mut std::collections::HashSet<String>,
+) -> Option<Vec<u8>> {
+    if !matches!(
+        inputs.snapshot.resolution,
+        LockfileResolution::Registry(_) | LockfileResolution::Tarball(_),
+    ) {
+        return None;
+    }
+    // The frame carries the integrity the client prefetches against;
+    // an entry that pins none has no frame to announce.
+    let Ok((tarball_url, Some(integrity))) =
+        tarball_url_and_integrity(&inputs.snapshot.resolution, inputs.package_key, inputs.config)
+    else {
+        return None;
+    };
+    let name = inputs.package_key.name.to_string();
+    let version = inputs.package_key.suffix.version().to_string();
+    let upstream_tarball_url = tarball_url;
+    let tarball_url = inputs.router.route_url(&name, &version, &upstream_tarball_url);
+    if !seen_urls.insert(tarball_url.clone()) {
+        return None;
+    }
+    let id = format!("{name}@{version}");
+    let integrity = integrity.to_string();
+    let revision =
+        pnpr_served_revision(&inputs.snapshot.resolution, &tarball_url, &upstream_tarball_url);
+    let stats = inputs.dist_stats.get(&(name.clone(), version.clone())).map(|entry| *entry.value());
+    let frame = package_frame(
+        inputs.router,
+        &ResolvedPackageHint {
+            id: &id,
+            name: &name,
+            version: &version,
+            integrity: &integrity,
+            tarball_url: &tarball_url,
+            unpacked_size: stats.and_then(|stats| stats.unpacked_size),
+            file_count: stats.and_then(|stats| stats.file_count),
+            revision,
+            // The URL is already routed (canonical → endpoint above), so
+            // re-routing by registry would be redundant; route_url is a
+            // no-op on an already-routed URL.
+            from_registry: false,
+        },
+    );
+    ndjson_line(&frame).ok()
 }
 
 /// The tarball revision a frame announces. Only a URL still pointing at the

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -598,7 +598,7 @@ async fn serve_registry_version_manifest(
     tarball_base: &str,
 ) -> Response {
     let name = match CanonicalPackageName::parse(raw_name, pnpr_package_name::Ecosystem::Npm) {
-        Ok(n) => n,
+        Ok(name) => name,
         Err(err) => return err.into_response(),
     };
     let resolved_source = resolve_registry_source(state, registry, name.as_str());
@@ -608,14 +608,11 @@ async fn serve_registry_version_manifest(
         Err(err) => return err.into_response(),
     };
     let packument: Value = match serde_json::from_slice(&bytes) {
-        Ok(v) => v,
+        Ok(packument) => packument,
         Err(err) => return RegistryError::Json(err).into_response(),
     };
-    if let Some(osv_index) = state.inner.osv_index.as_ref() {
-        let resolved = resolve_version_or_tag(&packument, version_or_tag);
-        if is_osv_vulnerable_packument_version(&packument, name.as_str(), resolved, osv_index) {
-            return not_found();
-        }
+    if osv_hides_version(state, &packument, name.as_str(), version_or_tag) {
+        return not_found();
     }
     let revision_registry = match &resolved_source {
         RegistrySource::Upstream(source) => revision_source_registry(state, registry, source),
@@ -638,6 +635,18 @@ async fn serve_registry_version_manifest(
         Ok(body) => packument_bytes_response(body, "application/json", None),
         Err(err) => RegistryError::Json(err).into_response(),
     }
+}
+
+fn osv_hides_version(
+    state: &AppState,
+    packument: &Value,
+    package_name: &str,
+    version_or_tag: &str,
+) -> bool {
+    state.inner.osv_index.as_ref().is_some_and(|osv_index| {
+        let resolved = resolve_version_or_tag(packument, version_or_tag);
+        is_osv_vulnerable_packument_version(packument, package_name, resolved, osv_index)
+    })
 }
 
 /// Serve a single version's manifest (`GET <base>/<pkg>/<version-or-tag>`)
@@ -1017,7 +1026,7 @@ async fn serve_tarball_via_upstream(
     filename: &str,
 ) -> Response {
     let name = match CanonicalPackageName::parse(raw_name, pnpr_package_name::Ecosystem::Npm) {
-        Ok(n) => n,
+        Ok(name) => name,
         Err(err) => return err.into_response(),
     };
     let (filename, parsed_version) = match tarball_cache_name(&name, filename) {
@@ -2534,22 +2543,13 @@ async fn serve_search(
     registry: Option<&str>,
     query_string: &str,
 ) -> Response {
-    let result = |objects: Vec<Value>, total: usize| {
-        let body = json!({ "objects": objects, "total": total, "time": now_iso() });
-        let bytes = serde_json::to_vec(&body).expect("search response serializes");
-        Response::builder()
-            .status(StatusCode::OK)
-            .header(header::CONTENT_TYPE, "application/json")
-            .body(Body::from(bytes))
-            .expect("static-shape response always builds")
-    };
     let Some(params) = pnpr_search::parse_params(query_string, 20) else {
-        return result(Vec::new(), 0);
+        return search_response(&[], 0);
     };
     let Some(registry) =
         registry.map(str::to_string).or_else(|| default_registry_target(state, Ecosystem::Npm))
     else {
-        return result(Vec::new(), 0);
+        return search_response(&[], 0);
     };
     let browse = pnpr_search::browse_requested(query_string);
     let mut page = SearchPage::new(params.from, params.size);
@@ -2582,7 +2582,17 @@ async fn serve_search(
         }
     }
     let total = page.total();
-    result(page.objects, total)
+    search_response(&page.objects, total)
+}
+
+fn search_response(objects: &[Value], total: usize) -> Response {
+    let body = json!({ "objects": objects, "total": total, "time": now_iso() });
+    let bytes = serde_json::to_vec(&body).expect("search response serializes");
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(bytes))
+        .expect("static-shape response always builds")
 }
 
 /// One hosted source of a search.

--- a/pnpr/crates/pnpr/src/server/cargo.rs
+++ b/pnpr/crates/pnpr/src/server/cargo.rs
@@ -110,23 +110,36 @@ async fn get_search(
         .map_or(0, |page| page.saturating_sub(1).saturating_mul(size));
 
     let mut page = SearchPage::new(from, size);
-    for source in discovery_sources(&state, &target, ECOSYSTEM) {
-        let DiscoverySource::Hosted(source) = source else {
-            continue;
-        };
-        let hosted =
-            hosted_search_names(&state, &identity, &target, &source, ECOSYSTEM, &text).await;
-        let (storage, names) = match hosted {
-            Ok(Some(hosted)) => hosted,
-            Ok(None) => continue,
-            Err(err) => return error_response(err),
-        };
-        add_crates_to_page(&mut page, &storage, names).await;
+    if let Err(err) = collect_hosted_crates(&state, &identity, &target, &text, &mut page).await {
+        return error_response(err);
     }
     let total = page.total();
     // Results are filtered per caller (registry access plus per-package
     // ACL), so they must never land in a shared HTTP cache.
     private_no_cache(respond(page.objects, total))
+}
+
+/// Add every hosted registry's matching crates to the page.
+async fn collect_hosted_crates(
+    state: &AppState,
+    identity: &Identity,
+    target: &str,
+    text: &pnpr_search::SearchText,
+    page: &mut SearchPage<SearchCrate>,
+) -> Result<(), RegistryError> {
+    for source in discovery_sources(state, target, ECOSYSTEM) {
+        let DiscoverySource::Hosted(source) = source else {
+            continue;
+        };
+        let hosted = hosted_search_names(state, identity, target, &source, ECOSYSTEM, text).await;
+        let (storage, names) = match hosted {
+            Ok(Some(hosted)) => hosted,
+            Ok(None) => continue,
+            Err(err) => return Err(err),
+        };
+        add_crates_to_page(page, &storage, names).await;
+    }
+    Ok(())
 }
 
 /// `GET api/v1/crates?q=<query>&per_page=<n>&page=<n>` — `cargo search`.
@@ -361,28 +374,7 @@ async fn download_via_upstream(
             reason: format!("index entry {name}@{version} has no SHA-256 checksum"),
         });
     };
-    let config_key = CanonicalPackageName::parse(INDEX_CONFIG_KEY, Ecosystem::Npm)
-        .expect("static key is a safe segment");
-    let request = UpstreamDocument {
-        name: &config_key,
-        relative_path: INDEX_CONFIG_KEY,
-        accept: None,
-        limit: INDEX_CONFIG_LIMIT,
-    };
-    let config = load_upstream_document(state, upstream, &namespace, request, |document| {
-        IndexConfig::parse(&document.bytes).map(|_| document.bytes).map_err(|err| {
-            RegistryError::UpstreamResponse { url: document.url, reason: err.to_string() }
-        })
-    })
-    .await
-    .and_then(|bytes| {
-        let bytes = bytes.ok_or_else(|| RegistryError::UpstreamResponse {
-            url: INDEX_CONFIG_KEY.to_string(),
-            reason: "the upstream index has no config.json".to_string(),
-        })?;
-        IndexConfig::parse(&bytes).map_err(RegistryError::Json)
-    });
-    let config = match config {
+    let config = match upstream_index_config(state, upstream, &namespace).await {
         Ok(config) => config,
         Err(err) => return error_response(err),
     };
@@ -395,6 +387,33 @@ async fn download_via_upstream(
     }
     let filename = crate_filename(&entry.name, &entry.vers);
     serve_upstream_artifact(state, upstream, &namespace, key, &filename, &url, &integrity).await
+}
+
+/// The upstream sparse index's `config.json`, through the cache.
+async fn upstream_index_config(
+    state: &AppState,
+    upstream: &pnpr_upstream::Upstream,
+    namespace: &str,
+) -> Result<IndexConfig, RegistryError> {
+    let config_key = CanonicalPackageName::parse(INDEX_CONFIG_KEY, Ecosystem::Npm)
+        .expect("static key is a safe segment");
+    let request = UpstreamDocument {
+        name: &config_key,
+        relative_path: INDEX_CONFIG_KEY,
+        accept: None,
+        limit: INDEX_CONFIG_LIMIT,
+    };
+    let bytes = load_upstream_document(state, upstream, namespace, request, |document| {
+        IndexConfig::parse(&document.bytes).map(|_| document.bytes).map_err(|err| {
+            RegistryError::UpstreamResponse { url: document.url, reason: err.to_string() }
+        })
+    })
+    .await?
+    .ok_or_else(|| RegistryError::UpstreamResponse {
+        url: INDEX_CONFIG_KEY.to_string(),
+        reason: "the upstream index has no config.json".to_string(),
+    })?;
+    IndexConfig::parse(&bytes).map_err(RegistryError::Json)
 }
 
 /// `PUT api/v1/crates/new` — `cargo publish`.

--- a/pnpr/crates/pnpr/src/server/oci.rs
+++ b/pnpr/crates/pnpr/src/server/oci.rs
@@ -281,14 +281,7 @@ impl Request {
     ) -> Result<Option<Response>, RegistryError> {
         let Ok(digest) = Digest::parse(mount) else { return Ok(None) };
         let Ok((source_key, source)) = self.hosted_source(from) else { return Ok(None) };
-        if let Some(raw) = self
-            .headers
-            .get(header::AUTHORIZATION)
-            .and_then(|value| value.to_str().ok())
-            .and_then(super::authentication::token_credentials)
-            && let Some(claims) = tokens::decode(&self.state, &raw)?
-            && !claims.allows(source_key.as_str(), "pull")
-        {
+        if self.token_forbids_pull(source_key.as_str())? {
             return Ok(None);
         }
         let source_org = match hosted_read_namespace(
@@ -334,32 +327,34 @@ impl Request {
         else {
             return error(ErrorCode::DigestInvalid, "last must be a supported digest");
         };
-        let (key, source) = match self.hosted_source(name) {
-            Ok(found) => found,
+        let repo = match self.hosted_repo(name) {
+            Ok(repo) => repo,
             Err(refusal) => return refusal.respond(),
         };
-        let org = match hosted_read_namespace(&self.state, &self.identity, &source, key.as_str()) {
-            Ok(org) => org,
+        let document = match read_hosted_document::<ImageDocument>(
+            &self.state,
+            &self.identity,
+            &repo.source,
+            &repo.key,
+        )
+        .await
+        {
+            Ok(document) => document.unwrap_or_else(|| ImageDocument::new(repo.key.as_str())),
             Err(err) => return registry_error(err),
         };
-        let storage = self.state.inner.storage.for_hosted(&org);
-        let document =
-            match read_hosted_document::<ImageDocument>(&self.state, &self.identity, &source, &key)
-                .await
-            {
-                Ok(document) => document.unwrap_or_else(|| ImageDocument::new(key.as_str())),
-                Err(err) => return registry_error(err),
-            };
         let filter = ReferrerFilter::new(digest, &self.query);
-        let page = match self.scan_referrers(&storage, &key, &document, &filter, last).await {
-            Ok(page) => page,
-            Err(response) => return response,
-        };
-        if let Err(response) = self.record_referrer_index(&storage, &key, &page.additions).await {
+        let page =
+            match self.scan_referrers(&repo.storage, &repo.key, &document, &filter, last).await {
+                Ok(page) => page,
+                Err(response) => return response,
+            };
+        if let Err(response) =
+            self.record_referrer_index(&repo.storage, &repo.key, &page.additions).await
+        {
             return response;
         }
-        let response = self.referrers_page_response(&key, &filter, &page);
-        self.caller_scoped(Some(key.as_str()), response)
+        let response = self.referrers_page_response(&repo.key, &filter, &page);
+        self.caller_scoped(Some(repo.key.as_str()), response)
     }
 
     /// Walk the manifest index from `last` onwards, reading only the manifests
@@ -523,26 +518,10 @@ impl Request {
         let last = query_param(Some(&self.query), "last");
         let mut repositories = Vec::new();
         for source in hosted_sources(&self.state, &target, ECOSYSTEM) {
-            let Some(hosted) = self.state.inner.config.hosted.get(&source) else { continue };
-            let storage = self.state.inner.storage.for_hosted(&hosted.org);
-            let names = match storage.hosted_package_names().await {
-                Ok(names) => names,
+            match self.readable_repositories(&target, &source, last.as_deref()).await {
+                Ok(names) => repositories.extend(names),
                 Err(err) => return registry_error(err),
-            };
-            // A listing may only name what this caller could have fetched.
-            repositories.extend(names.into_iter().filter(|name| {
-                last.as_ref().is_none_or(|last| name > last)
-                    && CanonicalPackageName::parse(name, ECOSYSTEM).is_ok()
-                    && matches!(resolve_ecosystem_source(&self.state, &target, ECOSYSTEM, name), RegistrySource::Hosted(ref resolved) if resolved == &source)
-                    && authorize(
-                        &self.state,
-                        &self.identity,
-                        &RegistrySource::Hosted(source.clone()),
-                        name,
-                        Action::Access,
-                    )
-                    .is_ok()
-            }));
+            }
         }
         repositories.sort();
         repositories.dedup();
@@ -612,31 +591,30 @@ impl Request {
         if let Some((key, source)) = self.upstream_source(name) {
             return self.proxy_manifest(&key, &source, reference).await;
         }
-        let (key, source) = match self.hosted_source(name) {
-            Ok(found) => found,
+        let repo = match self.hosted_repo(name) {
+            Ok(repo) => repo,
             Err(refusal) => return refusal.respond(),
         };
-        let document =
-            match read_hosted_document::<ImageDocument>(&self.state, &self.identity, &source, &key)
-                .await
-            {
-                Ok(Some(document)) => document,
-                Ok(None) => return unknown_repository(name).respond(),
-                Err(err) => return registry_error(err),
-            };
+        let document = match read_hosted_document::<ImageDocument>(
+            &self.state,
+            &self.identity,
+            &repo.source,
+            &repo.key,
+        )
+        .await
+        {
+            Ok(Some(document)) => document,
+            Ok(None) => return unknown_repository(name).respond(),
+            Err(err) => return registry_error(err),
+        };
         let Some(entry) = document.resolve(reference).cloned() else {
             return error(ErrorCode::ManifestUnknown, "no such manifest or tag");
         };
-        let org = match hosted_read_namespace(&self.state, &self.identity, &source, key.as_str()) {
-            Ok(org) => org,
-            Err(err) => return registry_error(err),
-        };
-        let storage = self.state.inner.storage.for_hosted(&org);
         // A manifest is small enough to answer from memory, and the response
         // carries its digest and media type either way.
         let bytes = match read_manifest_bytes(
-            &storage,
-            &key,
+            &repo.storage,
+            &repo.key,
             &entry.digest.blob_filename(),
             self.state.inner.config.oci.max_manifest_bytes,
         )
@@ -657,27 +635,11 @@ impl Request {
             .header(DOCKER_CONTENT_DIGEST, entry.digest.to_string())
             .body(body)
             .unwrap_or_else(|_| server_error());
-        self.caller_scoped(Some(key.as_str()), response)
+        self.caller_scoped(Some(repo.key.as_str()), response)
     }
 
     async fn write_manifest(&self, name: &str, reference: &str, body: Body) -> Response {
-        let (key, org) = match self.publish_target(name) {
-            Ok(target) => target,
-            Err(refusal) => return refusal.respond(),
-        };
-        let content_type =
-            self.headers.get(header::CONTENT_TYPE).and_then(|value| value.to_str().ok());
-        let bytes = match collect_body(body, self.state.inner.config.oci.max_manifest_bytes).await {
-            Ok(bytes) => bytes,
-            Err(refusal) => return refusal.respond(),
-        };
-        let publication = match OciPublication::new(
-            (key, org),
-            reference.to_string(),
-            bytes,
-            content_type,
-            self.state.inner.config.oci.max_manifest_bytes,
-        ) {
+        let publication = match self.manifest_publication(name, reference, body).await {
             Ok(publication) => publication,
             Err(refusal) => return refusal.respond(),
         };
@@ -706,27 +668,23 @@ impl Request {
     }
 
     async fn delete_manifest(&self, name: &str, reference: &str) -> Response {
-        let (key, source) = match self.hosted_source(name) {
-            Ok(found) => found,
+        let repo = match self.hosted_repo(name) {
+            Ok(repo) => repo,
             Err(refusal) => return refusal.respond(),
-        };
-        let org = match hosted_read_namespace(&self.state, &self.identity, &source, key.as_str()) {
-            Ok(org) => org,
-            Err(err) => return registry_error(err),
         };
         if let Err(err) = authorize(
             &self.state,
             &self.identity,
-            &RegistrySource::Hosted(source.clone()),
-            key.as_str(),
+            &RegistrySource::Hosted(repo.source.clone()),
+            repo.key.as_str(),
             Action::Unpublish,
         ) {
             return registry_error(err);
         }
-        let storage = self.state.inner.storage.for_hosted(&org);
-        let _guard = self.state.inner.package_locks.lock(key.as_str()).await;
-        let outcome = storage
-            .update_hosted_document_with_retry(&key, DOCUMENT_WRITE_RETRIES, |existing| {
+        let _guard = self.state.inner.package_locks.lock(repo.key.as_str()).await;
+        let outcome = repo
+            .storage
+            .update_hosted_document_with_retry(&repo.key, DOCUMENT_WRITE_RETRIES, |existing| {
                 let Some(bytes) = existing else { return Ok(None) };
                 let mut document = ImageDocument::parse(bytes).map_err(RegistryError::Json)?;
                 let removed = match Digest::parse(reference) {
@@ -758,31 +716,29 @@ impl Request {
         if let Some((key, source)) = self.upstream_source(name) {
             return self.proxy_blob(&key, &source, digest).await;
         }
-        let (key, source) = match self.hosted_source(name) {
-            Ok(found) => found,
+        let repo = match self.hosted_repo(name) {
+            Ok(repo) => repo,
             Err(refusal) => return refusal.respond(),
         };
-        let org = match hosted_read_namespace(&self.state, &self.identity, &source, key.as_str()) {
-            Ok(org) => org,
-            Err(err) => return registry_error(err),
-        };
-        let storage = self.state.inner.storage.for_hosted(&org);
         let etag = format!(r#""{digest}""#);
         if let Some(range) = self.requested_download_range(&etag) {
-            let ranged =
-                storage.open_hosted_blob_range(&key, &digest.blob_filename(), &range).await;
+            let ranged = repo
+                .storage
+                .open_hosted_blob_range(&repo.key, &digest.blob_filename(), &range)
+                .await;
             let response = match ranged {
                 Ok(Some(blob)) => ranged_blob_response(blob, digest, &etag),
                 Ok(None) => return error(ErrorCode::BlobUnknown, "no such blob"),
                 Err(err) => return registry_error(err),
             };
-            return self.caller_scoped(Some(key.as_str()), response);
+            return self.caller_scoped(Some(repo.key.as_str()), response);
         }
-        let (body, size) = match storage.open_hosted_blob(&key, &digest.blob_filename()).await {
-            Ok(Some(blob)) => blob,
-            Ok(None) => return error(ErrorCode::BlobUnknown, "no such blob"),
-            Err(err) => return registry_error(err),
-        };
+        let (body, size) =
+            match repo.storage.open_hosted_blob(&repo.key, &digest.blob_filename()).await {
+                Ok(Some(blob)) => blob,
+                Ok(None) => return error(ErrorCode::BlobUnknown, "no such blob"),
+                Err(err) => return registry_error(err),
+            };
         let mut response = Response::builder()
             .status(StatusCode::OK)
             .header(header::ACCEPT_RANGES, "bytes")
@@ -794,7 +750,7 @@ impl Request {
         }
         let body = if self.method == Method::HEAD { Body::empty() } else { body };
         let response = response.body(body).unwrap_or_else(|_| server_error());
-        self.caller_scoped(Some(key.as_str()), response)
+        self.caller_scoped(Some(repo.key.as_str()), response)
     }
 
     /// The byte range a `GET` asks for, when it asks for exactly one and its
@@ -1022,6 +978,81 @@ impl Request {
     /// allowed to publish it.
     fn publish_target(&self, name: &str) -> Result<(CanonicalPackageName, String), Refusal> {
         authorize_publication(&self.state, &self.identity, self.registry.as_deref(), name)
+    }
+
+    /// The hosted repository `name` addresses, with the storage this caller
+    /// may read it from.
+    fn hosted_repo(&self, name: &str) -> Result<HostedRepo, Refusal> {
+        let (key, source) = self.hosted_source(name)?;
+        let org = hosted_read_namespace(&self.state, &self.identity, &source, key.as_str())
+            .map_err(Refusal::from)?;
+        let storage = self.state.inner.storage.for_hosted(&org);
+        Ok(HostedRepo { key, source, storage })
+    }
+
+    /// Whether a bearer token on the request denies pulling `source_key`.
+    fn token_forbids_pull(&self, source_key: &str) -> Result<bool, RegistryError> {
+        let Some(raw) = self
+            .headers
+            .get(header::AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .and_then(super::authentication::token_credentials)
+        else {
+            return Ok(false);
+        };
+        Ok(tokens::decode(&self.state, &raw)?
+            .is_some_and(|claims| !claims.allows(source_key, "pull")))
+    }
+
+    /// The repositories of one hosted registry this caller may list, after
+    /// `last`.
+    async fn readable_repositories(
+        &self,
+        target: &str,
+        source: &str,
+        last: Option<&str>,
+    ) -> Result<Vec<String>, RegistryError> {
+        let Some(hosted) = self.state.inner.config.hosted.get(source) else {
+            return Ok(Vec::new());
+        };
+        let storage = self.state.inner.storage.for_hosted(&hosted.org);
+        let names = storage.hosted_package_names().await?;
+        // A listing may only name what this caller could have fetched.
+        Ok(names
+            .into_iter()
+            .filter(|name| {
+            last.is_none_or(|last| name.as_str() > last)
+                && CanonicalPackageName::parse(name, ECOSYSTEM).is_ok()
+                && matches!(resolve_ecosystem_source(&self.state, target, ECOSYSTEM, name), RegistrySource::Hosted(ref resolved) if resolved == source)
+                && authorize(
+                    &self.state,
+                    &self.identity,
+                    &RegistrySource::Hosted(source.to_string()),
+                    name,
+                    Action::Access,
+                )
+                .is_ok()
+        })
+            .collect())
+    }
+
+    async fn manifest_publication(
+        &self,
+        name: &str,
+        reference: &str,
+        body: Body,
+    ) -> Result<OciPublication, Refusal> {
+        let (key, org) = self.publish_target(name)?;
+        let content_type =
+            self.headers.get(header::CONTENT_TYPE).and_then(|value| value.to_str().ok());
+        let bytes = collect_body(body, self.state.inner.config.oci.max_manifest_bytes).await?;
+        OciPublication::new(
+            (key, org),
+            reference.to_string(),
+            bytes,
+            content_type,
+            self.state.inner.config.oci.max_manifest_bytes,
+        )
     }
 }
 
@@ -1325,6 +1356,13 @@ struct TagList<'listing> {
 /// The status is carried rather than re-derived from the code, because a
 /// `RegistryError` has already chosen one, and deriving it back from the spec
 /// code would answer `405` for every error that has no code of its own.
+/// A hosted repository and the storage it is read from.
+struct HostedRepo {
+    key: CanonicalPackageName,
+    source: String,
+    storage: Storage,
+}
+
 pub(super) struct Refusal {
     status: StatusCode,
     code: ErrorCode,

--- a/pnpr/crates/pnpr/src/server/oci/proxy.rs
+++ b/pnpr/crates/pnpr/src/server/oci/proxy.rs
@@ -109,55 +109,63 @@ impl Request {
             Ok(found) => found,
             Err(err) => return registry_error(err),
         };
-        let namespace = format!("{namespace}-oci-blobs");
-        let filename = digest.blob_filename();
-        let storage = &self.state.inner.storage;
-        let result = async {
-            if upstream.caches()
-                && let Some((file, len)) =
-                    storage.open_upstream_blob(&namespace, key, &filename).await?
-            {
-                return Ok(tarball_response(
-                    if self.method == Method::HEAD {
-                        Body::empty()
-                    } else {
-                        streaming::stream_file(file)
-                    },
-                    Some(len),
-                ));
-            }
-            if self.method == Method::HEAD {
-                return head_proxy_blob(upstream, key, digest).await;
-            }
-            let fetched = upstream
-                .fetch_oci(key.as_str(), &format!("blobs/{digest}"), "application/octet-stream")
-                .await?;
-            let response = match fetched {
-                FetchOutcome::NotFound => {
-                    return Ok(error(ErrorCode::BlobUnknown, "upstream blob does not exist"));
-                }
-                FetchOutcome::Ok(response) => response,
-            };
-            let write = storage.open_upstream_blob_tmp(&namespace, key, &filename).await?;
-            let integrity = sha256_integrity(digest.hex()).expect("validated SHA-256 digest");
-            let limit = self.state.inner.config.oci.max_blob_bytes;
-            if upstream.caches() {
-                let body = streaming::stream_verified_to_cache(response, write, &integrity, limit)
-                    .map_err(|err| tarball_stream_error(err, key, &filename))?;
-                return Ok::<_, RegistryError>(tarball_response(body, None));
-            }
-            let (file, len, path) =
-                streaming::download_verified_to_temp(response, write, &integrity, limit)
-                    .await
-                    .map_err(|err| tarball_stream_error(err, key, &filename))?;
-            Ok(tarball_response(streaming::stream_file_and_remove(file, path), Some(len)))
-        }
-        .await;
+        let result =
+            self.proxied_blob(upstream, &format!("{namespace}-oci-blobs"), key, digest).await;
         let mut response = result.unwrap_or_else(IntoResponse::into_response);
         if response.status().is_success() {
             super::insert_header(&mut response, DOCKER_CONTENT_DIGEST, &digest.to_string());
         }
         self.caller_scoped(Some(key.as_str()), api_version(response))
+    }
+
+    /// The blob from the upstream's cache, or fetched and (for a caching
+    /// upstream) stored on the way through.
+    async fn proxied_blob(
+        &self,
+        upstream: &pnpr_upstream::Upstream,
+        namespace: &str,
+        key: &CanonicalPackageName,
+        digest: &Digest,
+    ) -> Result<Response, RegistryError> {
+        let filename = digest.blob_filename();
+        let storage = &self.state.inner.storage;
+        if upstream.caches()
+            && let Some((file, len)) = storage.open_upstream_blob(namespace, key, &filename).await?
+        {
+            return Ok(tarball_response(
+                if self.method == Method::HEAD {
+                    Body::empty()
+                } else {
+                    streaming::stream_file(file)
+                },
+                Some(len),
+            ));
+        }
+        if self.method == Method::HEAD {
+            return head_proxy_blob(upstream, key, digest).await;
+        }
+        let fetched = upstream
+            .fetch_oci(key.as_str(), &format!("blobs/{digest}"), "application/octet-stream")
+            .await?;
+        let response = match fetched {
+            FetchOutcome::NotFound => {
+                return Ok(error(ErrorCode::BlobUnknown, "upstream blob does not exist"));
+            }
+            FetchOutcome::Ok(response) => response,
+        };
+        let write = storage.open_upstream_blob_tmp(namespace, key, &filename).await?;
+        let integrity = sha256_integrity(digest.hex()).expect("validated SHA-256 digest");
+        let limit = self.state.inner.config.oci.max_blob_bytes;
+        if upstream.caches() {
+            let body = streaming::stream_verified_to_cache(response, write, &integrity, limit)
+                .map_err(|err| tarball_stream_error(err, key, &filename))?;
+            return Ok(tarball_response(body, None));
+        }
+        let (file, len, path) =
+            streaming::download_verified_to_temp(response, write, &integrity, limit)
+                .await
+                .map_err(|err| tarball_stream_error(err, key, &filename))?;
+        Ok(tarball_response(streaming::stream_file_and_remove(file, path), Some(len)))
     }
 }
 

--- a/pnpr/crates/pnpr/src/server/oidc.rs
+++ b/pnpr/crates/pnpr/src/server/oidc.rs
@@ -53,17 +53,7 @@ pub(super) async fn callback(
         );
     }
     let cookie_name = format!("__Host-pnpr-oidc-{}", query.state);
-    let mut cookies = headers
-        .get_all(header::COOKIE)
-        .iter()
-        .filter_map(|value| value.to_str().ok())
-        .flat_map(|value| value.split(';'))
-        .filter_map(|cookie| cookie.trim().split_once('='))
-        .filter(|(name, _)| *name == cookie_name);
-    let secret = cookies.next().map(|(_, value)| value);
-    let response = if let Some(secret) = secret
-        && cookies.next().is_none()
-    {
+    let response = if let Some(secret) = browser_secret(&headers, &cookie_name) {
         match state
             .inner
             .oidc
@@ -90,6 +80,19 @@ pub(super) async fn callback(
         response.headers_mut().insert(header::SET_COOKIE, cookie);
     }
     response
+}
+
+/// The login cookie's value, when exactly one cookie carries the name.
+fn browser_secret<'h>(headers: &'h HeaderMap, cookie_name: &str) -> Option<&'h str> {
+    let mut cookies = headers
+        .get_all(header::COOKIE)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(|value| value.split(';'))
+        .filter_map(|cookie| cookie.trim().split_once('='))
+        .filter(|(name, _)| *name == cookie_name);
+    let secret = cookies.next().map(|(_, value)| value)?;
+    cookies.next().is_none().then_some(secret)
 }
 
 fn protect(response: Response) -> Response {

--- a/pnpr/crates/pnpr/src/server/package_mutation.rs
+++ b/pnpr/crates/pnpr/src/server/package_mutation.rs
@@ -34,7 +34,7 @@ pub(super) async fn update_packument(
     body: &[u8],
 ) -> Response {
     let name = match CanonicalPackageName::parse(raw_name, pnpr_package_name::Ecosystem::Npm) {
-        Ok(n) => n,
+        Ok(name) => name,
         Err(err) => return err.into_response(),
     };
     let target = match resolve_write_target(state, identity, registry, &name) {
@@ -68,7 +68,7 @@ pub(super) async fn update_packument(
         return err.into_response();
     }
     let bytes = match serde_json::to_vec_pretty(&packument) {
-        Ok(b) => b,
+        Ok(bytes) => bytes,
         Err(err) => return RegistryError::Json(err).into_response(),
     };
     let written = storage
@@ -490,7 +490,7 @@ where
     Mutate: FnMut(&mut serde_json::Map<String, Value>) -> Result<(), RegistryError>,
 {
     let name = match CanonicalPackageName::parse(raw_name, pnpr_package_name::Ecosystem::Npm) {
-        Ok(n) => n,
+        Ok(name) => name,
         Err(err) => return err.into_response(),
     };
     // A dist-tag change is a write, so it routes to a hosted namespace like
@@ -519,38 +519,7 @@ where
     let _ = tag; // the tag name is captured by the `mutate` closure.
     let outcome = storage
         .update_hosted_document_with_retry(&name, DOCUMENT_WRITE_RETRIES, |existing_bytes| {
-            // A hosted org has no upstream, so a dist-tag change starts from the
-            // org's own packument; a package it does not host can't be tagged.
-            let Some(bytes) = existing_bytes else {
-                return Ok(None);
-            };
-            let mut packument: Value = serde_json::from_slice(bytes)?;
-            let Some(packument_obj) = packument.as_object_mut() else {
-                return Err(RegistryError::BadRequest {
-                    reason: "stored packument is not an object".to_string(),
-                });
-            };
-            let tags_entry = packument_obj
-                .entry("dist-tags".to_string())
-                .or_insert_with(|| Value::Object(serde_json::Map::new()));
-            let Some(tags) = tags_entry.as_object_mut() else {
-                return Err(RegistryError::BadRequest {
-                    reason: "stored dist-tags is not an object".to_string(),
-                });
-            };
-            mutate(tags)?;
-            // Refresh `time.modified` so clients do not lag behind a
-            // dist-tag change when deciding packument freshness.
-            let time_entry = packument_obj
-                .entry("time".to_string())
-                .or_insert_with(|| Value::Object(serde_json::Map::new()));
-            let Some(time_obj) = time_entry.as_object_mut() else {
-                return Err(RegistryError::BadRequest {
-                    reason: "stored time is not an object".to_string(),
-                });
-            };
-            time_obj.insert("modified".to_string(), Value::String(now_iso()));
-            Ok(Some(serde_json::to_vec_pretty(&packument)?))
+            retag_packument(existing_bytes, &mut mutate)
         })
         .await;
     match outcome {
@@ -565,4 +534,47 @@ where
         .header(header::CONTENT_TYPE, "application/json")
         .body(Body::from(bytes))
         .expect("static-shape response always builds")
+}
+
+/// The stored packument with its `dist-tags` mutated and `time.modified`
+/// stamped, or `None` when no packument is stored.
+fn retag_packument<Mutate>(
+    existing_bytes: Option<&[u8]>,
+    mutate: &mut Mutate,
+) -> Result<Option<Vec<u8>>, RegistryError>
+where
+    Mutate: FnMut(&mut serde_json::Map<String, Value>) -> Result<(), RegistryError>,
+{
+    // A hosted org has no upstream, so a dist-tag change starts from the
+    // org's own packument; a package it does not host can't be tagged.
+    let Some(bytes) = existing_bytes else {
+        return Ok(None);
+    };
+    let mut packument: Value = serde_json::from_slice(bytes)?;
+    let Some(packument_obj) = packument.as_object_mut() else {
+        return Err(RegistryError::BadRequest {
+            reason: "stored packument is not an object".to_string(),
+        });
+    };
+    let tags_entry = packument_obj
+        .entry("dist-tags".to_string())
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    let Some(tags) = tags_entry.as_object_mut() else {
+        return Err(RegistryError::BadRequest {
+            reason: "stored dist-tags is not an object".to_string(),
+        });
+    };
+    mutate(tags)?;
+    // Refresh `time.modified` so clients do not lag behind a
+    // dist-tag change when deciding packument freshness.
+    let time_entry = packument_obj
+        .entry("time".to_string())
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    let Some(time_obj) = time_entry.as_object_mut() else {
+        return Err(RegistryError::BadRequest {
+            reason: "stored time is not an object".to_string(),
+        });
+    };
+    time_obj.insert("modified".to_string(), Value::String(now_iso()));
+    Ok(Some(serde_json::to_vec_pretty(&packument)?))
 }

--- a/pnpr/crates/pnpr/src/server/publishing.rs
+++ b/pnpr/crates/pnpr/src/server/publishing.rs
@@ -15,7 +15,7 @@ use pnpr_package_name::CanonicalPackageName;
 use pnpr_policy::Identity;
 use pnpr_registry::{Ecosystem, Registry};
 use pnpr_storage::{
-    HostedDocumentVersion,
+    HostedDocumentForUpdate, HostedDocumentVersion, Storage,
     journal::{CommitOutcome, JournaledPublish, JournaledRevisionRef},
     publish::{
         PendingAttachment, extract_attachments, merge_manifest, now_iso,
@@ -444,23 +444,14 @@ pub(super) async fn stage_publish(
     let ValidatedPublish { name, incoming, prepared } = doc;
     let storage = hosted_storage(state, org);
 
-    let hosted_packument = storage.read_hosted_document_for_update(&name).await?;
-    let (hosted_bytes, base_version) = match hosted_packument {
-        Some(packument) => (Some(packument.bytes), Some(packument.version)),
-        None => (None, None),
-    };
-    let hosted: Option<Value> = match hosted_bytes.as_deref().map(serde_json::from_slice) {
-        Some(Ok(value)) => Some(value),
-        Some(Err(err)) => return Err(RegistryError::Json(err)),
-        None => None,
-    };
+    let (hosted, base_version) =
+        parse_hosted_packument(storage.read_hosted_document_for_update(&name).await?)?;
 
     check_publishable_versions(&name, &incoming, hosted.as_ref(), &prepared)?;
 
     // A hosted registry has no upstream, so a publish seeds the merge only from
     // the org's own hosted packument; a brand-new package starts from `None`.
-    let existing: Option<Value> = hosted.clone();
-    let merged = merge_manifest(existing.as_ref(), &incoming, hosted.as_ref(), now_iso);
+    let merged = merge_manifest(hosted.as_ref(), &incoming, hosted.as_ref(), now_iso);
     let merged_bytes = serde_json::to_vec_pretty(&merged).map_err(RegistryError::Json)?;
     let original_refs = prepared
         .iter()
@@ -475,36 +466,7 @@ pub(super) async fn stage_publish(
     // missing integrity field — short-circuits the publish with a
     // 400; any tmp files written before the failure get removed
     // along the way so a bad upload leaves no on-disk artifact.
-    let mut written_slots = Vec::with_capacity(prepared.len());
-    for PreparedAttachment { attachment, canonical, version: _, dist } in prepared {
-        let slot = match storage.reserve_hosted_blob(&name, &canonical).await {
-            Ok(slot) => slot,
-            Err(err) => {
-                cleanup_tmp_slots(written_slots).await;
-                return Err(err);
-            }
-        };
-        let PendingAttachment { filename, data, declared_length } = attachment;
-        let tmp_path = slot.tmp_path.clone();
-        let dist_for_task = (!dist.is_null()).then_some(dist);
-        let result = tokio::task::spawn_blocking(move || {
-            let dist_ref = dist_for_task.as_ref();
-            stream_decode_verify_and_write(&filename, &data, declared_length, dist_ref, &tmp_path)
-        })
-        .await;
-        match result {
-            Ok(Ok(_)) => written_slots.push(slot),
-            Ok(Err(err)) => {
-                cleanup_tmp_slots(written_slots).await;
-                return Err(err);
-            }
-            Err(join_err) => {
-                let _ = tokio::fs::remove_file(&slot.tmp_path).await;
-                cleanup_tmp_slots(written_slots).await;
-                return Err(RegistryError::Io(std::io::Error::other(join_err.to_string())));
-            }
-        }
-    }
+    let written_slots = write_attachment_slots(&storage, &name, prepared).await?;
     Ok(StagedPublish {
         name,
         ecosystem: Ecosystem::Npm,
@@ -514,6 +476,70 @@ pub(super) async fn stage_publish(
         revision_refs: original_refs,
         org: org.map(str::to_string),
     })
+}
+
+/// The stored packument, parsed, with the version its update must be based
+/// on. `None` for a package the org has not published yet.
+fn parse_hosted_packument(
+    hosted: Option<HostedDocumentForUpdate>,
+) -> Result<(Option<Value>, Option<HostedDocumentVersion>), RegistryError> {
+    let Some(packument) = hosted else {
+        return Ok((None, None));
+    };
+    let value = serde_json::from_slice(&packument.bytes).map_err(RegistryError::Json)?;
+    Ok((Some(value), Some(packument.version)))
+}
+
+/// Write every attachment into its reserved blob slot. A failure removes
+/// the slots written so far, so a bad upload leaves no on-disk artifact.
+async fn write_attachment_slots(
+    storage: &Storage,
+    name: &CanonicalPackageName,
+    prepared: Vec<PreparedAttachment>,
+) -> Result<Vec<pnpr_storage::BlobSlot>, RegistryError> {
+    let mut written_slots = Vec::with_capacity(prepared.len());
+    for attachment in prepared {
+        match write_attachment_slot(storage, name, attachment).await {
+            Ok(slot) => written_slots.push(slot),
+            Err(err) => {
+                cleanup_tmp_slots(written_slots).await;
+                return Err(err);
+            }
+        }
+    }
+    Ok(written_slots)
+}
+
+/// Stream-decode, verify and write one tarball into a reserved slot. A
+/// mismatch, or a missing integrity field, fails with a 400.
+async fn write_attachment_slot(
+    storage: &Storage,
+    name: &CanonicalPackageName,
+    prepared: PreparedAttachment,
+) -> Result<pnpr_storage::BlobSlot, RegistryError> {
+    let PreparedAttachment { attachment, canonical, version: _, dist } = prepared;
+    let slot = storage.reserve_hosted_blob(name, &canonical).await?;
+    let PendingAttachment { filename, data, declared_length } = attachment;
+    let tmp_path = slot.tmp_path.clone();
+    let dist_for_task = (!dist.is_null()).then_some(dist);
+    let result = tokio::task::spawn_blocking(move || {
+        stream_decode_verify_and_write(
+            &filename,
+            &data,
+            declared_length,
+            dist_for_task.as_ref(),
+            &tmp_path,
+        )
+    })
+    .await;
+    match result {
+        Ok(Ok(_)) => Ok(slot),
+        Ok(Err(err)) => Err(err),
+        Err(join_err) => {
+            let _ = tokio::fs::remove_file(&slot.tmp_path).await;
+            Err(RegistryError::Io(std::io::Error::other(join_err.to_string())))
+        }
+    }
 }
 
 /// Merge the incoming packument with the on-disk / upstream state
@@ -559,12 +585,7 @@ fn check_publishable_versions(
                 ),
             });
         };
-        let incoming_integrity =
-            incoming_manifest.pointer("/dist/integrity").and_then(Value::as_str);
-        let hosted_integrity = hosted_manifest.pointer("/dist/integrity").and_then(Value::as_str);
-        let integrity_changed =
-            incoming_integrity.is_some_and(|integrity| Some(integrity) != hosted_integrity);
-        if has_attachment || integrity_changed {
+        if has_attachment || integrity_changed(incoming_manifest, hosted_manifest) {
             return Err(RegistryError::VersionAlreadyPublished {
                 package: name.as_str().to_string(),
                 version: version.clone(),
@@ -572,6 +593,14 @@ fn check_publishable_versions(
         }
     }
     Ok(())
+}
+
+/// Whether the incoming manifest declares an integrity other than the one
+/// the hosted manifest carries.
+fn integrity_changed(incoming_manifest: &Value, hosted_manifest: &Value) -> bool {
+    let incoming_integrity = incoming_manifest.pointer("/dist/integrity").and_then(Value::as_str);
+    let hosted_integrity = hosted_manifest.pointer("/dist/integrity").and_then(Value::as_str);
+    incoming_integrity.is_some_and(|integrity| Some(integrity) != hosted_integrity)
 }
 
 fn staged_hosted_original_ref(

--- a/pnpr/crates/pnpr/src/server/routing.rs
+++ b/pnpr/crates/pnpr/src/server/routing.rs
@@ -49,25 +49,19 @@ pub(super) fn router_with_auth_and_osv(
     auth: AuthState,
     osv_index: Option<Arc<pnpr_osv::OsvIndex>>,
 ) -> pnpr_error::Result<Router> {
-    let cors_origins = config
-        .cors
-        .allowed_origins()
-        .iter()
-        .map(|origin| {
-            HeaderValue::from_str(origin).map_err(|_| pnpr_error::RegistryError::InvalidConfig {
-                reason: format!("CORS allowed origin {origin:?} is not a valid HTTP header value"),
-            })
-        })
-        .collect::<pnpr_error::Result<Vec<_>>>()?;
+    let cors_origins = cors_origins(&config)?;
     let storage =
         Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone())?;
-    let registry_enabled = config.registry.enabled;
-    let resolver_enabled = config.resolver.enabled;
-    let artifacts_enabled = config.artifacts.enabled;
-    let pipeline_enabled = config.pipeline.enabled;
+    let surfaces = EnabledSurfaces {
+        resolver: config.resolver.enabled,
+        registry: config.registry.enabled,
+        artifacts: config.artifacts.enabled,
+        pipeline: config.pipeline.enabled,
+    };
     let pipeline_runs =
-        pipeline_enabled.then(|| pnpr_pipeline_runs::PipelineRunStore::new(storage.clone()));
-    let artifacts = artifacts_enabled
+        surfaces.pipeline.then(|| pnpr_pipeline_runs::PipelineRunStore::new(storage.clone()));
+    let artifacts = surfaces
+        .artifacts
         .then(|| {
             pnpr_shared_artifacts::SharedArtifactStore::new(
                 &config.hosted_store,
@@ -78,24 +72,7 @@ pub(super) fn router_with_auth_and_osv(
     // Only the registry routes consult the upstreams, so a resolver-only
     // server builds none — skipping a `ThrottledClient` allocation per
     // configured upstream.
-    let upstreams: IndexMap<String, Upstream> = if registry_enabled {
-        config
-            .upstreams
-            .iter()
-            .map(|(name, upstream)| {
-                let client = Upstream::new(name, upstream);
-                let client = if config.registries.ecosystem(name) == Some(Ecosystem::Npm) {
-                    client
-                } else {
-                    client
-                        .with_fetch_guard(super::ecosystem::upstream_fetch_guard(&config, upstream))
-                };
-                (name.clone(), client)
-            })
-            .collect()
-    } else {
-        IndexMap::new()
-    };
+    let upstreams = upstream_clients(&config, surfaces.registry);
     let upstream_cache_namespaces = config
         .upstreams
         .keys()
@@ -120,12 +97,6 @@ pub(super) fn router_with_auth_and_osv(
             osv_index,
         }),
     };
-    let surfaces = EnabledSurfaces {
-        resolver: resolver_enabled,
-        registry: registry_enabled,
-        artifacts: artifacts_enabled,
-        pipeline: pipeline_enabled,
-    };
     let router = surface_routes(&state, surfaces);
     let mut router = router
         .layer(DefaultBodyLimit::max(MAX_PUBLISH_BODY_BYTES))
@@ -143,7 +114,47 @@ pub(super) fn router_with_auth_and_osv(
                 .allow_headers([header::AUTHORIZATION, header::ACCEPT, header::CONTENT_TYPE]),
         );
     }
-    let router = router
+    Ok(with_observability_layers(router).with_state(state))
+}
+
+fn cors_origins(config: &Config) -> pnpr_error::Result<Vec<HeaderValue>> {
+    config
+        .cors
+        .allowed_origins()
+        .iter()
+        .map(|origin| {
+            HeaderValue::from_str(origin).map_err(|_| pnpr_error::RegistryError::InvalidConfig {
+                reason: format!("CORS allowed origin {origin:?} is not a valid HTTP header value"),
+            })
+        })
+        .collect()
+}
+
+/// Only the registry routes consult the upstreams, so a resolver-only
+/// server builds none, skipping a `ThrottledClient` allocation per
+/// configured upstream.
+fn upstream_clients(config: &Config, registry_enabled: bool) -> IndexMap<String, Upstream> {
+    if !registry_enabled {
+        return IndexMap::new();
+    }
+    config
+        .upstreams
+        .iter()
+        .map(|(name, upstream)| {
+            let client = Upstream::new(name, upstream);
+            let client = if config.registries.ecosystem(name) == Some(Ecosystem::Npm) {
+                client
+            } else {
+                client.with_fetch_guard(super::ecosystem::upstream_fetch_guard(config, upstream))
+            };
+            (name.clone(), client)
+        })
+        .collect()
+}
+
+/// The compression and access-log layers every response passes through.
+fn with_observability_layers(router: Router<AppState>) -> Router<AppState> {
+    router
         // gzip metadata responses for clients that send `Accept-Encoding:
         // gzip`, matching how a real (CDN-fronted) registry serves
         // packuments — pnpr is commonly hit directly with no proxy in
@@ -194,8 +205,7 @@ pub(super) fn router_with_auth_and_osv(
                     );
                 })
                 .on_failure(()),
-        );
-    Ok(router.with_state(state))
+        )
 }
 
 /// Which of the configurable surfaces this server mounts.

--- a/pnpr/crates/pnpr/src/server/staged.rs
+++ b/pnpr/crates/pnpr/src/server/staged.rs
@@ -31,7 +31,7 @@ use serde_json::{Value, json};
 use super::{
     Action, AppState, AuthedCaller, Identity, RegistrySource, TargetRegistry, authorize,
     commit_publishes, json_response, not_found, private_no_cache,
-    publishing::{cleanup_tmp_slots, report_unrecorded},
+    publishing::{ValidatedPublish, cleanup_tmp_slots, report_unrecorded},
     resolve_write_target, stage_publish, validate_publish_doc,
 };
 use pnpr_error::RegistryError;
@@ -252,45 +252,67 @@ async fn serve_staged_publish(
             Err(err) => return err.into_response(),
         };
 
+    let stage_id = generate_stage_id();
+    let record = staged_record(&validated, identity, registry, &stage_id);
+
+    if let Err(err) = store_staged(state, &stage_id, body, &record).await {
+        return err.into_response();
+    }
+    json_response(StatusCode::CREATED, &json!({ "ok": true, "stageId": stage_id }))
+}
+
+fn staged_record(
+    validated: &ValidatedPublish,
+    identity: &Identity,
+    registry: Option<&str>,
+    stage_id: &str,
+) -> StagedRecord {
     let (version, dist) = validated.prepared.first().map_or((None, Value::Null), |attachment| {
         (Some(attachment.version.clone()), attachment.dist.clone())
     });
-    let tag = validated.incoming.get("dist-tags").and_then(Value::as_object).and_then(|tags| {
-        match &version {
-            Some(version) => tags
-                .iter()
-                .find(|(_, tagged)| tagged.as_str() == Some(version))
-                .or_else(|| tags.iter().next())
-                .map(|(tag, _)| tag.clone()),
-            None => tags.keys().next().cloned(),
-        }
-    });
     let (actor, actor_type) = actor_of(identity);
-    let stage_id = generate_stage_id();
-    let record = StagedRecord {
-        id: stage_id.clone(),
+    StagedRecord {
+        id: stage_id.to_string(),
         package_name: validated.name.as_str().to_string(),
+        tag: staged_tag(&validated.incoming, version.as_deref()),
         version,
-        tag,
         created_at: now_iso(),
         actor,
         actor_type,
         shasum: dist.get("shasum").and_then(Value::as_str).map(str::to_string),
         registry: registry.map(str::to_string),
         approving_since: None,
-    };
+    }
+}
 
-    // Body first, metadata last: a record whose metadata exists always has
-    // its body. On a metadata failure the body is cleaned up best-effort.
-    if let Err(err) = state.inner.storage.create_staged_body(&stage_id, body).await {
-        return err.into_response();
+/// The dist-tag naming the staged version, else the first tag declared.
+fn staged_tag(incoming: &Value, version: Option<&str>) -> Option<String> {
+    let tags = incoming.get("dist-tags").and_then(Value::as_object)?;
+    match version {
+        Some(version) => tags
+            .iter()
+            .find(|(_, tagged)| tagged.as_str() == Some(version))
+            .or_else(|| tags.iter().next())
+            .map(|(tag, _)| tag.clone()),
+        None => tags.keys().next().cloned(),
     }
-    let meta_bytes = serde_json::to_vec(&record).expect("a staged record serializes");
-    if let Err(err) = state.inner.storage.create_staged_meta(&stage_id, &meta_bytes).await {
-        let _ = state.inner.storage.remove_staged(&stage_id).await;
-        return err.into_response();
+}
+
+/// Body first, metadata last: a record whose metadata exists always has
+/// its body. On a metadata failure the body is cleaned up best-effort.
+async fn store_staged(
+    state: &AppState,
+    stage_id: &str,
+    body: &axum::body::Bytes,
+    record: &StagedRecord,
+) -> Result<(), RegistryError> {
+    state.inner.storage.create_staged_body(stage_id, body).await?;
+    let meta_bytes = serde_json::to_vec(record).expect("a staged record serializes");
+    if let Err(err) = state.inner.storage.create_staged_meta(stage_id, &meta_bytes).await {
+        let _ = state.inner.storage.remove_staged(stage_id).await;
+        return Err(err);
     }
-    json_response(StatusCode::CREATED, &json!({ "ok": true, "stageId": stage_id }))
+    Ok(())
 }
 
 /// `GET /-/stage?page=&perPage=&package=` — the staged records visible to

--- a/pnpr/crates/pypi/src/multipart.rs
+++ b/pnpr/crates/pypi/src/multipart.rs
@@ -84,13 +84,9 @@ pub fn parse_form(content_type: &str, body: &[u8]) -> Result<Vec<FormPart>, Mult
             .strip_prefix(b"\r\n")
             .filter(|rest| !rest.is_empty())
             .ok_or(MultipartError::MissingClosingBoundary)?;
-        let header_end = find(rest, b"\r\n\r\n").ok_or(MultipartError::MissingHeaderTerminator)?;
-        let headers =
-            std::str::from_utf8(&rest[..header_end]).map_err(|_| MultipartError::HeadersNotText)?;
+        let (headers, data_start) = split_part_headers(rest)?;
         let (name, filename) = content_disposition(headers)?;
-        let data_start = header_end + 4;
-        let data = &rest[data_start..];
-        let data_offset = body.len() - data.len();
+        let data_offset = body.len() - (rest.len() - data_start);
         let next =
             matcher.find_at(body, data_offset).ok_or(MultipartError::MissingClosingBoundary)?;
         if !body[next.start()..].starts_with(b"\r\n") {
@@ -99,6 +95,14 @@ pub fn parse_form(content_type: &str, body: &[u8]) -> Result<Vec<FormPart>, Mult
         parts.push(FormPart { name, filename, data: body[data_offset..next.start()].to_vec() });
         cursor = next.end() - 2;
     }
+}
+
+/// A part's header block, and the offset its data starts at.
+fn split_part_headers(rest: &[u8]) -> Result<(&str, usize), MultipartError> {
+    let header_end = find(rest, b"\r\n\r\n").ok_or(MultipartError::MissingHeaderTerminator)?;
+    let headers =
+        std::str::from_utf8(&rest[..header_end]).map_err(|_| MultipartError::HeadersNotText)?;
+    Ok((headers, header_end + 4))
 }
 
 fn content_disposition(headers: &str) -> Result<(String, Option<String>), MultipartError> {

--- a/pnpr/crates/search/src/lib.rs
+++ b/pnpr/crates/search/src/lib.rs
@@ -172,12 +172,8 @@ fn build_search_entry(name: &str, packument: &Value) -> Option<Value> {
 /// `description` / `keywords`.
 fn build_search_package(name: &str, packument: &Value) -> Option<Value> {
     let obj = packument.as_object()?;
-    let dist_tags = obj.get("dist-tags").and_then(Value::as_object);
-    let latest_tag = dist_tags.and_then(|tags| tags.get("latest")).and_then(Value::as_str);
     let versions = obj.get("versions").and_then(Value::as_object)?;
-    let version_id: &str = latest_tag
-        .filter(|tag| versions.contains_key(*tag))
-        .or_else(|| versions.keys().next().map(String::as_str))?;
+    let version_id = latest_version_id(obj, versions)?;
     let version_obj = versions.get(version_id).and_then(Value::as_object);
     let mut pkg = Map::new();
     pkg.insert("name".to_string(), Value::String(name.to_string()));
@@ -201,12 +197,29 @@ fn build_search_package(name: &str, packument: &Value) -> Option<Value> {
     if let Some(npm_user) = version_obj.and_then(|v| v.get("_npmUser")) {
         pkg.insert("publisher".to_string(), npm_user.clone());
     }
-    // `links.npm` is what the npm website surfaces. Synthesized
-    // from the name so the search response looks the part.
+    pkg.insert("links".to_string(), package_links(name)?);
+    Some(Value::Object(pkg))
+}
+
+/// The `latest` tag's version when it is published, else the first one.
+fn latest_version_id<'p>(
+    obj: &'p Map<String, Value>,
+    versions: &'p Map<String, Value>,
+) -> Option<&'p str> {
+    let dist_tags = obj.get("dist-tags").and_then(Value::as_object);
+    dist_tags
+        .and_then(|tags| tags.get("latest"))
+        .and_then(Value::as_str)
+        .filter(|tag| versions.contains_key(*tag))
+        .or_else(|| versions.keys().next().map(String::as_str))
+}
+
+/// `links.npm` is what the npm website surfaces. Synthesized
+/// from the name so the search response looks the part.
+fn package_links(name: &str) -> Option<Value> {
     let mut links = BTreeMap::new();
     links.insert("npm".to_string(), Value::String(format!("https://npmx.dev/package/{name}")));
-    pkg.insert("links".to_string(), serde_json::to_value(links).ok()?);
-    Some(Value::Object(pkg))
+    serde_json::to_value(links).ok()
 }
 
 /// Copy the per-version fields npm's search results carry.

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -398,22 +398,22 @@ impl SharedArtifactStore {
         else {
             return Ok(false);
         };
-        let PreparedPublication {
-            entry,
-            envelope_bytes,
-            variant_path,
-            payload,
-            envelope_digest,
-            ..
-        } = prepared;
         let mut charge =
             PublicationQuota { owner: &owner, added_bytes, retained_bytes, reclamation_needed };
         self.store_new_blobs(new_blobs, &mut charge).await?;
         let created = self
-            .store_envelope(&variant_path, envelope_bytes.clone(), envelope_size, &mut charge)
+            .store_envelope(
+                &prepared.variant_path,
+                prepared.envelope_bytes.clone(),
+                envelope_size,
+                &mut charge,
+            )
             .await?;
-        if !self.settle_envelope(created, &variant_path, &envelope_bytes, charge).await? {
-            return Err(RegistryError::ArtifactAlreadyPublished { owner, entry });
+        if !self
+            .settle_envelope(created, &prepared.variant_path, &prepared.envelope_bytes, charge)
+            .await?
+        {
+            return Err(RegistryError::ArtifactAlreadyPublished { owner, entry: prepared.entry });
         }
         if created && started.elapsed() >= ACTIVE_PUBLICATION_EXPIRY {
             // Long enough to have been written off, which lets reclamation run
@@ -438,11 +438,17 @@ impl SharedArtifactStore {
                 // stand for blobs a collector may already have taken. The
                 // scopes it holds name an artifact that is no longer there,
                 // which is what reclamation collects.
-                self.store.delete(&self.object_path(&variant_path)).await?;
+                self.store.delete(&self.object_path(&prepared.variant_path)).await?;
                 return Err(error);
             }
-            self.recover_after_expiry(&owner, &entry, &variant_path, &payload, &envelope_digest)
-                .await?;
+            self.recover_after_expiry(
+                &owner,
+                &prepared.entry,
+                &prepared.variant_path,
+                &prepared.payload,
+                &prepared.envelope_digest,
+            )
+            .await?;
         }
         Ok(created)
     }

--- a/pnpr/crates/storage/src/publish.rs
+++ b/pnpr/crates/storage/src/publish.rs
@@ -510,9 +510,14 @@ pub fn iso_from_unix_millis(millis: i64) -> String {
     let (h, rem) = (ms_in_day / 3_600_000, ms_in_day.rem_euclid(3_600_000));
     let (m, rem) = (rem / 60_000, rem.rem_euclid(60_000));
     let (s, ms) = (rem / 1000, rem.rem_euclid(1000));
-    // Days since 1970-01-01 → year/month/day. Howard Hinnant's
-    // algorithm, adapted to integer days from epoch. Shift so era
-    // is positive (719_468 = days from 0000-03-01 to 1970-01-01).
+    let (year, month, day) = civil_from_days(days);
+    format!("{year:04}-{month:02}-{day:02}T{h:02}:{m:02}:{s:02}.{ms:03}Z")
+}
+
+/// Days since 1970-01-01 → year/month/day. Howard Hinnant's
+/// algorithm, adapted to integer days from epoch. Shift so era
+/// is positive (`719_468` = days from 0000-03-01 to 1970-01-01).
+fn civil_from_days(days: i64) -> (i64, u32, u32) {
     let epoch_days = days + 719_468;
     let era = epoch_days.div_euclid(146_097);
     let doe = epoch_days.rem_euclid(146_097) as u32;
@@ -523,7 +528,7 @@ pub fn iso_from_unix_millis(millis: i64) -> String {
     let day = doy - (153 * mp + 2) / 5 + 1;
     let month = if mp < 10 { mp + 3 } else { mp - 9 };
     let year = if month <= 2 { year + 1 } else { year };
-    format!("{year:04}-{month:02}-{day:02}T{h:02}:{m:02}:{s:02}.{ms:03}Z")
+    (year, month, day)
 }
 
 #[cfg(test)]

--- a/pnpr/crates/upstream/src/lib.rs
+++ b/pnpr/crates/upstream/src/lib.rs
@@ -671,31 +671,8 @@ fn rewrite_dist_tarball(
     if let Some(source_registry) = source_registry {
         rewrite_upstream_revision_tarball_urls(dist, source_registry, public_url);
     }
-    let revision_url = source_registry.and_then(|source_registry| {
-        let revision = dist.get("revision")?.as_u64()?;
-        TarballRevision::try_from(revision).ok()?;
-        let integrity: Integrity = dist.get("integrity")?.as_str()?.parse().ok()?;
-        let tarball = dist.get("tarball")?.as_str()?;
-        if !is_integrity_addressed_registry_tarball_url(tarball, &integrity, source_registry) {
-            return None;
-        }
-        let revision_url = integrity_addressed_registry_tarball_url(&integrity, public_url)?;
-        let matches = dist
-            .get("revisions")?
-            .as_array()?
-            .iter()
-            .filter(|entry| {
-                entry.get("revision").and_then(Value::as_u64) == Some(revision)
-                    && entry
-                        .get("integrity")
-                        .and_then(Value::as_str)
-                        .and_then(|integrity| integrity.parse::<Integrity>().ok())
-                        .is_some_and(|candidate| candidate == integrity)
-                    && entry.get("tarball").and_then(Value::as_str) == Some(revision_url.as_str())
-            })
-            .count();
-        (matches == 1).then_some(revision_url)
-    });
+    let revision_url = source_registry
+        .and_then(|source_registry| unique_revision_url(dist, source_registry, public_url));
     if let Some(revision_url) = revision_url {
         let Some(tarball_value) = dist.get_mut("tarball") else { return };
         *tarball_value = Value::String(revision_url);
@@ -713,6 +690,38 @@ fn rewrite_dist_tarball(
         .or(fallback)
         .unwrap_or_default();
     *tarball_value = Value::String(format!("{public_url}/{}/-/{filename}", pkg.as_str()));
+}
+
+/// The integrity-addressed tarball route on this server for the packument's
+/// pinned revision, when exactly one listed revision matches it.
+fn unique_revision_url(
+    dist: &serde_json::Map<String, Value>,
+    source_registry: &str,
+    public_url: &str,
+) -> Option<String> {
+    let revision = dist.get("revision")?.as_u64()?;
+    TarballRevision::try_from(revision).ok()?;
+    let integrity: Integrity = dist.get("integrity")?.as_str()?.parse().ok()?;
+    let tarball = dist.get("tarball")?.as_str()?;
+    if !is_integrity_addressed_registry_tarball_url(tarball, &integrity, source_registry) {
+        return None;
+    }
+    let revision_url = integrity_addressed_registry_tarball_url(&integrity, public_url)?;
+    let matches = dist
+        .get("revisions")?
+        .as_array()?
+        .iter()
+        .filter(|entry| {
+            entry.get("revision").and_then(Value::as_u64) == Some(revision)
+                && entry
+                    .get("integrity")
+                    .and_then(Value::as_str)
+                    .and_then(|integrity| integrity.parse::<Integrity>().ok())
+                    .is_some_and(|candidate| candidate == integrity)
+                && entry.get("tarball").and_then(Value::as_str) == Some(revision_url.as_str())
+        })
+        .count();
+    (matches == 1).then_some(revision_url)
 }
 
 fn rewrite_upstream_revision_tarball_urls(


### PR DESCRIPTION
## Summary

Finishes the `too_many_local_bindings` adoption started in pnpm/pnpm#14737 (Related to pnpm/pnpm#14562): every remaining production function that bound more than 12 distinct local names is restructured, and the rule leaves `dylint.toml`'s `disable` list so the pre-push and CI dylint gates now enforce it.

The remainder covered the crates the earlier installments did not touch: `deps-restorer`, `resolving-deps-resolver`, `tarball`, `resolving-npm-resolver`, `napi`, `config`, `pnpr` and its crates, `cli`, and ~35 sites across the small crates and the two task binaries. The recipe is the same as before: read a struct's fields where they are used instead of destructuring, take owned fields first, and hand each phase to a named step or a small typed view. No behavior, performance or memory changes are intended; every crate's tests pass and no changeset is needed.

Two small fixes ride along: pnpr's streamed resolve needed `#![recursion_limit = "256"]` once the engine's futures were split into steps (rustc overflowed proving the spawned future `Send`), and the three copies of the `scriptsPrependNodePath` config-to-executor mapping in `deps-restorer` and `package-manager` are now one shared function.

## Squash Commit Body

```text
Bring every production function under the 12-binding cap and enable the
`too_many_local_bindings` dylint rule (`max_bindings = 12`,
`exempt_tests = true`).

Each oversized function reads its inputs' fields in place, takes owned
fields before the borrows it needs, and hands its remaining locals to a
named step or a typed view: the virtual-store creation, the workspace and
peer resolvers, the tarball ingestion, the npm resolver's mirror and
result assembly, the NAPI bindings, the config load, the pnpr resolver
and OCI/publish handlers, and the CLI commands. Behavior, error precedence
and allocations are unchanged.

pnpr's streamed resolve gained `#![recursion_limit = "256"]`: with the
engine's futures split into steps, rustc overflowed proving the spawned
future `Send`. The config-to-executor `scriptsPrependNodePath` mapping now
lives once in deps-restorer.

Related to pnpm/pnpm#14562.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR4Ev797PFQ6iaC3AtzRw

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791594281&installation_model_id=426870&pr_number=14760&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14760&signature=9b4223142d887f7818e29b7ed59254c42fc2698725350f7742235d020770d1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal command, dependency resolution, configuration, publishing, packaging, and workspace workflows into smaller, clearer components.
  * Consolidated shared processing and validation across installation, deployment, auditing, signing, and registry operations.
  * Preserved existing behavior, output, error handling, and command interfaces.

* **Chores**
  * Re-enabled an additional code-quality check while retaining its existing limits and test exclusions.
  * Updated internal documentation and configuration handling without changing supported workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->