### PR TITLE
fix: prune stale minimum release age excludes after install

### DIFF
--- a/.changeset/quiet-shrimps-prune.md
+++ b/.changeset/quiet-shrimps-prune.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` and `pnpm dedupe` now prune stale `minimumReleaseAgeExclude` entries after writing a fresh lockfile [pnpm/pnpm#14759](https://github.com/pnpm/pnpm/issues/14759).

--- a/.changeset/quiet-shrimps-prune.md
+++ b/.changeset/quiet-shrimps-prune.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm install` and `pnpm dedupe` now prune stale `minimumReleaseAgeExclude` entries after writing a fresh lockfile [pnpm/pnpm#14759](https://github.com/pnpm/pnpm/issues/14759).
+`pnpm install` and `pnpm dedupe` now prune the `minimumReleaseAgeExclude` and `trustPolicyExclude` entries in `pnpm-workspace.yaml` that the freshly written lockfile no longer resolves, when `minimumReleaseAgeExcludePrune` or `trustPolicyExcludePrune` is enabled. Only `pnpm add`, `pnpm update`, and `pnpm remove` ran that cleanup before [pnpm/pnpm#14759](https://github.com/pnpm/pnpm/issues/14759).

--- a/pnpm/crates/cli/tests/suite/catalog.rs
+++ b/pnpm/crates/cli/tests/suite/catalog.rs
@@ -535,14 +535,64 @@ fn prunes_the_minimum_release_age_excludes() {
     drop((root, anchor));
 }
 
+/// Regression test for [pnpm/pnpm#14759](https://github.com/pnpm/pnpm/issues/14759):
+/// `install` runs the same prune pass as `add`.
 #[test]
 fn install_prunes_the_minimum_release_age_excludes_after_resolution_changes() {
     let (root, workspace, anchor) = setup();
-    write_manifest(&workspace, &format!(r#"{{ "{FOO}": "1.0.0" }}"#));
+    lock_foo_with_stale_excludes(&workspace);
+    write_manifest(&workspace, &format!(r#"{{ "{FOO}": "2.0.0" }}"#));
 
     run_ok(&workspace, &["install", "--lockfile-only"]);
+
+    assert_excludes_narrowed_to_foo_2(&workspace);
+    drop((root, anchor));
+}
+
+#[test]
+fn dedupe_prunes_the_minimum_release_age_excludes_after_resolution_changes() {
+    let (root, workspace, anchor) = setup();
+    lock_foo_with_stale_excludes(&workspace);
+    write_manifest(&workspace, &format!(r#"{{ "{FOO}": "2.0.0" }}"#));
+
+    run_ok(&workspace, &["dedupe", "--lockfile-only"]);
+
+    assert_excludes_narrowed_to_foo_2(&workspace);
+    drop((root, anchor));
+}
+
+/// Dropping a dependency is drift the install absorbs by rewriting the
+/// loaded lockfile in place of a resolution, and `--lockfile-only` then
+/// returns before materializing anything; the prune pass has to run on
+/// that early return too.
+#[test]
+fn install_prunes_the_minimum_release_age_excludes_after_a_dependency_is_removed() {
+    let (root, workspace, anchor) = setup();
+    lock_foo_with_stale_excludes(&workspace);
+    write_manifest(&workspace, "{}");
+
+    run_ok(&workspace, &["install", "--lockfile-only"]);
+
+    let workspace_yaml = read(&workspace, "pnpm-workspace.yaml");
+    assert!(
+        !workspace_yaml.contains("minimumReleaseAgeExclude:"),
+        "a list left with no resolved entry must be dropped:\n{workspace_yaml}",
+    );
+    assert!(
+        workspace_yaml.contains("minimumReleaseAgeExcludePrune: true"),
+        "the prune setting itself must survive:\n{workspace_yaml}",
+    );
+    drop((root, anchor));
+}
+
+/// Lock `FOO@1.0.0`, then list it (alongside a package the workspace never
+/// resolves) under `minimumReleaseAgeExcludePrune` so a later run that
+/// drops it from the lockfile has something to prune.
+fn lock_foo_with_stale_excludes(workspace: &Path) {
+    write_manifest(workspace, &format!(r#"{{ "{FOO}": "1.0.0" }}"#));
+    run_ok(workspace, &["install", "--lockfile-only"]);
     append_workspace_yaml(
-        &workspace,
+        workspace,
         &format!(
             "minimumReleaseAgeExcludePrune: true\n\
              minimumReleaseAgeExclude:\n  \
@@ -550,11 +600,10 @@ fn install_prunes_the_minimum_release_age_excludes_after_resolution_changes() {
              - '@pnpm.e2e/bar@100.0.0'\n",
         ),
     );
-    write_manifest(&workspace, &format!(r#"{{ "{FOO}": "2.0.0" }}"#));
+}
 
-    run_ok(&workspace, &["install", "--lockfile-only"]);
-
-    let workspace_yaml = read(&workspace, "pnpm-workspace.yaml");
+fn assert_excludes_narrowed_to_foo_2(workspace: &Path) {
+    let workspace_yaml = read(workspace, "pnpm-workspace.yaml");
     assert!(
         workspace_yaml.contains(&format!("{FOO}@2.0.0")),
         "the narrowed exclude must keep the newly resolved version:\n{workspace_yaml}",
@@ -567,8 +616,6 @@ fn install_prunes_the_minimum_release_age_excludes_after_resolution_changes() {
         !workspace_yaml.contains("@pnpm.e2e/bar"),
         "the exclude for an absent package must be dropped:\n{workspace_yaml}",
     );
-
-    drop((root, anchor));
 }
 
 /// The `trustPolicyExcludePrune` counterpart of

--- a/pnpm/crates/cli/tests/suite/catalog.rs
+++ b/pnpm/crates/cli/tests/suite/catalog.rs
@@ -535,6 +535,42 @@ fn prunes_the_minimum_release_age_excludes() {
     drop((root, anchor));
 }
 
+#[test]
+fn install_prunes_the_minimum_release_age_excludes_after_resolution_changes() {
+    let (root, workspace, anchor) = setup();
+    write_manifest(&workspace, &format!(r#"{{ "{FOO}": "1.0.0" }}"#));
+
+    run_ok(&workspace, &["install", "--lockfile-only"]);
+    append_workspace_yaml(
+        &workspace,
+        &format!(
+            "minimumReleaseAgeExcludePrune: true\n\
+             minimumReleaseAgeExclude:\n  \
+             - '{FOO}@1.0.0 || 2.0.0'\n  \
+             - '@pnpm.e2e/bar@100.0.0'\n",
+        ),
+    );
+    write_manifest(&workspace, &format!(r#"{{ "{FOO}": "2.0.0" }}"#));
+
+    run_ok(&workspace, &["install", "--lockfile-only"]);
+
+    let workspace_yaml = read(&workspace, "pnpm-workspace.yaml");
+    assert!(
+        workspace_yaml.contains(&format!("{FOO}@2.0.0")),
+        "the narrowed exclude must keep the newly resolved version:\n{workspace_yaml}",
+    );
+    assert!(
+        !workspace_yaml.contains("1.0.0"),
+        "the previously resolved version must be pruned once it is unresolved:\n{workspace_yaml}",
+    );
+    assert!(
+        !workspace_yaml.contains("@pnpm.e2e/bar"),
+        "the exclude for an absent package must be dropped:\n{workspace_yaml}",
+    );
+
+    drop((root, anchor));
+}
+
 /// The `trustPolicyExcludePrune` counterpart of
 /// [`prunes_the_minimum_release_age_excludes`], over `trustPolicyExclude`.
 #[test]

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -2273,11 +2273,11 @@ pub struct Config {
     /// [`minimum_release_age`]: Self::minimum_release_age
     pub minimum_release_age_exclude: Option<Vec<String>>,
 
-    /// When `true`, `add` / `remove` / `update` prune
-    /// [`Self::minimum_release_age_exclude`] entries in
-    /// `pnpm-workspace.yaml` whose versions the freshly resolved
-    /// lockfile no longer records, once the install has written that
-    /// lockfile. The `minimumReleaseAgeExcludePrune` setting;
+    /// When `true`, the resolving commands (`install`, `dedupe`, `add`,
+    /// `remove`, `update`) prune [`Self::minimum_release_age_exclude`]
+    /// entries in `pnpm-workspace.yaml` whose versions the freshly
+    /// resolved lockfile no longer records, once the install has written
+    /// that lockfile. The `minimumReleaseAgeExcludePrune` setting;
     /// default `false`, matching pnpm.
     pub minimum_release_age_exclude_prune: bool,
 
@@ -2402,9 +2402,9 @@ pub struct Config {
     /// [`trust_policy`]: Self::trust_policy
     pub trust_policy_exclude: Option<Vec<String>>,
 
-    /// When `true`, `add` / `remove` / `update` prune
-    /// [`Self::trust_policy_exclude`] entries in
-    /// `pnpm-workspace.yaml` whose versions the freshly resolved
+    /// When `true`, the resolving commands (`install`, `dedupe`, `add`,
+    /// `remove`, `update`) prune [`Self::trust_policy_exclude`] entries
+    /// in `pnpm-workspace.yaml` whose versions the freshly resolved
     /// lockfile no longer records, once the install has written that
     /// lockfile. The `trustPolicyExcludePrune` setting; default
     /// `false`, matching pnpm.

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -881,6 +881,11 @@ pub enum InstallError {
         #[error(source)] pnpm_workspace_manifest_writer::UpdateWorkspaceManifestError,
     ),
 
+    /// Surfaces a failure from post-install pruning of policy and build
+    /// entries in `pnpm-workspace.yaml`.
+    #[diagnostic(transparent)]
+    WriteWorkspaceManifest(#[error(source)] crate::catalog_cleanup::WriteWorkspaceCatalogsError),
+
     /// Surfaces a failure to persist `node_modules/.package-map.json`,
     /// the package-map metadata Node consumes when the user opts into
     /// `--experimental-package-map`.

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -505,7 +505,9 @@ where
     /// the user-facing resolving commands (`install`, `add`, `update` with
     /// `--save`, `dedupe`); `false` for embedder-driven installs and every
     /// command that must not touch the workspace manifest. Ignored on the
-    /// frozen path, which resolves nothing.
+    /// frozen path, which resolves nothing. The same permission gates the
+    /// post-run prune of that manifest's exclude lists
+    /// (`minimumReleaseAgeExcludePrune` / `trustPolicyExcludePrune`).
     pub persist_policy_excludes: bool,
     /// Which lockfile pins to withhold from the preferred-versions seed.
     /// [`UpdateSeedPolicy::KeepAll`] for `install` / `add`; the `DropAll`

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -20,6 +20,8 @@ use pnpm_config::Config;
 use pnpm_executor::DEV_PREINSTALL_STAGE;
 use pnpm_store_dir::VerifiedFileIntegrity;
 
+use crate::catalog_cleanup::post_install_prune;
+
 impl<'a, DependencyGroupList> Install<'a, DependencyGroupList>
 where
     DependencyGroupList: IntoIterator<Item = DependencyGroup>,
@@ -226,6 +228,7 @@ where
         })
         .await?;
 
+        let workspace_manifest_dir = workspace.workspace_manifest_dir.clone();
         apply_materialization_result::<Reporter>(ApplyMaterializationInputs {
             materialized: materialized.materialized,
             resolve_only: mode.resolve_only,
@@ -261,6 +264,17 @@ where
             catalogs: workspace.catalogs,
         })
         .await?;
+
+        if install.config.lockfile
+            && options.save_lockfile
+            && !options.lockfile_check
+            && !install.dry_run
+            && (install.config.minimum_release_age_exclude_prune
+                || install.config.trust_policy_exclude_prune)
+        {
+            post_install_prune(install.config, Some(&workspace_manifest_dir), install.manifest)
+                .map_err(InstallError::WriteWorkspaceManifest)?;
+        }
 
         // Only now wait out the store-index writer's teardown — its
         // final flush and the WAL checkpoint `SQLite` runs when the

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -20,18 +20,20 @@ use pnpm_config::Config;
 use pnpm_executor::DEV_PREINSTALL_STAGE;
 use pnpm_store_dir::VerifiedFileIntegrity;
 
-use crate::catalog_cleanup::post_install_prune;
+use crate::{ProjectMutation, catalog_cleanup::post_install_prune};
 
 impl<'a, DependencyGroupList> Install<'a, DependencyGroupList>
 where
     DependencyGroupList: IntoIterator<Item = DependencyGroup>,
 {
-    /// Runs the install, then deletes the per-branch lockfiles it has
-    /// just folded into the wanted lockfile.
+    /// Runs the install, then the passes over what it wrote: deleting the
+    /// per-branch lockfiles it has just folded into the wanted lockfile,
+    /// and pruning the `pnpm-workspace.yaml` exclude entries that lockfile
+    /// no longer resolves.
     ///
-    /// The cleanup lives out here because every success path of
+    /// Both live out here because every success path of
     /// [`Self::run_inner_impl`] — including the short-circuits that do
-    /// nothing but rewrite the lockfile — has to leave them gone.
+    /// nothing but rewrite the lockfile — has to run them.
     pub(super) async fn run_inner<Reporter: self::Reporter + 'static>(
         self,
         options: InstallRunOptions<'a, '_>,
@@ -53,12 +55,39 @@ where
                 lockfile_root_dir(self.config, manifest_dir).map_err(InstallError::FindWorkspaceDir)
             })
             .transpose()?;
-        Box::pin(self.run_inner_impl::<Reporter>(options)).await?;
+        let prune_excludes = self.prunes_workspace_excludes(&options);
+        let (config, manifest) = (self.config, self.manifest);
+        let outcome = Box::pin(self.run_inner_impl::<Reporter>(options)).await?;
         if let Some(lockfile_dir) = branch_lockfiles_to_clean {
             Lockfile::clean_git_branch_lockfiles(&lockfile_dir)
                 .map_err(InstallError::CleanGitBranchLockfiles)?;
         }
+        if prune_excludes
+            && let InstallRunOutcome::LockfileSettled { workspace_manifest_dir } = outcome
+        {
+            post_install_prune(config, Some(&workspace_manifest_dir), manifest)
+                .map_err(InstallError::WriteWorkspaceManifest)?;
+        }
         Ok(())
+    }
+
+    /// Whether this run owes the [`post_install_prune`] pass over the
+    /// `minimumReleaseAgeExclude` / `trustPolicyExclude` lists. `add`,
+    /// `update` and `remove` run it themselves once their manifest edits
+    /// are persisted; the whole-workspace commands (`install`, `dedupe`)
+    /// have only this run to do it. It reads the lockfile back from disk,
+    /// so the gates of the branch-lockfile cleanup apply: a run that
+    /// leaves the lockfile untouched, has it restored afterwards, or only
+    /// reports gives it nothing new to see.
+    fn prunes_workspace_excludes(&self, options: &InstallRunOptions<'_, '_>) -> bool {
+        self.persist_policy_excludes
+            && matches!(self.mutation, ProjectMutation::InstallWorkspace)
+            && self.config.lockfile
+            && options.save_lockfile
+            && !options.lockfile_check
+            && !self.dry_run
+            && (self.config.minimum_release_age_exclude_prune
+                || self.config.trust_policy_exclude_prune)
     }
 
     /// Separate what every phase reads from what one of them consumes.
@@ -107,7 +136,7 @@ where
     async fn run_inner_impl<Reporter: self::Reporter + 'static>(
         self,
         mut options: InstallRunOptions<'a, '_>,
-    ) -> Result<(), InstallError> {
+    ) -> Result<InstallRunOutcome, InstallError> {
         let (install, mut owned) = self.split();
         install.http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
         owned.http_client_arc.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
@@ -128,7 +157,7 @@ where
                 level: LogLevel::Debug,
                 prefix: workspace.prefix,
             }));
-            return Ok(());
+            return Ok(InstallRunOutcome::AlreadyUpToDate);
         }
         let loaded = load_lockfiles::<Reporter>(
             install,
@@ -173,7 +202,9 @@ where
         )
         .await?
         else {
-            return Ok(());
+            return Ok(InstallRunOutcome::LockfileSettled {
+                workspace_manifest_dir: workspace.workspace_manifest_dir,
+            });
         };
 
         let materialized = materialize::<Reporter>(MaterializationInputs {
@@ -265,17 +296,6 @@ where
         })
         .await?;
 
-        if install.config.lockfile
-            && options.save_lockfile
-            && !options.lockfile_check
-            && !install.dry_run
-            && (install.config.minimum_release_age_exclude_prune
-                || install.config.trust_policy_exclude_prune)
-        {
-            post_install_prune(install.config, Some(&workspace_manifest_dir), install.manifest)
-                .map_err(InstallError::WriteWorkspaceManifest)?;
-        }
-
         // Only now wait out the store-index writer's teardown — its
         // final flush and the WAL checkpoint `SQLite` runs when the
         // connection closes (~40 ms of otherwise pure tail on a cold
@@ -289,8 +309,19 @@ where
             "; some rows may not be persisted",
         )
         .await;
-        Ok(())
+        Ok(InstallRunOutcome::LockfileSettled { workspace_manifest_dir })
     }
+}
+
+/// How far [`Install::run_inner_impl`] got, for the passes
+/// [`Install::run_inner`] runs over what it wrote.
+enum InstallRunOutcome {
+    /// The repeat-install fast path found nothing to do; no file changed.
+    AlreadyUpToDate,
+    /// The run settled the wanted lockfile, rewriting it wherever it had
+    /// drifted, so the exclude lists in `pnpm-workspace.yaml` under
+    /// `workspace_manifest_dir` may now name versions nothing resolves.
+    LockfileSettled { workspace_manifest_dir: PathBuf },
 }
 
 /// The install's borrowed and `Copy` inputs, as one value every phase reads.


### PR DESCRIPTION
## Summary

`pnpm install` and `pnpm dedupe` now run the same `minimumReleaseAgeExcludePrune` / `trustPolicyExcludePrune` pass that `add`, `update`, and `remove` already run, so stale `minimumReleaseAgeExclude` entries are removed whenever an install rewrites the lockfile.

Fixes pnpm/pnpm#14759.

## Squash Commit Body

```text
Run the workspace manifest prune pass after every install that writes the lockfile.

The pass lives in Install::run_inner, the hook every success path of the install driver returns through, because the frozen --lockfile-only finisher rewrites the lockfile after the fast update absorbs a removed dependency and returns before materialization. run_inner_impl reports an InstallRunOutcome so the repeat-install short-circuit, which writes nothing, skips the lockfile re-read. The pass runs only for whole-workspace runs that may touch the workspace manifest: add, update and remove run it themselves after the install.

Adds pacquet integration regressions for install, dedupe, and a removed dependency for pnpm/pnpm#14759.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

AI assistance was used to prepare this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791603815&installation_model_id=426870&pr_number=14761&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14761&signature=02390af719cc9b0c0fedcabafc1a7e14d942aa01173c097750620995e6319035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm install` and `pnpm dedupe` now remove stale `minimumReleaseAgeExclude` and `trustPolicyExclude` entries when pruning is enabled.
  * Workspace manifests are cleaned up after eligible installations, removing outdated policy and build entries.
  * Improved error reporting when workspace manifest cleanup cannot be completed.

* **Documentation**
  * Updated configuration documentation to include all supported commands that can prune exclusion entries.

* **Tests**
  * Added coverage for pruning outdated and unused package exclusions when dependency resolutions change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
