### PR TITLE
refactor(deps-restorer): keep the frozen install's git source cache in its plan

### DIFF
--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
@@ -351,7 +351,6 @@ impl<'a> InstallFrozenLockfile<'a> {
             )
             .await?;
 
-        let git_source_cache = pnpm_git_fetcher::GitSourceCache::default();
         let ctx = crate::InstallContext {
             config: self.config,
             workspace_root: self.workspace_root,
@@ -361,7 +360,7 @@ impl<'a> InstallFrozenLockfile<'a> {
             allow_build_policy: &allow_build_policy,
             link_options: &plan.link_options,
             logged_methods: self.logged_methods,
-            git_source_cache: &git_source_cache,
+            git_source_cache: &plan.git_source_cache,
         };
 
         // Spawn the batched store-index writer here so it lives
@@ -919,6 +918,7 @@ impl<'a> InstallFrozenLockfile<'a> {
                 layout,
                 dir_clone_cache,
                 cas_prefetch,
+                git_source_cache: pnpm_git_fetcher::GitSourceCache::default(),
             })
         }
     }
@@ -1002,6 +1002,7 @@ struct MaterializationPlan<'p> {
     /// Borrows the allow-builds policy `run` owns.
     dir_clone_cache: Option<crate::DirCloneCache<'p>>,
     cas_prefetch: crate::create_virtual_store::CasPrefetch,
+    git_source_cache: pnpm_git_fetcher::GitSourceCache,
 }
 
 /// The install's borrowed inputs, as one `Copy` value a phase's future


### PR DESCRIPTION
## Summary

`Rust CI / Dylint` fails on main since pnpm/pnpm#14727 landed on top of pnpm/pnpm#14760: `InstallFrozenLockfile::run` binds 13 local names, one over the cap `perfectionist::too_many_local_bindings` now enforces. The extra binding is the install-scoped `GitSourceCache` the frozen path creates before building its `InstallContext`.

The materialization plan already owns the layout and link options the context borrows, so the cache now lives there as well, and `run` borrows it from the plan like the others. No behavior changes.

Failing job: https://github.com/pnpm/pnpm/actions/runs/34444432855/job/102766119385

Verified with a freshly built perfectionist library at the pinned revision: `cargo dylint --all -- --all-targets --workspace` reports the failure on main's version of the file and passes with this change. `pnpm-deps-restorer` unit tests (469) and the CLI `git_hosted_install` suite (26) pass.

## Squash Commit Body

```text
`InstallFrozenLockfile::run` bound the install-scoped git source cache
as its own local, which put the method one binding over the cap that
main enforces since pnpm/pnpm#14760. The materialization plan already
owns the layout and link options the install context borrows, so the
cache lives there too.

Fixes the `Rust CI / Dylint` failure on main introduced by
pnpm/pnpm#14727.
```

## Checklist

- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Not needed: internal refactor with no user-visible change.
- [x] Added or updated tests. Not needed: the lint gate is the test.

---
Written by an agent (Claude Code, claude-fable-5-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKhjCP4gc5tkVkPVqg4gZi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791613529&installation_model_id=426870&pr_number=14763&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14763&signature=7ee4654639ec60c11b727560db23f35e2266fd4cf8ceedd120f086fdc45f9cbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated frozen lockfile installation to reuse Git source cache information from the materialization plan.
  * No user-visible behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->