### PR TITLE
fix(cli): suggest negated frozen lockfile flag

### DIFF
--- a/.changeset/frozen-lockfile-error-hint.md
+++ b/.changeset/frozen-lockfile-error-hint.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install --frozen-lockfile false` now suggests using `--no-frozen-lockfile` in its error message [#14741](https://github.com/pnpm/pnpm/issues/14741).

--- a/pnpm/crates/cli/src/install_as_add.rs
+++ b/pnpm/crates/cli/src/install_as_add.rs
@@ -16,8 +16,15 @@
 //! [`relocate_pre_subcommand_flags`]: crate::flag_relocation::relocate_pre_subcommand_flags
 //! [`subcommand_option_names`]: crate::parse_boundary::subcommand_option_names
 
-use crate::flag_relocation::{ArgTable, PositionalScan, find_positional, scan_for_positional};
-use clap::Command;
+use crate::{
+    cli_args::grammar,
+    flag_relocation::{ArgTable, PositionalScan, find_positional, scan_for_positional},
+    parse_boundary::{option_width, union_arity},
+};
+use clap::{
+    Command,
+    error::{ContextKind, ContextValue, ErrorKind},
+};
 use std::ffi::OsString;
 
 /// Rewrite the `install` subcommand token to `add` when a package name
@@ -48,6 +55,38 @@ pub(crate) fn rewrite(cmd: &Command, mut argv: Vec<OsString>) -> Vec<OsString> {
     }
     argv[subcommand_index] = OsString::from("add");
     argv
+}
+
+pub(crate) fn suggest_no_frozen_lockfile(argv: &[OsString], error: &mut clap::Error) {
+    if error.kind() != ErrorKind::UnknownArgument
+        || !matches!(error.get(ContextKind::InvalidArg), Some(ContextValue::String(arg)) if arg == "--frozen-lockfile")
+    {
+        return;
+    }
+    let command = grammar();
+    let arity = union_arity();
+    let Some(subcommand_index) = find_positional(argv, 1, arity, arity) else {
+        return;
+    };
+    if command
+        .find_subcommand(&argv[subcommand_index])
+        .is_none_or(|subcommand| subcommand.get_name() != "install")
+    {
+        return;
+    }
+    let mut index = subcommand_index + 1;
+    while let Some(token) = argv.get(index).and_then(|token| token.to_str()) {
+        if token == "--" {
+            break;
+        }
+        let next = argv.get(index + 1).and_then(|token| token.to_str());
+        if token == "--frozen-lockfile" && next == Some("false") {
+            let hint = "to disable frozen-lockfile mode, use '--no-frozen-lockfile' instead of '--frozen-lockfile false'".into();
+            error.insert(ContextKind::Suggested, ContextValue::StyledStrs(vec![hint]));
+            break;
+        }
+        index += option_width(token, next, arity).unwrap_or(1);
+    }
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -134,14 +134,7 @@ fn run_cli() -> miette::Result<()> {
     // options written before the subcommand to after it so clap agrees.
     // See `flag_relocation`.
     let argv = relocate_pre_subcommand_flags(&command, argv);
-    // `pnpm install <pkg>` is pnpm's spelling of `pnpm add <pkg>`; clap's
-    // `install` takes no package name, so rename the subcommand token.
-    // See `install_as_add`.
-    let argv = install_as_add::rewrite(&command, argv);
-    // A command whose arguments begin at a `--` would otherwise lose it to
-    // clap's escape handling. See `leading_separator`.
-    let argv = leading_separator::preserve_leading_separator(argv);
-    let mut args = match parse_cli_args(command, argv.clone()) {
+    let mut args = match parse_cli_args(command, &argv) {
         Ok(args) => args,
         Err(err) if err.kind() == clap::error::ErrorKind::DisplayVersion => {
             return print_version(&argv, &child_argv, &config_overrides);
@@ -189,12 +182,21 @@ fn run_cli() -> miette::Result<()> {
 }
 
 /// Parse argv, recording whether `--dir` came from the command line.
-fn parse_cli_args(command: clap::Command, argv: Vec<OsString>) -> Result<CliArgs, clap::Error> {
-    command.try_get_matches_from(argv).and_then(|matches| {
-        let dir_from_command_line =
-            matches.value_source("dir") == Some(clap::parser::ValueSource::CommandLine);
-        CliArgs::from_arg_matches(&matches).map(|args| CliArgs { dir_from_command_line, ..args })
-    })
+fn parse_cli_args(command: clap::Command, argv: &[OsString]) -> Result<CliArgs, clap::Error> {
+    let parsed_argv = install_as_add::rewrite(&command, argv.to_vec());
+    let parsed_argv = leading_separator::preserve_leading_separator(parsed_argv);
+    command
+        .try_get_matches_from(parsed_argv)
+        .map_err(|mut error| {
+            install_as_add::suggest_no_frozen_lockfile(argv, &mut error);
+            error
+        })
+        .and_then(|matches| {
+            let dir_from_command_line =
+                matches.value_source("dir") == Some(clap::parser::ValueSource::CommandLine);
+            CliArgs::from_arg_matches(&matches)
+                .map(|args| CliArgs { dir_from_command_line, ..args })
+        })
 }
 
 /// pnpm prints the bare version, not clap's `pnpm <version>` rendering —

--- a/pnpm/crates/cli/tests/suite/install.rs
+++ b/pnpm/crates/cli/tests/suite/install.rs
@@ -2153,6 +2153,45 @@ fn frozen_lockfile_accepts_a_peer_package_extensions_injected() {
 }
 
 #[test]
+fn frozen_lockfile_false_suggests_the_negated_flag() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    for args in [
+        &["install", "--frozen-lockfile", "false"][..],
+        &["i", "--frozen-lockfile", "false"],
+        &["install", "--offline", "--frozen-lockfile", "false"],
+    ] {
+        let assertion = new_pacquet_command(&workspace).with_args(args).assert().failure();
+        let stderr = String::from_utf8_lossy(&assertion.get_output().stderr);
+        eprintln!("{args:?}:\n{stderr}");
+        assert!(stderr.contains("unexpected argument '--frozen-lockfile' found"));
+        assert!(stderr.contains("use '--no-frozen-lockfile' instead of '--frozen-lockfile false'"));
+    }
+    drop(root);
+}
+
+#[test]
+fn unrelated_parse_errors_do_not_suggest_no_frozen_lockfile() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    for args in [
+        &["install", "--frozen-lockfile", "true"][..],
+        &["add", "--frozen-lockfile", "false"],
+        &["--frozen-lockfile", "false", "install"],
+        &["install", "--unknown-option", "--frozen-lockfile", "false"],
+        &["install", "--filter", "--frozen-lockfile", "false"],
+    ] {
+        let assertion = new_pacquet_command(&workspace).with_args(args).assert().failure();
+        let stderr = String::from_utf8_lossy(&assertion.get_output().stderr);
+        eprintln!("{args:?}:\n{stderr}");
+        assert!(!stderr.contains("to disable frozen-lockfile mode"));
+    }
+    new_pacquet_command(&workspace)
+        .with_args(["install", "--help", "--frozen-lockfile", "false"])
+        .assert()
+        .success();
+    drop(root);
+}
+
+#[test]
 fn frozen_lockfile_setting_drives_the_headless_install() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();


### PR DESCRIPTION
## Summary

`pnpm install --frozen-lockfile false` now includes a tip telling users to use `--no-frozen-lockfile`. The unsupported syntax still fails. The hint applies to the reported install invocation and its aliases, without changing accepted arguments or unrelated parse errors.

The GitHub v12.0.0 release page has been updated with the migration guidance. Companion pnpm.io documentation: https://github.com/pnpm/pnpm.io/pull/924. Closes pnpm/pnpm#14741.

Validation: the full Rust suite passed all 10,951 tests. The focused diagnostic tests, workspace check, formatting, spelling, and workspace Clippy checks passed.

## Squash Commit Body

```text
Add a migration hint when an install invocation rejects
--frozen-lockfile false. The existing install-to-add rewrite treats
false as a package name, so clap reports --frozen-lockfile as unknown.

Retain the argv before that rewrite until parsing finishes so the error
can distinguish install from an explicit add invocation. Reuse the
argument-width scan to avoid interpreting option values as flags, and
attach the hint through clap's error context only on the matching error.
The successful parse path retains the same argument transformations and
number of argv copies.

Keep the parsing rules unchanged. pnpm v11 already accepts this syntax;
only pnpm v12 needs the diagnostic. Document the supported replacement
on the v12.0.0 release page.

Closes pnpm/pnpm#14741.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-6).
