### PR TITLE
fix(fs): normalize relative symlink paths

### DIFF
--- a/.changeset/fix-parent-workspace-links.md
+++ b/.changeset/fix-parent-workspace-links.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed dangling dependency links in workspace packages located above the workspace root [pnpm/pnpm#14726](https://github.com/pnpm/pnpm/issues/14726).

--- a/pnpm/crates/cli/tests/suite/workspace_install.rs
+++ b/pnpm/crates/cli/tests/suite/workspace_install.rs
@@ -74,6 +74,64 @@ fn assert_frozen_outdated(workspace: &Path) {
 }
 
 #[test]
+fn workspace_links_above_root_resolve() {
+    for (workspace_depth, node_linker) in [
+        ("app", "isolated"),
+        ("app", "hoisted"),
+        ("apps/desktop", "isolated"),
+        ("apps/desktop", "hoisted"),
+    ] {
+        assert_workspace_links_above_root_resolve(workspace_depth, node_linker);
+    }
+}
+
+fn assert_workspace_links_above_root_resolve(workspace_depth: &str, node_linker: &str) {
+    use _utils::{ManifestDeps, pacquet_in, write_project_manifest};
+
+    let fixture = CommandTempCwd::init();
+    let workspace = fixture.workspace.join(workspace_depth);
+    let libs = fixture.workspace.join("libs");
+    write_project_manifest(&workspace, "app", ManifestDeps::default());
+    write_project_manifest(
+        &libs.join("a"),
+        "a",
+        ManifestDeps {
+            prod: &[("b", "workspace:*"), ("@scope/c", "workspace:*")],
+            ..ManifestDeps::default()
+        },
+    );
+    for (dir, name) in [("b", "b"), ("c", "@scope/c")] {
+        write_project_manifest(&libs.join(dir), name, ManifestDeps::default());
+    }
+    let pattern = if workspace_depth == "app" { "../libs/*" } else { "../../libs/*" };
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        format!(
+            "packages: ['{pattern}']\nnodeLinker: {node_linker}\noffline: true\n\
+             enableGlobalVirtualStore: false\n",
+        ),
+    )
+    .unwrap();
+
+    for args in [vec!["install"], vec!["install", "--frozen-lockfile"], vec!["install", "--force"]]
+    {
+        pacquet_in(&workspace).with_args(args).assert().success();
+        for (alias, relative_target) in [("b", "../../b"), ("@scope/c", "../../../c")] {
+            let link = libs.join("a/node_modules").join(alias);
+            assert_eq!(
+                fs::canonicalize(&link).unwrap_or_else(|error| panic!("{link:?}: {error}")),
+                fs::canonicalize(link.parent().unwrap().join(relative_target)).unwrap(),
+            );
+            #[cfg(unix)]
+            assert_eq!(fs::read_link(&link).unwrap(), Path::new(relative_target));
+        }
+        for dir in [workspace.join("node_modules"), libs.join("a/node_modules")] {
+            fs::remove_dir_all(dir).unwrap();
+        }
+    }
+}
+
+#[test]
 fn normalized_workspace_patterns_select_install_list_and_script_projects() {
     let manifest = |name: &str, dependency: &str| {
         serde_json::json!({

--- a/pnpm/crates/fs/src/lexical_normalize.rs
+++ b/pnpm/crates/fs/src/lexical_normalize.rs
@@ -87,7 +87,7 @@ fn normalize_components<'path>(
                 Some(Component::Normal(_)) => {
                     kept.pop();
                 }
-                Some(Component::RootDir | Component::Prefix(_)) => {}
+                Some(Component::RootDir) => {}
                 _ => kept.push(Component::ParentDir),
             },
             Component::CurDir => {}

--- a/pnpm/crates/fs/src/lexical_normalize/tests.rs
+++ b/pnpm/crates/fs/src/lexical_normalize/tests.rs
@@ -75,6 +75,33 @@ fn keeps_windows_prefixes() {
 }
 
 #[test]
+#[cfg_attr(not(windows), ignore = "Windows path semantics")]
+fn preserves_parent_components_after_drive_relative_prefixes() {
+    for (path, expected) in [
+        (r"C:..\target", r"C:..\target"),
+        (r"C:foo\..\..\target", r"C:..\target"),
+        (r"C:..\..\target", r"C:..\..\target"),
+        (r"C:\..\target", r"C:\target"),
+        (r"\\server\share\..\target", r"\\server\share\target"),
+    ] {
+        assert_eq!(lexical_normalize(Path::new(path)), Path::new(expected));
+    }
+}
+
+#[test]
+#[cfg_attr(not(windows), ignore = "Windows path semantics")]
+fn relative_paths_preserve_drive_relative_parent_traversal() {
+    assert_eq!(
+        crate::relative_path(Path::new(r"C:project\node_modules"), Path::new(r"C:..\target")),
+        Path::new(r"..\..\..\target"),
+    );
+    assert_eq!(
+        crate::relative_path(Path::new(r"C:project\..\node_modules"), Path::new(r"C:..\target")),
+        Path::new(r"..\..\target"),
+    );
+}
+
+#[test]
 fn posix_normalization_preserves_relative_roots_and_trailing_slashes() {
     for (path, expected) in [
         ("", "."),

--- a/pnpm/crates/fs/src/relative_path.rs
+++ b/pnpm/crates/fs/src/relative_path.rs
@@ -4,13 +4,14 @@ use std::path::{Path, PathBuf};
 /// `path.relative(base, path)`: the shortest relative path when the two
 /// share a filesystem root, otherwise the absolute `path` (Node likewise
 /// returns the absolute target when the inputs cannot be related).
+/// Both inputs are normalized lexically before computing the difference.
 ///
 /// On Windows the two `Prefix` components must match (drive letters
 /// case-folded) before diffing; without that guard [`pathdiff::diff_paths`]
 /// emits a re-anchored garbage path across drives or UNC shares.
 #[must_use]
 pub fn relative_path(base: &Path, path: &Path) -> PathBuf {
-    relative_path_inner(base, path)
+    relative_path_inner(&crate::lexical_normalize(base), &crate::lexical_normalize(path))
 }
 
 #[cfg(windows)]

--- a/pnpm/crates/fs/src/symlink_dir/tests.rs
+++ b/pnpm/crates/fs/src/symlink_dir/tests.rs
@@ -35,6 +35,25 @@ fn unix_symlink_contents_are_relative_to_link_parent() {
 }
 
 #[test]
+fn force_symlink_dir_resolves_parent_components_in_link_and_target() {
+    let root = tempdir().expect("create temp dir");
+    let workspace = root.path().join("apps/desktop");
+    fs::create_dir_all(&workspace).unwrap();
+    let target = root.path().join("libs/b");
+    let link = workspace.join("../../libs/a/node_modules/b");
+    fs::create_dir_all(&target).unwrap();
+
+    force_symlink_dir(&target, &link).unwrap();
+
+    assert_eq!(fs::canonicalize(&link).unwrap(), fs::canonicalize(&target).unwrap());
+    #[cfg(unix)]
+    assert_eq!(fs::read_link(&link).unwrap(), std::path::Path::new("../../b"));
+    let outcome = force_symlink_dir(&workspace.join("../../libs/b"), &link).unwrap();
+    eprintln!("reuse outcome: {outcome:?}");
+    assert!(outcome.reused);
+}
+
+#[test]
 fn force_symlink_dir_returns_reused_when_already_pointing_at_target() {
     let root = tempdir().expect("create temp dir");
     let target = root.path().join("real");


### PR DESCRIPTION
## Summary

Fix dangling dependency symlinks when workspace members live above the workspace root, such as `packages: ['../libs/*']`. The relative-path helper now normalizes both inputs before computing the link target.

Closes pnpm/pnpm#14726.

Validation: `just ready` passed, including all 10,951 tests, formatting, build checks, spelling, and Clippy.

This affects pnpm v12 only. The v11 symlink helper already uses Node's normalizing `path.relative`; its equivalent fixture produces a resolving `../../b` link. The peer-snapshot reports pnpm/pnpm#14714 and pnpm/pnpm#14764 concern a separate resolution path.

## Squash Commit Body

```text
Parent-relative importer IDs reach the symlink writer as joined paths
containing unresolved parent components. pathdiff counts those components
as directory levels, producing too many parent traversals in the link.

Normalize both inputs in pnpm-fs's relative_path helper using the existing
lexical_normalize utility. This requires no filesystem lookup and preserves
the Windows cross-root fallback. Preserve leading parent traversal after a
Windows drive-relative prefix; only an actual root suppresses it. Add Windows
regressions for both lexical normalization and relative-path calculation.

Cover link creation and reuse at the filesystem layer, plus fresh, frozen,
and forced CLI installs with isolated and hoisted layouts, two workspace
root depths, and scoped and unscoped dependencies. Both new regressions
failed before the fix and passed afterward.

Closes pnpm/pnpm#14726.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed workspace dependency links for packages located above the workspace root.
  - Workspace packages now resolve and symlink correctly across supported installation modes.
  - Improved handling of relative paths containing parent-directory components.
  - Reusing equivalent normalized symlink targets now works reliably.
  - Improved path handling on Windows, including drive-relative and UNC paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->