### PR TITLE
perf(deps-restorer): verify store files only for the snapshots a frozen install materializes

### DIFF
--- a/.changeset/lazy-store-verification.md
+++ b/.changeset/lazy-store-verification.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` now checks the store's files only for the packages it links into `node_modules`. A warm restore of a workspace using the global virtual store no longer stats every file of every package in the lockfile before skipping the slots that already exist [#14540](https://github.com/pnpm/pnpm/issues/14540).

--- a/pnpm/crates/deps-restorer/src/create_virtual_store.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store.rs
@@ -23,10 +23,13 @@ use pnpm_reporter::{
     LogEvent, LogLevel, ProgressLog, ProgressMessage, Reporter, StatsLog, StatsMessage,
 };
 use pnpm_store_dir::{
-    SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter,
+    SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreDir, StoreIndex, StoreIndexWriter,
     store_index_key,
 };
-use pnpm_tarball::{MemCache, PrefetchResult, SharedReportedProgressKeys, prefetch_cas_paths};
+use pnpm_tarball::{
+    MemCache, PrefetchIntegrityCheck, PrefetchResult, SharedReportedProgressKeys,
+    prefetch_cas_paths,
+};
 use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
@@ -157,11 +160,16 @@ impl CasPrefetch {
                 Arc::clone(context.verified_files_cache)
             });
         let cache_keys = derive_cache_keys(config, entries, supported_architectures);
+        // The files check waits for the plan: only the snapshots this
+        // run materializes have their CAFS files stat'd, in
+        // `CreateVirtualStore::settle_prefetch`. Under a global virtual
+        // store or an unchanged lockfile that is few or none of the rows
+        // read here.
         let task = tokio::spawn(prefetch_cas_paths(
             store_index.clone(),
             store_dir,
             prefetch_keys(&cache_keys),
-            config.verify_store_integrity,
+            PrefetchIntegrityCheck::deferred_if(config.verify_store_integrity),
             SharedVerifiedFilesCache::clone(&verified_files_cache),
         ));
         CasPrefetch { store_index, verified_files_cache, cache_keys, task }
@@ -370,7 +378,14 @@ impl<'a> CreateVirtualStore<'a> {
         let prefetch = self.prefetch(wanted).await;
         let marker_source = self.prepare_store().await?;
         let mut plan = self.plan::<Reporter>(wanted, prefetch.cache_keys)?;
-        let prefetched = self.settle_prefetch(prefetch.task, wanted.packages, &mut plan).await?;
+        let prefetched = self
+            .settle_prefetch(
+                prefetch.task,
+                &prefetch.verified_files_cache,
+                wanted.packages,
+                &mut plan,
+            )
+            .await?;
         let mut partition = partition::partition_snapshots(
             &plan.survivors,
             &plan.skipped_entries,
@@ -533,10 +548,11 @@ impl<'a> CreateVirtualStore<'a> {
     async fn settle_prefetch(
         &self,
         task: tokio::task::JoinHandle<PrefetchResult>,
+        verified_files_cache: &SharedVerifiedFilesCache,
         packages: &HashMap<PackageKey, PackageMetadata>,
         plan: &mut snapshot_plan::SnapshotPlan<'_>,
     ) -> Result<PrefetchResult, CreateVirtualStoreError> {
-        let prefetch = task.await.unwrap_or_else(|error| {
+        let prefetched = task.await.unwrap_or_else(|error| {
             tracing::warn!(
                 target: "pacquet::install",
                 ?error,
@@ -544,15 +560,73 @@ impl<'a> CreateVirtualStore<'a> {
             );
             PrefetchResult::default()
         });
+        let prefetched = self.verify_imported_rows(prefetched, verified_files_cache, plan).await;
         enforce_cached_git_prepare_policy(
             &mut plan.survivors,
             packages,
-            &prefetch,
+            &prefetched,
             self.ctx.allow_build_policy,
             self.ctx.config.ignore_scripts,
             plan.has_git_hosted_survivor,
         )?;
-        Ok(prefetch)
+        Ok(prefetched)
+    }
+
+    /// Run the files checks the prefetch deferred for the rows whose
+    /// files this install may import: every survivor, and every skipped
+    /// snapshot whose row carries a side-effects overlay, which the
+    /// build phase's cache hit materializes into the slot. A row whose
+    /// CAFS files have gone missing is dropped and re-fetched. The other
+    /// skipped snapshots keep their rows unchecked: nothing imports
+    /// their files, and their manifests and `requiresBuild` flags come
+    /// from the row itself.
+    async fn verify_imported_rows(
+        &self,
+        mut prefetched: PrefetchResult,
+        verified_files_cache: &SharedVerifiedFilesCache,
+        plan: &snapshot_plan::SnapshotPlan<'_>,
+    ) -> PrefetchResult {
+        if prefetched.pending_checks.is_empty() {
+            return prefetched;
+        }
+        let imported_keys: Vec<String> = plan
+            .survivors
+            .iter()
+            .filter_map(|(_, _, cache_key)| cache_key.clone())
+            .chain(
+                plan.skipped_entries
+                    .iter()
+                    .filter_map(|(_, _, cache_key)| cache_key.clone())
+                    .filter(|cache_key| prefetched.side_effects_maps.contains_key(cache_key)),
+            )
+            .collect();
+        let store_dir: &'static StoreDir = &self.ctx.config.store_dir;
+        let verified_files_cache = SharedVerifiedFilesCache::clone(verified_files_cache);
+        tokio::task::spawn_blocking(move || {
+            let verify_start = std::time::Instant::now();
+            let failed = prefetched.verify_rows(
+                imported_keys.iter().map(String::as_str),
+                store_dir,
+                &verified_files_cache,
+            );
+            tracing::debug!(
+                target: "pacquet::download",
+                rows = imported_keys.len(),
+                failed,
+                verify_ms = verify_start.elapsed().as_millis() as u64,
+                "store rows of the imported snapshots verified",
+            );
+            prefetched
+        })
+        .await
+        .unwrap_or_else(|error| {
+            tracing::warn!(
+                target: "pacquet::install",
+                ?error,
+                "store-row verification task failed; treating every lookup as a miss",
+            );
+            PrefetchResult::default()
+        })
     }
 
     fn link_plan(&self, plan: &snapshot_plan::SnapshotPlan<'_>) -> LinkPlan<'a> {

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/tests.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/tests.rs
@@ -355,6 +355,242 @@ async fn shared_store_context_materializes_a_warm_package() {
     assert!(installed_body.is_file(), "warm package must be materialized: {installed_body:?}");
 }
 
+/// A one-package lockfile whose store row and CAS blobs are seeded under
+/// the install's own store, for the warm-restore integrity scenarios.
+struct SeededStoreInstall {
+    _root: tempfile::TempDir,
+    workspace_root: std::path::PathBuf,
+    config: &'static pnpm_config::Config,
+    package_key: PackageKey,
+    snapshots: HashMap<PackageKey, SnapshotEntry>,
+    packages: HashMap<PackageKey, PackageMetadata>,
+    /// The CAS blob of the package's `index.js`.
+    body_blob: std::path::PathBuf,
+}
+
+impl SeededStoreInstall {
+    /// `build_output` is the content of a `build/output.js` a cached
+    /// build added, recorded in the row's side-effects cache under one
+    /// dep-state cache key. `None` seeds a row without a side-effects
+    /// cache.
+    fn new(build_output: Option<&[u8]>) -> Self {
+        use pnpm_config::{Config, PackageImportMethod};
+        use pnpm_store_dir::{
+            CafsFileInfo, PackageFilesIndex, SideEffectsDiff, StoreIndex, store_index_key,
+        };
+
+        let root = tempfile::tempdir().expect("create temp dir");
+        let workspace_root = root.path().join("workspace");
+        fs::create_dir_all(&workspace_root).expect("create workspace root");
+        let modules_dir = workspace_root.join("node_modules");
+
+        let mut config = Config::new();
+        config.registry = "https://registry.test".to_string();
+        config.store_dir = root.path().join("store").into();
+        config.modules_dir = modules_dir.clone();
+        config.virtual_store_dir = modules_dir.join(".pacquet");
+        config.enable_global_virtual_store = true;
+        config.global_virtual_store_dir = root.path().join("links");
+        config.package_import_method = PackageImportMethod::Copy;
+        config.offline = true;
+
+        let package_key = key("seeded", "1.0.0");
+        let mut files = HashMap::new();
+        let mut body_blob = None;
+        for (path, content) in [
+            ("package.json", br#"{"name":"seeded","version":"1.0.0"}"#.as_slice()),
+            ("index.js", b"module.exports = true\n".as_slice()),
+        ] {
+            let (blob, digest) =
+                config.store_dir.write_cas_file(content, false).expect("write package file");
+            if path == "index.js" {
+                body_blob = Some(blob);
+            }
+            files.insert(
+                path.to_string(),
+                CafsFileInfo {
+                    digest: format!("{digest:x}"),
+                    mode: 0o644,
+                    size: content.len() as u64,
+                    checked_at: None,
+                },
+            );
+        }
+        let side_effects = build_output.map(|content| {
+            let (_, digest) =
+                config.store_dir.write_cas_file(content, false).expect("write build output");
+            let added = HashMap::from([(
+                "build/output.js".to_string(),
+                CafsFileInfo {
+                    digest: format!("{digest:x}"),
+                    mode: 0o644,
+                    size: content.len() as u64,
+                    checked_at: None,
+                },
+            )]);
+            HashMap::from([(
+                "linux-x64-node22".to_string(),
+                SideEffectsDiff { added: Some(added), deleted: None, remote_origin: None },
+            )])
+        });
+        StoreIndex::open_in(&config.store_dir)
+            .expect("open store index")
+            .set(
+                &store_index_key(DUMMY_SHA512, &package_key.without_peer().pkg_id()),
+                &PackageFilesIndex {
+                    manifest: None,
+                    requires_build: Some(false),
+                    requires_prepare: None,
+                    algo: "sha512".to_string(),
+                    files,
+                    side_effects,
+                    remote_side_effects_quarantine: None,
+                },
+            )
+            .expect("seed store index");
+
+        SeededStoreInstall {
+            _root: root,
+            workspace_root,
+            config: config.leak(),
+            snapshots: HashMap::from([(package_key.clone(), SnapshotEntry::default())]),
+            packages: HashMap::from([(
+                package_key.without_peer(),
+                metadata_with_integrity(DUMMY_SHA512),
+            )]),
+            package_key,
+            body_blob: body_blob.expect("index.js blob"),
+        }
+    }
+
+    async fn run(&self) -> Result<super::CreateVirtualStoreOutput, super::CreateVirtualStoreError> {
+        use crate::{AllowBuildPolicy, SkippedSnapshots, VirtualStoreLayout};
+        use pnpm_config::NodeLinker;
+        use pnpm_store_dir::StoreIndexWriter;
+        use pnpm_tarball::SharedReportedProgressKeys;
+
+        let allow_build_policy = AllowBuildPolicy::default();
+        let layout = VirtualStoreLayout::new(
+            self.config,
+            Some("linux-x64-node22"),
+            Some(&self.snapshots),
+            Some(&self.packages),
+            Some(&allow_build_policy),
+            None,
+        );
+        let skipped = SkippedSnapshots::new();
+        let logged_methods = AtomicU8::new(0);
+        let progress_reported = SharedReportedProgressKeys::default();
+        let (store_index_writer, writer_task) = StoreIndexWriter::spawn(&self.config.store_dir);
+        let requester = self.workspace_root.to_string_lossy().into_owned();
+
+        let output = CreateVirtualStore {
+            ctx: &crate::InstallContext {
+                config: self.config,
+                workspace_root: &self.workspace_root,
+                requester: &requester,
+                layout: &layout,
+                node_linker: NodeLinker::Isolated,
+                allow_build_policy: &allow_build_policy,
+                link_options: &pnpm_cmd_shim::LinkBinsOptions::default(),
+                logged_methods: &logged_methods,
+                git_source_cache: &pnpm_git_fetcher::GitSourceCache::default(),
+            },
+            http_client: &pnpm_network::ThrottledClient::default(),
+            entries: LockfileEntries {
+                packages: Some(&self.packages),
+                snapshots: Some(&self.snapshots),
+            },
+            current_entries: LockfileEntries::default(),
+            store_index_writer: &store_index_writer,
+            store_context: None,
+            cas_prefetch: None,
+            skipped: &skipped,
+            include_optional_dependencies: true,
+            supported_architectures: None,
+            dir_clone_cache: None,
+            progress_reported: &progress_reported,
+            tarball_mem_cache: None,
+            custom_fetcher_session: None,
+            planned_canonical_fetches: None,
+            link_concurrency_probe: None,
+        }
+        .run::<SilentReporter>()
+        .await;
+
+        drop(store_index_writer);
+        writer_task.await.expect("join store-index writer").expect("flush store-index writer");
+        output
+    }
+}
+
+/// A warm global-virtual-store slot is skipped without its store row's
+/// CAS blobs being checked: nothing imports them, and the row still
+/// feeds the build phase.
+#[tokio::test]
+async fn skipped_warm_slot_keeps_its_store_row_without_checking_cas_blobs() {
+    let install = SeededStoreInstall::new(None);
+    let first = install.run().await.expect("seeded store satisfies the offline install");
+    assert_eq!(first.materialized_snapshots.as_slice(), std::slice::from_ref(&install.package_key));
+
+    fs::remove_file(&install.body_blob).expect("remove the CAS blob behind index.js");
+
+    let second = install.run().await.expect("an existing slot needs no CAS blob");
+    assert!(
+        second.materialized_snapshots.is_empty(),
+        "the slot is current: {:?}",
+        second.materialized_snapshots,
+    );
+    assert_eq!(second.requires_build_by_snapshot.get(&install.package_key), Some(&false));
+}
+
+/// A skipped slot's row is still checked when it carries a side-effects
+/// overlay: the build phase's cache hit imports the overlay's base files
+/// into the slot, so a row whose CAS blob is gone must not reach it.
+#[tokio::test]
+async fn skipped_warm_slot_with_a_side_effects_row_is_still_checked() {
+    let install = SeededStoreInstall::new(Some(b"module.exports = 'built'\n"));
+    let first = install.run().await.expect("seeded store satisfies the offline install");
+    assert_eq!(first.requires_build_by_snapshot.get(&install.package_key), Some(&false));
+    assert!(
+        first.side_effects_maps_by_snapshot.contains_key(&install.package_key),
+        "the seeded side-effects row must reach the build phase while its files verify",
+    );
+
+    fs::remove_file(&install.body_blob).expect("remove the CAS blob behind index.js");
+
+    let second = install.run().await.expect("an existing slot needs no CAS blob");
+    assert!(
+        second.materialized_snapshots.is_empty(),
+        "the slot is current: {:?}",
+        second.materialized_snapshots,
+    );
+    assert!(
+        !second.side_effects_maps_by_snapshot.contains_key(&install.package_key),
+        "a row that failed its files check must not feed the build phase",
+    );
+    assert_eq!(
+        second.requires_build_by_snapshot.get(&install.package_key),
+        None,
+        "a row that failed its files check must be dropped entirely",
+    );
+}
+
+/// A snapshot the install materializes still has its store row
+/// checked, so a row whose CAS blob is gone is re-fetched rather than
+/// imported.
+#[tokio::test]
+async fn materialized_snapshot_with_a_missing_cas_blob_is_refetched() {
+    let install = SeededStoreInstall::new(None);
+    fs::remove_file(&install.body_blob).expect("remove the CAS blob behind index.js");
+
+    let Err(error) = install.run().await else {
+        panic!("offline re-fetch of the missing blob must fail");
+    };
+    let message = error.to_string();
+    assert!(message.contains("offline mode"), "{message}");
+}
+
 /// Under the global virtual store, peer variants hashing to one slot
 /// directory must produce one link task through the whole
 /// [`CreateVirtualStore::run`] pass — the probe's lifetime counter

--- a/pnpm/crates/resolving-tarball-resolver/src/tarball_resolver.rs
+++ b/pnpm/crates/resolving-tarball-resolver/src/tarball_resolver.rs
@@ -14,7 +14,8 @@ use pnpm_store_dir::{
     SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreDir, StoreIndexWriter,
 };
 use pnpm_tarball::{
-    FetchTarballForResolution, MemCache, PrefetchResult, RetryOpts, prefetch_cas_paths,
+    FetchTarballForResolution, MemCache, PrefetchIntegrityCheck, PrefetchResult, RetryOpts,
+    prefetch_cas_paths,
 };
 use ssri::Integrity;
 
@@ -228,7 +229,7 @@ impl TarballResolver {
             ctx.store_index.clone(),
             ctx.store_dir,
             vec![cache_key.clone()],
-            ctx.verify_store_integrity,
+            PrefetchIntegrityCheck::eager_if(ctx.verify_store_integrity),
             Arc::clone(&ctx.verified_files_cache),
         )
         .await;

--- a/pnpm/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/pnpm/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -166,36 +166,7 @@ pub struct VerifyResult {
 /// No stat syscalls — the caller trusts the index, and any missing /
 /// corrupt CAFS file surfaces lazily at import time.
 pub fn build_file_maps_from_index(store_dir: &StoreDir, entry: PackageFilesIndex) -> VerifyResult {
-    let PackageFilesIndex { files, side_effects, remote_side_effects_quarantine, .. } = entry;
-    let mut files_map = HashMap::with_capacity(files.len());
-    let mut passed = true;
-    // Consume `entry.files` so the owned `String` filenames move into
-    // `files_map` without a per-file clone.
-    for (filename, info) in files {
-        let Some(path) = store_dir.cas_file_path_by_mode(&info.digest, info.mode) else {
-            // A malformed digest (non-hex / too short) makes this entry
-            // unreconstructable. pnpm doesn't validate the digest and
-            // would crash at import time; this `None` is a
-            // pacquet-specific guardrail.
-            tracing::debug!(
-                target: "pacquet::store_index",
-                ?filename,
-                digest = %info.digest,
-                "malformed CAFS digest in store-index row; re-fetching",
-            );
-            passed = false;
-            continue;
-        };
-        files_map.insert(filename, path);
-    }
-    let side_effects_maps = build_side_effects_maps(store_dir, side_effects.as_ref(), &files_map);
-    VerifyResult {
-        passed,
-        files_map,
-        side_effects_maps,
-        side_effects,
-        remote_side_effects_quarantine,
-    }
+    defer_pkg_files_integrity(store_dir, entry).0
 }
 
 /// Careful path used when `verify-store-integrity` is `true` (the
@@ -211,45 +182,88 @@ pub fn check_pkg_files_integrity(
     entry: PackageFilesIndex,
     verified_files_cache: &VerifiedFilesCache,
 ) -> VerifyResult {
-    // Destructure so the owned `files` HashMap and `algo` String can be
-    // consumed below, moving the filenames into `files_map` without a
-    // per-file clone on the hot path.
+    let (mut result, pending) = defer_pkg_files_integrity(store_dir, entry);
+    result.passed = pending.verify(store_dir, verified_files_cache) && result.passed;
+    result
+}
+
+/// The maps of [`build_file_maps_from_index`] together with the files
+/// check that would turn them into [`check_pkg_files_integrity`]'s
+/// answer, for a caller that reads many rows but materializes few:
+/// it builds every row's maps here and runs [`PendingFilesCheck::verify`]
+/// only for the rows it goes on to import.
+pub fn defer_pkg_files_integrity(
+    store_dir: &StoreDir,
+    entry: PackageFilesIndex,
+) -> (VerifyResult, PendingFilesCheck) {
     let PackageFilesIndex { files, algo, side_effects, remote_side_effects_quarantine, .. } = entry;
-    let mut all_verified = true;
     let mut files_map = HashMap::with_capacity(files.len());
-    for (filename, info) in files {
+    let mut passed = true;
+    for (filename, info) in &files {
         let Some(path) = store_dir.cas_file_path_by_mode(&info.digest, info.mode) else {
+            // A malformed digest (non-hex / too short) makes this entry
+            // unreconstructable. pnpm doesn't validate the digest and
+            // would crash at import time; this `None` is a
+            // pacquet-specific guardrail.
             tracing::debug!(
                 target: "pacquet::store_index",
                 ?filename,
                 digest = %info.digest,
                 "malformed CAFS digest in store-index row; re-fetching",
             );
-            all_verified = false;
+            passed = false;
             continue;
         };
-        if !verified_files_cache.contains(&path) {
-            if verify_file(&path, &filename, &info, &algo) {
+        files_map.insert(filename.clone(), path);
+    }
+    let side_effects_maps = build_side_effects_maps(store_dir, side_effects.as_ref(), &files_map);
+    let result = VerifyResult {
+        passed,
+        files_map,
+        side_effects_maps,
+        side_effects,
+        remote_side_effects_quarantine,
+    };
+    (result, PendingFilesCheck { files, algo })
+}
+
+/// The on-disk check of one store-index row's files, split off its
+/// map building by [`defer_pkg_files_integrity`].
+#[derive(Debug)]
+pub struct PendingFilesCheck {
+    files: HashMap<String, CafsFileInfo>,
+    algo: String,
+}
+
+impl PendingFilesCheck {
+    /// Whether every file the row records is still on disk with its
+    /// recorded content. A file already in `verified_files_cache` is
+    /// trusted without a stat; one that passes here is added to it.
+    #[must_use]
+    pub fn verify(self, store_dir: &StoreDir, verified_files_cache: &VerifiedFilesCache) -> bool {
+        let mut all_verified = true;
+        for (filename, info) in &self.files {
+            // A malformed digest already failed the row's maps.
+            let Some(path) = store_dir.cas_file_path_by_mode(&info.digest, info.mode) else {
+                all_verified = false;
+                continue;
+            };
+            if verified_files_cache.contains(&path) {
+                continue;
+            }
+            if verify_file(&path, filename, info, &self.algo) {
                 // Concurrency note: another thread may verify the same
                 // path between the `contains` check and our `insert`,
                 // doing the stat twice. That's benign — `verify_file`
                 // is idempotent and the cache converges to the same
                 // state either way. Pnpm's worker_threads cache has
                 // the same race-window for the same reason.
-                verified_files_cache.insert(path.clone());
+                verified_files_cache.insert(path);
             } else {
                 all_verified = false;
             }
         }
-        files_map.insert(filename, path);
-    }
-    let side_effects_maps = build_side_effects_maps(store_dir, side_effects.as_ref(), &files_map);
-    VerifyResult {
-        passed: all_verified,
-        files_map,
-        side_effects_maps,
-        side_effects,
-        remote_side_effects_quarantine,
+        all_verified
     }
 }
 

--- a/pnpm/crates/store-dir/src/check_pkg_files_integrity/tests.rs
+++ b/pnpm/crates/store-dir/src/check_pkg_files_integrity/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     VerifiedFileIntegrity, VerifiedFilesCache, build_file_maps_from_index,
-    check_pkg_files_integrity, package_dir_matches_index,
+    check_pkg_files_integrity, defer_pkg_files_integrity, package_dir_matches_index,
 };
 use crate::{CafsFileInfo, PackageFilesIndex, SideEffectsDiff, StoreDir};
 use pretty_assertions::assert_eq;
@@ -62,6 +62,33 @@ fn fast_path_skips_filesystem_checks() {
     let path = result.files_map.get("index.js").expect("path inserted");
     eprintln!("path={path:?} exists={}", path.exists());
     assert!(!path.exists(), "no file was planted — fast path didn't care");
+}
+
+#[test]
+fn deferred_check_builds_the_maps_first_and_stats_only_when_run() {
+    let _guard = TALLY.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    let tmp = tempdir().unwrap();
+    let store_dir = StoreDir::new(tmp.path());
+    let content = b"deferred";
+    let digest = sha512_hex(content);
+    // No `checked_at`, so a run of the check has to hash the file.
+    let entry =
+        index_with("sha512", vec![("index.js", info(&digest, content.len() as u64, 0o644, None))]);
+    let (result, pending) = defer_pkg_files_integrity(&store_dir, entry);
+    dbg!(&result);
+    assert!(result.passed, "a well-formed row passes before its files are checked");
+    let path = result.files_map.get("index.js").expect("path inserted");
+    let cache = VerifiedFilesCache::new();
+    assert!(!pending.verify(&store_dir, &cache), "the file was never planted");
+    assert!(cache.is_empty(), "a failed file is not cached as verified");
+
+    plant_cafs_file(&store_dir, &digest, 0o644, content);
+    let (_, pending) = defer_pkg_files_integrity(
+        &store_dir,
+        index_with("sha512", vec![("index.js", info(&digest, content.len() as u64, 0o644, None))]),
+    );
+    assert!(pending.verify(&store_dir, &cache), "the planted file verifies");
+    assert!(cache.contains(path), "a verified file is cached for later rows");
 }
 
 /// We can't easily set `mtime` from the standard library, but

--- a/pnpm/crates/tarball/src/prefetch.rs
+++ b/pnpm/crates/tarball/src/prefetch.rs
@@ -11,8 +11,8 @@ use super::{
 use pnpm_package_manifest::{files_include_install_scripts, manifest_requires_build};
 use pnpm_reporter::{GlobalLog, LogEvent, LogLevel};
 use pnpm_store_dir::{
-    PackageFilesIndex, PkgContentMismatch, SharedReadonlyStoreIndex, SharedVerifiedFilesCache,
-    StoreDir,
+    PackageFilesIndex, PendingFilesCheck, PkgContentMismatch, SharedReadonlyStoreIndex,
+    SharedVerifiedFilesCache, StoreDir,
 };
 
 /// Pre-fetched cas-paths map shared across all per-snapshot futures.
@@ -71,13 +71,47 @@ pub type PrefetchedRequiresBuild = HashMap<String, bool>;
 /// `requiresPrepare` flags present in git package store-index rows.
 pub type PrefetchedRequiresPrepare = HashMap<String, bool>;
 
-pub(crate) type DecodedPrefetchRow = (
-    String,
-    Option<Arc<serde_json::Value>>,
-    Option<bool>,
-    Option<bool>,
-    pnpm_store_dir::VerifyResult,
-);
+pub(crate) struct DecodedPrefetchRow {
+    cache_key: String,
+    manifest: Option<Arc<serde_json::Value>>,
+    stored_requires_build: Option<bool>,
+    stored_requires_prepare: Option<bool>,
+    verify_result: pnpm_store_dir::VerifyResult,
+    /// The row's files check when it was deferred — see
+    /// [`PrefetchIntegrityCheck::Deferred`].
+    pending_check: Option<PendingFilesCheck>,
+}
+
+/// When [`prefetch_cas_paths`] checks a row's CAFS files against the
+/// digests the row records.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrefetchIntegrityCheck {
+    /// Check every row as it is read. A row that fails is left out of
+    /// the result.
+    Eager,
+    /// Read every row trusting its files, and check a row only when the
+    /// caller names it in [`PrefetchResult::verify_rows`]. For a caller
+    /// that reads the whole lockfile but materializes a few snapshots,
+    /// this keeps the per-file stats to the rows it imports.
+    Deferred,
+    /// `verifyStoreIntegrity: false`. Rows are trusted; a missing or
+    /// corrupt CAFS file surfaces at import time.
+    Skip,
+}
+
+impl PrefetchIntegrityCheck {
+    /// [`Self::Eager`] under `verifyStoreIntegrity`, else [`Self::Skip`].
+    #[must_use]
+    pub fn eager_if(verify_store_integrity: bool) -> Self {
+        if verify_store_integrity { Self::Eager } else { Self::Skip }
+    }
+
+    /// [`Self::Deferred`] under `verifyStoreIntegrity`, else [`Self::Skip`].
+    #[must_use]
+    pub fn deferred_if(verify_store_integrity: bool) -> Self {
+        if verify_store_integrity { Self::Deferred } else { Self::Skip }
+    }
+}
 
 /// Output of [`prefetch_cas_paths`]: the warm-cache filesystem map
 /// plus any bundled manifests and side-effects overlays recovered
@@ -94,13 +128,61 @@ pub struct PrefetchResult {
     pub remote_side_effects_quarantine: PrefetchedRemoteSideEffectsQuarantine,
     pub requires_build: PrefetchedRequiresBuild,
     pub requires_prepare: PrefetchedRequiresPrepare,
+    /// The files checks [`PrefetchIntegrityCheck::Deferred`] left to
+    /// [`Self::verify_rows`], by store-index row key. Empty under the
+    /// other modes.
+    pub pending_checks: HashMap<String, PendingFilesCheck>,
+}
+
+impl PrefetchResult {
+    /// Run the deferred files checks of the named rows, dropping every
+    /// row that fails from all the maps so its snapshot falls through
+    /// to the per-snapshot lookup and re-fetch. A key that has no
+    /// pending check (already verified, never prefetched, or checked
+    /// by an earlier call) is skipped. Returns the number of rows
+    /// dropped.
+    ///
+    /// Blocking: the checks stat every file of every named row, fanned
+    /// out across rayon.
+    pub fn verify_rows<'a>(
+        &mut self,
+        cache_keys: impl IntoIterator<Item = &'a str>,
+        store_dir: &StoreDir,
+        verified_files_cache: &SharedVerifiedFilesCache,
+    ) -> usize {
+        let checks: Vec<(String, PendingFilesCheck)> = cache_keys
+            .into_iter()
+            .filter_map(|cache_key| self.pending_checks.remove_entry(cache_key))
+            .collect();
+        let failed: Vec<String> = checks
+            .into_par_iter()
+            .filter_map(|(cache_key, check)| {
+                (!check.verify(store_dir, verified_files_cache)).then_some(cache_key)
+            })
+            .collect();
+        for cache_key in &failed {
+            tracing::debug!(
+                target: "pacquet::download",
+                ?cache_key,
+                "store-index entry failed integrity check; leaving it to the per-snapshot lookup",
+            );
+            self.cas_paths.remove(cache_key);
+            self.manifests.remove(cache_key);
+            self.side_effects_maps.remove(cache_key);
+            self.side_effects.remove(cache_key);
+            self.remote_side_effects_quarantine.remove(cache_key);
+            self.requires_build.remove(cache_key);
+            self.requires_prepare.remove(cache_key);
+        }
+        failed.len()
+    }
 }
 
 /// Resolve the whole install's warm-cache lookups up front, returning a
 /// `cache_key → Arc<cas_paths>` map the per-snapshot futures hit
 /// synchronously. Keys with no row, an undecodable row, or a failed
 /// integrity check are absent, and fall through to their per-snapshot
-/// lookup.
+/// lookup. `integrity_check` says when that check runs.
 ///
 /// Runs as one `spawn_blocking` rather than one per snapshot: at ~1.3k
 /// snapshots the default 512-thread blocking pool spends its time
@@ -112,7 +194,7 @@ pub async fn prefetch_cas_paths(
     index: Option<SharedReadonlyStoreIndex>,
     store_dir: &'static StoreDir,
     cache_keys: Vec<String>,
-    verify_store_integrity: bool,
+    integrity_check: PrefetchIntegrityCheck,
     verified_files_cache: SharedVerifiedFilesCache,
 ) -> PrefetchResult {
     let Some(index) = index else { return PrefetchResult::default() };
@@ -134,7 +216,7 @@ pub async fn prefetch_cas_paths(
                     cache_key,
                     &bytes,
                     store_dir,
-                    verify_store_integrity,
+                    integrity_check,
                     &verified_files_cache,
                 )
             })
@@ -175,7 +257,7 @@ fn decode_prefetch_row(
     cache_key: String,
     bytes: &[u8],
     store_dir: &'static StoreDir,
-    verify_store_integrity: bool,
+    integrity_check: PrefetchIntegrityCheck,
     verified_files_cache: &SharedVerifiedFilesCache,
 ) -> Option<DecodedPrefetchRow> {
     let mut entry: PackageFilesIndex = match pnpm_store_dir::decode_package_files_index(bytes) {
@@ -210,12 +292,28 @@ fn decode_prefetch_row(
     let stored_requires_build = entry.requires_build;
     let stored_requires_prepare = entry.requires_prepare;
     let manifest = entry.manifest.take().map(Arc::new);
-    let verify_result = if verify_store_integrity {
-        pnpm_store_dir::check_pkg_files_integrity(store_dir, entry, verified_files_cache)
-    } else {
-        pnpm_store_dir::build_file_maps_from_index(store_dir, entry)
+    let (verify_result, pending_check) = match integrity_check {
+        PrefetchIntegrityCheck::Eager => (
+            pnpm_store_dir::check_pkg_files_integrity(store_dir, entry, verified_files_cache),
+            None,
+        ),
+        PrefetchIntegrityCheck::Deferred => {
+            let (verify_result, pending_check) =
+                pnpm_store_dir::defer_pkg_files_integrity(store_dir, entry);
+            (verify_result, Some(pending_check))
+        }
+        PrefetchIntegrityCheck::Skip => {
+            (pnpm_store_dir::build_file_maps_from_index(store_dir, entry), None)
+        }
     };
-    Some((cache_key, manifest, stored_requires_build, stored_requires_prepare, verify_result))
+    Some(DecodedPrefetchRow {
+        cache_key,
+        manifest,
+        stored_requires_build,
+        stored_requires_prepare,
+        verify_result,
+        pending_check,
+    })
 }
 
 /// Fold the verified rows into the per-key maps the install path reads.
@@ -225,11 +323,20 @@ fn collect_prefetch_result(decoded: Vec<DecodedPrefetchRow>) -> PrefetchResult {
         requires_build: HashMap::with_capacity(decoded.len()),
         ..PrefetchResult::default()
     };
-    for (cache_key, manifest, stored_requires_build, stored_requires_prepare, mut verify_result) in
-        decoded
-    {
+    for row in decoded {
+        let DecodedPrefetchRow {
+            cache_key,
+            manifest,
+            stored_requires_build,
+            stored_requires_prepare,
+            mut verify_result,
+            pending_check,
+        } = row;
         if !verify_result.passed {
             continue;
+        }
+        if let Some(pending_check) = pending_check {
+            result.pending_checks.insert(cache_key.clone(), pending_check);
         }
         let calculated_requires_build = stored_requires_build.unwrap_or_else(|| {
             manifest.as_deref().is_some_and(manifest_requires_build)

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -19,7 +19,7 @@ use super::{
         allocate_local_tarball_buffer, local_file_tarball_path, open_local_tarball,
         read_local_tarball_buffer, read_local_tarball_metadata,
     },
-    prefetch::{PrefetchedCasPaths, prefetch_cas_paths},
+    prefetch::{PrefetchIntegrityCheck, PrefetchedCasPaths, prefetch_cas_paths},
     zip_archive::{extract_zip_entries, write_zip_entry_to_cas},
 };
 use pipe_trait::Pipe;
@@ -624,7 +624,7 @@ async fn prefetch_cas_paths_returns_hits_for_live_index_rows() {
         StoreIndex::shared_readonly_in(store_path),
         store_path,
         vec![index_key.clone()],
-        true,
+        PrefetchIntegrityCheck::Eager,
         SharedVerifiedFilesCache::default(),
     )
     .await;
@@ -676,7 +676,7 @@ async fn prefetch_cas_paths_recomputes_requires_build_for_legacy_rows() {
         StoreIndex::shared_readonly_in(store_path),
         store_path,
         vec![index_key.clone()],
-        true,
+        PrefetchIntegrityCheck::Eager,
         SharedVerifiedFilesCache::default(),
     )
     .await;
@@ -734,7 +734,7 @@ async fn prefetch_cas_paths_omits_failed_integrity_entries() {
         // Verification on: the missing CAFS blob trips
         // `check_pkg_files_integrity`'s "scrub & re-fetch" path,
         // which turns the row into a miss.
-        true,
+        PrefetchIntegrityCheck::Eager,
         SharedVerifiedFilesCache::default(),
     )
     .await;
@@ -793,7 +793,7 @@ async fn prefetch_cas_paths_skips_filesystem_checks_when_verify_disabled() {
         StoreIndex::shared_readonly_in(store_path),
         store_path,
         vec![index_key.clone()],
-        false,
+        PrefetchIntegrityCheck::Skip,
         SharedVerifiedFilesCache::default(),
     )
     .await;
@@ -802,6 +802,70 @@ async fn prefetch_cas_paths_skips_filesystem_checks_when_verify_disabled() {
         "verify=false should trust the index row and surface the entry without checking disk",
     );
     assert!(map.contains_key("package.json"));
+    drop(store_dir);
+}
+
+/// Under [`PrefetchIntegrityCheck::Deferred`] a row is returned
+/// unchecked and only `verify_rows` decides it, so a caller that
+/// materializes a few of many rows stats only those.
+#[tokio::test]
+async fn prefetch_cas_paths_deferred_check_drops_a_row_only_when_verified() {
+    let (store_dir, store_path) = tempdir_with_leaked_path();
+
+    let pkg_integrity = integrity(
+        "sha512-q/IXcMGuF8v7ZLf/JeYfE/pB4Wg1yxT6jXJz8JxRK7a4mJSXV1QKMXDPfZkvMHTZpYxWBDoJiXtptDWFnoCA2w==",
+    );
+    let index = StoreIndex::open_in(store_path).unwrap();
+    let mut index_keys = Vec::new();
+    for pkg_id in ["gone@1.0.0", "unasked@1.0.0"] {
+        let index_key = store_index_key(&pkg_integrity.to_string(), pkg_id);
+        let mut files = HashMap::new();
+        files.insert(
+            "package.json".to_string(),
+            CafsFileInfo {
+                // Digest of a file that was never written to disk.
+                digest: "f".repeat(128),
+                mode: 0o644,
+                size: 15,
+                checked_at: None,
+            },
+        );
+        let entry = PackageFilesIndex {
+            manifest: None,
+            requires_build: Some(false),
+            requires_prepare: None,
+            algo: "sha512".to_string(),
+            files,
+            side_effects: None,
+            remote_side_effects_quarantine: None,
+        };
+        index.set(&index_key, &entry).unwrap();
+        index_keys.push(index_key);
+    }
+    drop(index);
+    let [gone_key, unasked_key] = index_keys.try_into().expect("two keys");
+
+    let verified_files_cache = SharedVerifiedFilesCache::default();
+    let mut prefetched = prefetch_cas_paths(
+        StoreIndex::shared_readonly_in(store_path),
+        store_path,
+        vec![gone_key.clone(), unasked_key.clone()],
+        PrefetchIntegrityCheck::Deferred,
+        SharedVerifiedFilesCache::clone(&verified_files_cache),
+    )
+    .await;
+
+    assert!(prefetched.cas_paths.contains_key(&gone_key), "unchecked rows are returned");
+    assert_eq!(prefetched.requires_build.get(&gone_key), Some(&false));
+    assert_eq!(prefetched.pending_checks.len(), 2, "both rows still owe their files check");
+
+    let failed = prefetched.verify_rows([gone_key.as_str()], store_path, &verified_files_cache);
+    assert_eq!(failed, 1);
+    assert!(!prefetched.cas_paths.contains_key(&gone_key), "a verified missing blob drops the row");
+    assert!(!prefetched.requires_build.contains_key(&gone_key));
+    assert!(prefetched.cas_paths.contains_key(&unasked_key), "rows nobody asked about stay");
+    assert!(prefetched.pending_checks.contains_key(&unasked_key));
+    assert!(!prefetched.pending_checks.contains_key(&gone_key));
     drop(store_dir);
 }
 


### PR DESCRIPTION
## Summary

Related to pnpm/pnpm#14540 (the warm global-virtual-store restore's syscall budget).

A frozen install prefetches every lockfile snapshot's store-index row at start, and with `verifyStoreIntegrity` on (the default) that prefetch stat'd every CAS file of every row before the plan had decided which slots to materialize. On a warm global-virtual-store restore the plan then skips nearly every slot, so almost all of that work was wasted. pnpm 11 only verifies the packages it actually fetches.

This PR makes the store-file check lazy: the prefetch reads every row trusting its files, and `CreateVirtualStore` verifies only the rows whose files this install may import: the snapshots it materializes (the plan survivors), plus any skipped snapshot whose row carries a side-effects overlay, since the build phase's cache hit can materialize that overlay into the slot. The other skipped snapshots keep their rows unchecked, which is safe because nothing imports their files; their manifests and `requiresBuild` flags come from the row itself.

Measured on the issue's 76-project / 20-dep repro (warm store, `node_modules` wiped, `--frozen-lockfile --ignore-scripts`), counting syscalls with a dyld interposer:

| | main | this PR |
|---|---:|---:|
| `stat` per warm restore | 9,182 | 838 |
| system CPU (5-run median) | 1.66 s | 1.54 s |

Wall time is within noise on this machine (~0.75 s both), as with the previous rounds on this issue; the gap the reporter sees comes from APFS serializing namespace operations under contention, so cutting syscalls is what moves it there.

## Squash Commit Body

```text
A frozen install prefetches every lockfile snapshot's store-index row
before the plan runs, and under verifyStoreIntegrity that prefetch
ran check_pkg_files_integrity over every row: one stat per CAS file of
every package in the lockfile. On a warm global-virtual-store restore
the plan then skips nearly every slot, so the ~9k stats on the issue's
76-project repro guarded imports that never happened. pnpm 11 verifies
only the packages it fetches.

The prefetch gains a PrefetchIntegrityCheck mode. The frozen install
uses Deferred: rows are decoded with their maps built but their files
unchecked, and after the plan CreateVirtualStore::settle_prefetch runs
PrefetchResult::verify_rows over the keys of the rows whose files the
install may import, on rayon in a spawn_blocking task, dropping every
row that fails so its snapshot falls through to the per-snapshot
lookup and re-fetch exactly as an eager failure did. Those rows are
the survivors plus any skipped snapshot whose row carries a
side-effects overlay, because the build phase's cache hit materializes
that overlay into the slot. The other skipped snapshots keep their
rows unchecked: nothing imports their files, and their manifests and
requiresBuild flags are read from the row, not the CAS. The
fresh-resolve reuse_from_warm_store path keeps the eager check since
every row it reads is materialized.

In store-dir, check_pkg_files_integrity is split into
defer_pkg_files_integrity (map building, shared with
build_file_maps_from_index) and PendingFilesCheck::verify (the stats
and hashes, with the verified-files cache), so the eager and deferred
paths share one loop. The split costs a filename clone per file in the
map build.

Per warm restore of the repro: stat 9,182 -> 838; system CPU median
1.66 s -> 1.54 s; wall time unchanged within noise on an M-series Mac.

Related to pnpm/pnpm#14540.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5-1).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Warm workspace restores now verify store files only for packages being linked or requiring validation, reducing unnecessary file checks.
  * Reused packages with side-effects data continue to receive integrity checks.
* **Reliability**
  * Missing or invalid package files are detected and eligible packages are re-fetched when needed.
  * Empty side-effects data no longer causes stale package reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->