### PR TITLE
fix(deps-restorer): fall back on EPERM from a hardlink or reflink

### DIFF
--- a/.changeset/import-eperm-falls-back.md
+++ b/.changeset/import-eperm-falls-back.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm install` no longer fails with `Operation not permitted` when the filesystem refuses a hardlink or a reflink. Under `packageImportMethod: auto`, `clone-or-copy`, and `hardlink`, pnpm copies the file. EdenFS checkouts, which have no hardlinks, and rootless containers, which refuse the clone syscall, both hit this. An explicit `packageImportMethod: clone` still reports the error [#14722](https://github.com/pnpm/pnpm/issues/14722).
+`pnpm install` no longer fails with `Operation not permitted` when the filesystem refuses a hardlink or a reflink. Under `packageImportMethod: auto` and `clone-or-copy`, pnpm copies the file. EdenFS checkouts, which have no hardlinks, and rootless containers, which refuse the clone syscall, both hit this. An explicit `packageImportMethod: hardlink` or `clone` still reports the error [#14722](https://github.com/pnpm/pnpm/issues/14722).

--- a/.changeset/import-eperm-falls-back.md
+++ b/.changeset/import-eperm-falls-back.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A hardlink or reflink refused with `EPERM` no longer fails the install under `packageImportMethod: auto` or `clone-or-copy`. An explicit `hardlink` copies the file instead. An explicit `clone` is unchanged. `EACCES` still fails the install. This fixes repeat installs on filesystems without hardlinks, such as EdenFS, where every `file:` dependency re-imported by a second install failed with `Operation not permitted`, and `pnpm deploy` inside rootless containers, where `FICLONE` is refused the same way [#14722](https://github.com/pnpm/pnpm/issues/14722).

--- a/.changeset/import-eperm-falls-back.md
+++ b/.changeset/import-eperm-falls-back.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-A hardlink or reflink refused with `EPERM` no longer fails the install under `packageImportMethod: auto` or `clone-or-copy`. An explicit `hardlink` copies the file instead. An explicit `clone` is unchanged. `EACCES` still fails the install. This fixes repeat installs on filesystems without hardlinks, such as EdenFS, where every `file:` dependency re-imported by a second install failed with `Operation not permitted`, and `pnpm deploy` inside rootless containers, where `FICLONE` is refused the same way [#14722](https://github.com/pnpm/pnpm/issues/14722).
+`pnpm install` no longer fails with `Operation not permitted` when the filesystem refuses a hardlink or a reflink. Under `packageImportMethod: auto`, `clone-or-copy`, and `hardlink`, pnpm copies the file. EdenFS checkouts, which have no hardlinks, and rootless containers, which refuse the clone syscall, both hit this. An explicit `packageImportMethod: clone` still reports the error [#14722](https://github.com/pnpm/pnpm/issues/14722).

--- a/pnpm/crates/deps-restorer/src/link_file.rs
+++ b/pnpm/crates/deps-restorer/src/link_file.rs
@@ -234,7 +234,7 @@ pub fn import_into_fresh_target<Reporter: self::Reporter>(
     // Current pnpm's indexed-pkg-importer does not guard against this
     // either — postinstall handling lives in the script runner, not the
     // import layer — so there's nothing to gate on here.
-    try_import::<Reporter>(method, logged, source_file, target_link)
+    try_import::<Reporter, Host>(method, logged, source_file, target_link)
         .or_else(|error| recover_from_concurrent_import(error, source_file, target_link))
 }
 
@@ -312,7 +312,7 @@ fn recover_from_concurrent_import(
 /// Run the import syscall for the configured `method`. Surfaces
 /// the raw `io::Error` so the caller can dispatch on
 /// `ErrorKind::AlreadyExists` for the EEXIST recovery path.
-fn try_import<Reporter: self::Reporter>(
+fn try_import<Reporter: self::Reporter, Sys: FsHardLink + FsReflink>(
     method: PackageImportMethod,
     logged: &AtomicU8,
     source_file: &Path,
@@ -321,22 +321,23 @@ fn try_import<Reporter: self::Reporter>(
     match method {
         PackageImportMethod::Auto => {
             static AUTO_STATE: AtomicU8 = AtomicU8::new(AUTO_FIRST_TIER);
-            auto_link::<Reporter>(logged, &AUTO_STATE, source_file, target_link)
+            auto_link::<Reporter, Sys>(logged, &AUTO_STATE, source_file, target_link)
         }
-        // pnpm's explicit `hardlink` method uses `hardlinkPkg(linkOrCopy)`
-        // which falls back to copy on `EXDEV` (cross-device link not
-        // permitted) but propagates other errors. Match that: if the
-        // user asks for hardlink and they've put their store on a
-        // different device from `node_modules`, copy silently; anything
-        // else (missing source, permission denied, ...) is a real error
-        // and should surface. No caching — the `fs::hard_link` syscall
-        // itself is already cheap; pnpm doesn't cache this path either.
-        PackageImportMethod::Hardlink => match fs::hard_link(source_file, target_link) {
+        // pnpm's explicit `hardlink` method uses `hardlinkPkg(linkOrCopy)`,
+        // which copies on any link failure other than `EEXIST`. Copy here
+        // when the link cannot be made at all: `EXDEV` (the store is on a
+        // different device from `node_modules`) and `EPERM` (the
+        // filesystem has no hardlinks). Anything else (missing source,
+        // access denied, ...) still surfaces, so a malformed call is not
+        // hidden behind a silent copy. No caching — the `fs::hard_link`
+        // syscall itself is already cheap; pnpm doesn't cache this path
+        // either.
+        PackageImportMethod::Hardlink => match Sys::hard_link(source_file, target_link) {
             Ok(()) => {
                 log_method_once::<Reporter>(logged, LOG_FLAG_HARDLINK, WireImportMethod::Hardlink);
                 Ok(())
             }
-            Err(error) if is_cross_device(&error) => {
+            Err(error) if is_cross_device(&error) || is_operation_not_permitted(&error) => {
                 copy_file(source_file, target_link).inspect(|()| {
                     log_method_once::<Reporter>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
                 })
@@ -348,7 +349,12 @@ fn try_import<Reporter: self::Reporter>(
         }),
         PackageImportMethod::CloneOrCopy => {
             static CLONE_OR_COPY_STATE: AtomicU8 = AtomicU8::new(LINK_STATE_CLONE);
-            clone_or_copy_link::<Reporter>(logged, &CLONE_OR_COPY_STATE, source_file, target_link)
+            clone_or_copy_link::<Reporter, Sys>(
+                logged,
+                &CLONE_OR_COPY_STATE,
+                source_file,
+                target_link,
+            )
         }
         PackageImportMethod::Copy => copy_file(source_file, target_link).inspect(|()| {
             log_method_once::<Reporter>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
@@ -370,28 +376,95 @@ fn clone_file(source_file: &Path, target_link: &Path) -> io::Result<()> {
     pnpm_fs::file_mode::restore_exec_bit_from_cas_suffix(source_file, target_link)
 }
 
+/// The hardlink syscall the import tiers issue. A capability seam so
+/// tests can hand the ladder the errors only some filesystems return
+/// (`EPERM` from a FUSE mount that has no hardlinks), which a temp dir
+/// on the CI runner's disk cannot reproduce.
+trait FsHardLink {
+    fn hard_link(source: &Path, target: &Path) -> io::Result<()>;
+}
+
+/// The reflink syscall the `Auto` and `CloneOrCopy` ladders issue. Same
+/// purpose as [`FsHardLink`]: `FICLONE` is answered with `EPERM` inside
+/// the user-namespace containers of pnpm/pnpm#14722, and the CI runners
+/// do not provide one.
+trait FsReflink {
+    fn reflink(source: &Path, target: &Path) -> io::Result<()>;
+}
+
+/// Production provider: the real syscalls.
+struct Host;
+
+impl FsHardLink for Host {
+    fn hard_link(source: &Path, target: &Path) -> io::Result<()> {
+        fs::hard_link(source, target)
+    }
+}
+
+impl FsReflink for Host {
+    fn reflink(source: &Path, target: &Path) -> io::Result<()> {
+        reflink_copy::reflink(source, target)
+    }
+}
+
+/// `EPERM`, "operation not permitted". For the link syscalls it means
+/// the filesystem will not perform *this operation* on *these paths*,
+/// as opposed to `EACCES`, which means the caller was denied an access
+/// the operation needed:
+///
+/// * `link(2)` returns it from filesystems that have no hardlinks. FUSE
+///   filesystems such as `EdenFS` answer every `link()` inside the mount
+///   this way, so an install whose `node_modules` and `file:` sources
+///   both live in the checkout gets `EPERM` from the first hardlink
+///   attempt. `fs.protected_hardlinks=1` returns it too, for a source
+///   the caller does not own and cannot both read and write.
+/// * `ioctl(FICLONE)` returns it in the rootless-container and
+///   unprivileged-LXC setups reported in pnpm/pnpm#14722.
+///
+/// Rust folds both errnos into `ErrorKind::PermissionDenied`, so the
+/// two have to be told apart by the raw code. A copy needs neither
+/// hardlinks nor clones, so `EPERM` downgrades like `EXDEV` does and the
+/// copy tier reports whatever is genuinely wrong with the paths. That
+/// is what pnpm's TypeScript importer ends up doing too: its
+/// `linkOrCopy` copies on any hardlink failure except `EEXIST`. `EACCES`
+/// keeps propagating here, one step more conservative than pnpm: a
+/// lower tier may or may not get past a denied path, and surfacing the
+/// denial is the reading that hides nothing.
+fn is_operation_not_permitted(err: &io::Error) -> bool {
+    #[cfg(unix)]
+    return err.raw_os_error() == Some(libc::EPERM);
+    #[cfg(not(unix))]
+    {
+        let _ = err;
+        false
+    }
+}
+
 /// Errors that indicate the call itself is malformed (missing source,
-/// permission denied, target already exists) — propagate these from
+/// access denied, target already exists) — propagate these from
 /// the downgrade cache instead of advancing to the next tier. A
 /// different tier won't fix an invalid call, and downgrading on a
 /// one-off `NotFound` would permanently disable reflink / hardlink for
-/// every other file in the install.
+/// every other file in the install. `EPERM` is the one
+/// `PermissionDenied` that is a capability signal rather than a call
+/// error; see [`is_operation_not_permitted`].
 ///
 /// Everything else — including the grab-bag of errno / Windows codes
 /// kernels use to signal "filesystem can't do this operation"
 /// (`EOPNOTSUPP`, `ENOTTY`, `ENOSYS`, `ERROR_INVALID_FUNCTION`, ...) —
-/// triggers the fallback. This is the same deny-list the `reflink-copy`
-/// crate uses in its own `reflink_or_copy` fallback logic, so it's
-/// battle-tested across the platform matrix. A deny-list is required
+/// triggers the fallback. This is the deny-list the `reflink-copy`
+/// crate uses in its own `reflink_or_copy` fallback logic, with `EPERM`
+/// carved out of it for the reasons above. A deny-list is required
 /// rather than an allow-list because Windows's `ERROR_INVALID_FUNCTION`
 /// (raw OS `1`, which Rust surfaces as `ErrorKind::InvalidInput`) for
 /// NTFS's rejection of `FSCTL_DUPLICATE_EXTENTS_TO_FILE` must trigger
 /// the fallback.
 fn is_call_error(err: &io::Error) -> bool {
-    matches!(
-        err.kind(),
-        io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied | io::ErrorKind::AlreadyExists,
-    )
+    match err.kind() {
+        io::ErrorKind::NotFound | io::ErrorKind::AlreadyExists => true,
+        io::ErrorKind::PermissionDenied => !is_operation_not_permitted(err),
+        _ => false,
+    }
 }
 
 /// `Auto`'s downgrade chain — hardlink → clone → copy on Linux,
@@ -404,7 +477,7 @@ fn is_call_error(err: &io::Error) -> bool {
 /// downgrade the cached state; other errors propagate immediately so a
 /// one-off `NotFound` on a single file doesn't permanently disable a
 /// tier for the rest of the process.
-fn auto_link<Reporter: self::Reporter>(
+fn auto_link<Reporter: self::Reporter, Sys: FsHardLink + FsReflink>(
     logged: &AtomicU8,
     state: &AtomicU8,
     source: &Path,
@@ -413,13 +486,13 @@ fn auto_link<Reporter: self::Reporter>(
     loop {
         match state.load(Ordering::Relaxed) {
             LINK_STATE_CLONE => {
-                if clone_tier::<Reporter>(logged, source, target)? {
+                if clone_tier::<Reporter, Sys>(logged, source, target)? {
                     return Ok(());
                 }
                 downgrade_auto_tier(state, LINK_STATE_CLONE);
             }
             LINK_STATE_HARDLINK => {
-                if hardlink_tier::<Reporter>(logged, source, target)? {
+                if hardlink_tier::<Reporter, Sys>(logged, source, target)? {
                     return Ok(());
                 }
                 downgrade_auto_tier(state, LINK_STATE_HARDLINK);
@@ -441,12 +514,12 @@ fn auto_link<Reporter: self::Reporter>(
 /// reflink created the target, so its error is terminal — downgrading
 /// on it would re-attempt the next tier against that just-created file
 /// and mask the real error behind `AlreadyExists`.
-fn clone_tier<Reporter: self::Reporter>(
+fn clone_tier<Reporter: self::Reporter, Sys: FsReflink>(
     logged: &AtomicU8,
     source: &Path,
     target: &Path,
 ) -> io::Result<bool> {
-    match reflink_copy::reflink(source, target) {
+    match Sys::reflink(source, target) {
         Ok(()) => {
             pnpm_fs::file_mode::restore_exec_bit_from_cas_suffix(source, target)?;
             log_method_once::<Reporter>(logged, LOG_FLAG_CLONE, WireImportMethod::Clone);
@@ -459,12 +532,12 @@ fn clone_tier<Reporter: self::Reporter>(
 
 /// Hardlink `source` to `target`, with the same downgrade contract as
 /// [`clone_tier`].
-fn hardlink_tier<Reporter: self::Reporter>(
+fn hardlink_tier<Reporter: self::Reporter, Sys: FsHardLink>(
     logged: &AtomicU8,
     source: &Path,
     target: &Path,
 ) -> io::Result<bool> {
-    match fs::hard_link(source, target) {
+    match Sys::hard_link(source, target) {
         Ok(()) => {
             log_method_once::<Reporter>(logged, LOG_FLAG_HARDLINK, WireImportMethod::Hardlink);
             Ok(true)
@@ -480,7 +553,7 @@ fn hardlink_tier<Reporter: self::Reporter>(
 /// first reflink failure reassigns its closure directly to `copyPkg`.
 /// Same error-narrowing as [`auto_link`]: only capability failures
 /// downgrade; real errors propagate.
-fn clone_or_copy_link<Reporter: self::Reporter>(
+fn clone_or_copy_link<Reporter: self::Reporter, Sys: FsReflink>(
     logged: &AtomicU8,
     state: &AtomicU8,
     source: &Path,
@@ -489,7 +562,7 @@ fn clone_or_copy_link<Reporter: self::Reporter>(
     loop {
         match state.load(Ordering::Relaxed) {
             LINK_STATE_CLONE => {
-                if clone_tier::<Reporter>(logged, source, target)? {
+                if clone_tier::<Reporter, Sys>(logged, source, target)? {
                     return Ok(());
                 }
                 state.fetch_max(LINK_STATE_COPY, Ordering::Relaxed);

--- a/pnpm/crates/deps-restorer/src/link_file.rs
+++ b/pnpm/crates/deps-restorer/src/link_file.rs
@@ -324,12 +324,14 @@ fn try_import<Reporter: self::Reporter, Sys: FsHardLink + FsReflink>(
             auto_link::<Reporter, Sys>(logged, &AUTO_STATE, source_file, target_link)
         }
         // pnpm's explicit `hardlink` method uses `hardlinkPkg(linkOrCopy)`,
-        // which copies on any link failure other than `EEXIST`. Copy here
-        // when the link cannot be made at all: `EXDEV` (the store is on a
-        // different device from `node_modules`) and `EPERM` (the
-        // filesystem has no hardlinks). Anything else (missing source,
-        // access denied, ...) still surfaces, so a malformed call is not
-        // hidden behind a silent copy. No caching — the `fs::hard_link`
+        // which copies on any link failure other than `EEXIST`. Only
+        // `EXDEV` copies here: a store on a different device from
+        // `node_modules` is a placement the user can change, and one
+        // package's copy is cheap. Everything else surfaces, `EPERM`
+        // included — a filesystem that refuses links would copy every
+        // package, which is the disk cost `hardlink` was chosen to
+        // avoid, so the user gets an error naming the method instead of
+        // a silent whole-install copy. No caching — the `fs::hard_link`
         // syscall itself is already cheap; pnpm doesn't cache this path
         // either.
         PackageImportMethod::Hardlink => match Sys::hard_link(source_file, target_link) {
@@ -337,7 +339,7 @@ fn try_import<Reporter: self::Reporter, Sys: FsHardLink + FsReflink>(
                 log_method_once::<Reporter>(logged, LOG_FLAG_HARDLINK, WireImportMethod::Hardlink);
                 Ok(())
             }
-            Err(error) if is_cross_device(&error) || is_operation_not_permitted(&error) => {
+            Err(error) if is_cross_device(&error) => {
                 copy_file(source_file, target_link).inspect(|()| {
                     log_method_once::<Reporter>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
                 })

--- a/pnpm/crates/deps-restorer/src/link_file.rs
+++ b/pnpm/crates/deps-restorer/src/link_file.rs
@@ -1,7 +1,7 @@
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pnpm_config::PackageImportMethod;
-use pnpm_fs::is_cross_device;
+use pnpm_fs::{Host, is_cross_device};
 use pnpm_reporter::{
     LogEvent, LogLevel, PackageImportMethod as WireImportMethod, PackageImportMethodLog, Reporter,
 };
@@ -344,7 +344,7 @@ fn try_import<Reporter: self::Reporter, Sys: FsHardLink + FsReflink>(
             }
             Err(error) => Err(error),
         },
-        PackageImportMethod::Clone => clone_file(source_file, target_link).inspect(|()| {
+        PackageImportMethod::Clone => clone_file::<Sys>(source_file, target_link).inspect(|()| {
             log_method_once::<Reporter>(logged, LOG_FLAG_CLONE, WireImportMethod::Clone);
         }),
         PackageImportMethod::CloneOrCopy => {
@@ -369,31 +369,28 @@ fn copy_file(source_file: &Path, target_link: &Path) -> io::Result<()> {
     pnpm_fs::file_mode::restore_exec_bit_from_cas_suffix(source_file, target_link)
 }
 
-/// `reflink_copy::reflink` for the clone tier, then exec-bit restoration via
-/// [`pnpm_fs::file_mode::restore_exec_bit_from_cas_suffix`].
-fn clone_file(source_file: &Path, target_link: &Path) -> io::Result<()> {
-    reflink_copy::reflink(source_file, target_link)?;
+/// [`FsReflink::reflink`] for the explicit `Clone` method, then exec-bit
+/// restoration via [`pnpm_fs::file_mode::restore_exec_bit_from_cas_suffix`].
+fn clone_file<Sys: FsReflink>(source_file: &Path, target_link: &Path) -> io::Result<()> {
+    Sys::reflink(source_file, target_link)?;
     pnpm_fs::file_mode::restore_exec_bit_from_cas_suffix(source_file, target_link)
 }
 
-/// The hardlink syscall the import tiers issue. A capability seam so
-/// tests can hand the ladder the errors only some filesystems return
+/// The hardlink syscall the import methods issue. A capability seam so
+/// tests can hand them the errors only some filesystems return
 /// (`EPERM` from a FUSE mount that has no hardlinks), which a temp dir
 /// on the CI runner's disk cannot reproduce.
 trait FsHardLink {
     fn hard_link(source: &Path, target: &Path) -> io::Result<()>;
 }
 
-/// The reflink syscall the `Auto` and `CloneOrCopy` ladders issue. Same
-/// purpose as [`FsHardLink`]: `FICLONE` is answered with `EPERM` inside
-/// the user-namespace containers of pnpm/pnpm#14722, and the CI runners
-/// do not provide one.
+/// The reflink syscall the import methods issue. Same purpose as
+/// [`FsHardLink`]: `FICLONE` is answered with `EPERM` inside the
+/// user-namespace containers of pnpm/pnpm#14722, and the CI runners do
+/// not provide one.
 trait FsReflink {
     fn reflink(source: &Path, target: &Path) -> io::Result<()>;
 }
-
-/// Production provider: the real syscalls.
-struct Host;
 
 impl FsHardLink for Host {
     fn hard_link(source: &Path, target: &Path) -> io::Result<()> {

--- a/pnpm/crates/deps-restorer/src/link_file/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_file/tests.rs
@@ -1,10 +1,13 @@
 use super::{
-    AUTO_FIRST_TIER, LINK_STATE_CLONE, LINK_STATE_HARDLINK, LinkFileError, auto_link,
+    AUTO_FIRST_TIER, Host, LINK_STATE_CLONE, LINK_STATE_HARDLINK, LinkFileError, auto_link,
     clone_or_copy_link, downgrade_auto_tier, is_call_error, link_file, next_auto_tier,
     recover_from_concurrent_import,
 };
 #[cfg(unix)]
-use super::{LINK_STATE_COPY, import_into_fresh_target};
+use super::{
+    FsHardLink, FsReflink, LINK_STATE_COPY, import_into_fresh_target, is_operation_not_permitted,
+    try_import,
+};
 use pnpm_config::PackageImportMethod;
 use pnpm_reporter::SilentReporter;
 use pretty_assertions::assert_eq;
@@ -457,7 +460,7 @@ fn auto_call_errors_propagate_without_downgrading() {
     let dst = tmp.path().join("dst");
     fs::write(&dst, b"pre-existing").unwrap();
 
-    let err = auto_link::<SilentReporter>(&AtomicU8::new(0), &state, &src, &dst)
+    let err = auto_link::<SilentReporter, Host>(&AtomicU8::new(0), &state, &src, &dst)
         .expect_err("target exists → AlreadyExists");
     assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
     assert_eq!(
@@ -478,7 +481,7 @@ fn auto_hardlink_tier_call_errors_propagate() {
     let src = tmp.path().join("does-not-exist");
     let dst = tmp.path().join("dst");
 
-    let err = auto_link::<SilentReporter>(&AtomicU8::new(0), &state, &src, &dst)
+    let err = auto_link::<SilentReporter, Host>(&AtomicU8::new(0), &state, &src, &dst)
         .expect_err("missing source → NotFound");
     assert_eq!(err.kind(), io::ErrorKind::NotFound);
     assert_eq!(
@@ -502,7 +505,7 @@ fn auto_respects_cached_copy_state() {
     let src = write_source(tmp.path(), "src.txt", b"cached-copy");
     let dst = tmp.path().join("dst.txt");
 
-    auto_link::<SilentReporter>(&AtomicU8::new(0), &state, &src, &dst)
+    auto_link::<SilentReporter, Host>(&AtomicU8::new(0), &state, &src, &dst)
         .expect("copy should succeed");
 
     assert_eq!(fs::read(&dst).unwrap(), b"cached-copy");
@@ -572,7 +575,7 @@ fn auto_fresh_state_hardlinks_on_linux() {
     let src = write_source(tmp.path(), "src.txt", b"first-tier");
     let dst = tmp.path().join("dst.txt");
 
-    auto_link::<SilentReporter>(&AtomicU8::new(0), &state, &src, &dst)
+    auto_link::<SilentReporter, Host>(&AtomicU8::new(0), &state, &src, &dst)
         .expect("hardlink should succeed on same-FS tempdir");
 
     assert_eq!(
@@ -595,7 +598,7 @@ fn auto_respects_cached_hardlink_state() {
     let src = write_source(tmp.path(), "src.txt", b"cached-hardlink");
     let dst = tmp.path().join("dst.txt");
 
-    auto_link::<SilentReporter>(&AtomicU8::new(0), &state, &src, &dst)
+    auto_link::<SilentReporter, Host>(&AtomicU8::new(0), &state, &src, &dst)
         .expect("hardlink should succeed on same-FS tempdir");
 
     assert_eq!(
@@ -620,7 +623,7 @@ fn clone_or_copy_call_errors_propagate_without_downgrading() {
     let dst = tmp.path().join("dst");
     fs::write(&dst, b"pre-existing").unwrap();
 
-    let err = clone_or_copy_link::<SilentReporter>(&AtomicU8::new(0), &state, &src, &dst)
+    let err = clone_or_copy_link::<SilentReporter, Host>(&AtomicU8::new(0), &state, &src, &dst)
         .expect_err("target exists → AlreadyExists");
     assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
     assert_eq!(
@@ -658,6 +661,17 @@ fn is_call_error_rejects_capability_codes() {
     ] {
         assert!(!is_call_error(&err), "{err:?} should trigger fallback, not propagate");
     }
+
+    // The two errnos behind `PermissionDenied` split: EPERM is the
+    // filesystem refusing the operation (fall through), EACCES is the
+    // caller lacking access to the paths (propagate).
+    #[cfg(unix)]
+    {
+        let eperm = io::Error::from_raw_os_error(libc::EPERM);
+        assert!(!is_call_error(&eperm), "EPERM is a capability signal, not a call error");
+        let eacces = io::Error::from_raw_os_error(libc::EACCES);
+        assert!(is_call_error(&eacces), "EACCES is a call error");
+    }
 }
 
 /// Pre-seed `CloneOrCopy` state to `COPY` and verify it uses
@@ -674,7 +688,7 @@ fn clone_or_copy_respects_cached_copy_state() {
     let src = write_source(tmp.path(), "src.txt", b"cached");
     let dst = tmp.path().join("dst.txt");
 
-    clone_or_copy_link::<SilentReporter>(&AtomicU8::new(0), &state, &src, &dst)
+    clone_or_copy_link::<SilentReporter, Host>(&AtomicU8::new(0), &state, &src, &dst)
         .expect("copy should succeed");
 
     assert_ne!(
@@ -735,4 +749,228 @@ fn log_method_once_emits_first_call_per_method_only() {
         })
         .collect();
     assert_eq!(kinds, [WireImportMethod::Clone, WireImportMethod::Hardlink]);
+}
+
+/// A filesystem that refuses `link(2)` with `EPERM`: what a FUSE
+/// filesystem without hardlinks (`EdenFS`) answers for every link inside
+/// its mount. pnpm's store-to-checkout links usually fail `EXDEV` first
+/// and retire the tier before the ladder reaches such a link, so this
+/// is met when source and target both sit inside the mount, as the
+/// `file:` packages a repeat install re-imports do. Reflink and copy
+/// behave as the real filesystem does.
+#[cfg(unix)]
+struct EpermHardLink;
+
+#[cfg(unix)]
+impl FsHardLink for EpermHardLink {
+    fn hard_link(_source: &Path, _target: &Path) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::EPERM))
+    }
+}
+
+#[cfg(unix)]
+impl FsReflink for EpermHardLink {
+    fn reflink(source: &Path, target: &Path) -> io::Result<()> {
+        Host::reflink(source, target)
+    }
+}
+
+/// The user-namespace containers of pnpm/pnpm#14722, where `FICLONE`
+/// is refused with `EPERM`. Hardlinks work there.
+#[cfg(unix)]
+struct EpermReflink;
+
+#[cfg(unix)]
+impl FsHardLink for EpermReflink {
+    fn hard_link(source: &Path, target: &Path) -> io::Result<()> {
+        Host::hard_link(source, target)
+    }
+}
+
+#[cfg(unix)]
+impl FsReflink for EpermReflink {
+    fn reflink(_source: &Path, _target: &Path) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::EPERM))
+    }
+}
+
+/// `EACCES`: the caller was denied an access the link needed. Whether
+/// a copy would get past that is unknown, so the ladder surfaces it
+/// rather than guessing; it stays a call error.
+#[cfg(unix)]
+struct EaccesHardLink;
+
+/// A filesystem that refuses both links with `EPERM`, so the `Auto`
+/// ladder has only the copy tier left.
+#[cfg(unix)]
+struct EpermLinks;
+
+#[cfg(unix)]
+impl FsHardLink for EpermLinks {
+    fn hard_link(_source: &Path, _target: &Path) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::EPERM))
+    }
+}
+
+#[cfg(unix)]
+impl FsReflink for EpermLinks {
+    fn reflink(_source: &Path, _target: &Path) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::EPERM))
+    }
+}
+
+#[cfg(unix)]
+impl FsHardLink for EaccesHardLink {
+    fn hard_link(_source: &Path, _target: &Path) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::EACCES))
+    }
+}
+
+#[cfg(unix)]
+impl FsReflink for EaccesHardLink {
+    fn reflink(source: &Path, target: &Path) -> io::Result<()> {
+        Host::reflink(source, target)
+    }
+}
+
+#[cfg(unix)]
+fn inode(path: &Path) -> u64 {
+    use std::os::unix::fs::MetadataExt;
+    fs::metadata(path).unwrap().ino()
+}
+
+/// `EPERM` from the hardlink tier retires the tier and the file still
+/// lands, materialized by a lower tier rather than shared with the
+/// source. Before this the error propagated and the install died on
+/// the first `file:` package a repeat install re-imported into an
+/// `EdenFS` checkout.
+#[test]
+#[cfg(unix)]
+fn eperm_from_hard_link_downgrades_the_auto_ladder() {
+    let state = AtomicU8::new(LINK_STATE_HARDLINK);
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "src.txt", b"no hardlinks here");
+    let dst = tmp.path().join("nested/dst.txt");
+    fs::create_dir_all(dst.parent().unwrap()).unwrap();
+
+    auto_link::<SilentReporter, EpermHardLink>(&AtomicU8::new(0), &state, &src, &dst)
+        .expect("EPERM on the hardlink tier falls through to a tier that works");
+
+    assert_eq!(fs::read(&dst).unwrap(), b"no hardlinks here");
+    assert_ne!(inode(&src), inode(&dst), "the file was not hardlinked");
+    assert_ne!(
+        state.load(Ordering::Relaxed),
+        LINK_STATE_HARDLINK,
+        "the hardlink tier is retired for the rest of the process",
+    );
+}
+
+/// `EPERM` from the reflink tier is the same capability signal: the
+/// ladder moves on and the file lands.
+#[test]
+#[cfg(unix)]
+fn eperm_from_reflink_downgrades_the_clone_tier() {
+    let state = AtomicU8::new(LINK_STATE_CLONE);
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "src.txt", b"no clones here");
+    let dst = tmp.path().join("nested/dst.txt");
+    fs::create_dir_all(dst.parent().unwrap()).unwrap();
+
+    auto_link::<SilentReporter, EpermReflink>(&AtomicU8::new(0), &state, &src, &dst)
+        .expect("EPERM on the clone tier falls through to a tier that works");
+
+    assert_eq!(fs::read(&dst).unwrap(), b"no clones here");
+    assert_ne!(state.load(Ordering::Relaxed), LINK_STATE_CLONE, "the clone tier is retired");
+}
+
+/// `CloneOrCopy` has only the copy tier to fall to, and it must get
+/// there on `EPERM` too: this is the `pnpm deploy` project-file import
+/// of pnpm/pnpm#14722.
+#[test]
+#[cfg(unix)]
+fn eperm_from_reflink_downgrades_clone_or_copy_to_copy() {
+    let state = AtomicU8::new(LINK_STATE_CLONE);
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "src.txt", b"copied instead");
+    let dst = tmp.path().join("nested/dst.txt");
+    fs::create_dir_all(dst.parent().unwrap()).unwrap();
+
+    clone_or_copy_link::<SilentReporter, EpermReflink>(&AtomicU8::new(0), &state, &src, &dst)
+        .expect("EPERM on the clone tier falls through to copy");
+
+    assert_eq!(fs::read(&dst).unwrap(), b"copied instead");
+    assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_COPY);
+}
+
+/// `EACCES` shares `ErrorKind::PermissionDenied` with `EPERM` and must
+/// keep propagating: the tier stays, the error surfaces, nothing is
+/// written.
+#[test]
+#[cfg(unix)]
+fn eacces_from_hard_link_propagates_without_downgrading() {
+    let state = AtomicU8::new(LINK_STATE_HARDLINK);
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "src.txt", b"forbidden");
+    let dst = tmp.path().join("nested/dst.txt");
+    fs::create_dir_all(dst.parent().unwrap()).unwrap();
+
+    let err = auto_link::<SilentReporter, EaccesHardLink>(&AtomicU8::new(0), &state, &src, &dst)
+        .expect_err("EACCES is a call error");
+
+    assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    assert_eq!(err.raw_os_error(), Some(libc::EACCES));
+    assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_HARDLINK, "the tier is not retired");
+    assert!(!dst.exists(), "nothing was written");
+}
+
+/// The explicit `hardlink` method has no ladder, so it copies on
+/// `EPERM` the way it already copies on `EXDEV`; pnpm's `linkOrCopy`
+/// does the same.
+#[test]
+#[cfg(unix)]
+fn explicit_hardlink_copies_on_eperm() {
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "src.txt", b"explicit");
+    let dst = tmp.path().join("dst.txt");
+
+    try_import::<SilentReporter, EpermHardLink>(
+        PackageImportMethod::Hardlink,
+        &AtomicU8::new(0),
+        &src,
+        &dst,
+    )
+    .expect("EPERM on an explicit hardlink falls back to copy");
+
+    assert_eq!(fs::read(&dst).unwrap(), b"explicit");
+    assert_ne!(inode(&src), inode(&dst), "the file was copied, not linked");
+}
+
+/// Only the raw errno tells `EPERM` from `EACCES`; an error built from
+/// the kind alone carries no errno and stays a call error.
+#[test]
+#[cfg(unix)]
+fn is_operation_not_permitted_is_eperm_only() {
+    assert!(is_operation_not_permitted(&io::Error::from_raw_os_error(libc::EPERM)));
+    assert!(!is_operation_not_permitted(&io::Error::from_raw_os_error(libc::EACCES)));
+    assert!(!is_operation_not_permitted(&io::Error::from(io::ErrorKind::PermissionDenied)));
+}
+
+/// Downgrading on `EPERM` does not swallow what the copy tier then
+/// finds wrong with the paths: with both links refused and no parent
+/// directory for the target, the ladder reaches the copy tier, the copy
+/// fails, and that error is the one the caller sees.
+#[test]
+#[cfg(unix)]
+fn eperm_downgrade_still_surfaces_a_failed_copy() {
+    let state = AtomicU8::new(LINK_STATE_HARDLINK);
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "src.txt", b"unreachable target");
+    let dst = tmp.path().join("missing-parent/dst.txt");
+
+    let err = auto_link::<SilentReporter, EpermLinks>(&AtomicU8::new(0), &state, &src, &dst)
+        .expect_err("the copy tier cannot create a file under a missing directory");
+
+    assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_COPY, "both link tiers were retired");
+    assert!(!dst.exists());
 }

--- a/pnpm/crates/deps-restorer/src/link_file/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_file/tests.rs
@@ -794,12 +794,6 @@ impl FsReflink for EpermReflink {
     }
 }
 
-/// `EACCES`: the caller was denied an access the link needed. Whether
-/// a copy would get past that is unknown, so the ladder surfaces it
-/// rather than guessing; it stays a call error.
-#[cfg(unix)]
-struct EaccesHardLink;
-
 /// A filesystem that refuses both links with `EPERM`, so the `Auto`
 /// ladder has only the copy tier left.
 #[cfg(unix)]
@@ -818,6 +812,12 @@ impl FsReflink for EpermLinks {
         Err(io::Error::from_raw_os_error(libc::EPERM))
     }
 }
+
+/// `EACCES`: the caller was denied an access the link needed. Whether
+/// a copy would get past that is unknown, so the ladder surfaces it
+/// rather than guessing; it stays a call error.
+#[cfg(unix)]
+struct EaccesHardLink;
 
 #[cfg(unix)]
 impl FsHardLink for EaccesHardLink {
@@ -841,9 +841,8 @@ fn inode(path: &Path) -> u64 {
 
 /// `EPERM` from the hardlink tier retires the tier and the file still
 /// lands, materialized by a lower tier rather than shared with the
-/// source. Before this the error propagated and the install died on
-/// the first `file:` package a repeat install re-imported into an
-/// `EdenFS` checkout.
+/// source. This is the repeat install that re-imports a `file:` package
+/// inside an `EdenFS` checkout.
 #[test]
 #[cfg(unix)]
 fn eperm_from_hard_link_downgrades_the_auto_ladder() {

--- a/pnpm/crates/deps-restorer/src/link_file/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_file/tests.rs
@@ -922,26 +922,27 @@ fn eacces_from_hard_link_propagates_without_downgrading() {
     assert!(!dst.exists(), "nothing was written");
 }
 
-/// The explicit `hardlink` method has no ladder, so it copies on
-/// `EPERM` the way it already copies on `EXDEV`; pnpm's `linkOrCopy`
-/// does the same.
+/// The explicit `hardlink` method has no ladder to downgrade, and it
+/// must not answer `EPERM` with a copy: a filesystem that refuses links
+/// would copy every package, which is what choosing `hardlink` rules
+/// out. The error surfaces so the user can pick another method.
 #[test]
 #[cfg(unix)]
-fn explicit_hardlink_copies_on_eperm() {
+fn explicit_hardlink_propagates_eperm() {
     let tmp = tempdir().unwrap();
     let src = write_source(tmp.path(), "src.txt", b"explicit");
     let dst = tmp.path().join("dst.txt");
 
-    try_import::<SilentReporter, EpermHardLink>(
+    let err = try_import::<SilentReporter, EpermHardLink>(
         PackageImportMethod::Hardlink,
         &AtomicU8::new(0),
         &src,
         &dst,
     )
-    .expect("EPERM on an explicit hardlink falls back to copy");
+    .expect_err("EPERM on an explicit hardlink is not hidden behind a copy");
 
-    assert_eq!(fs::read(&dst).unwrap(), b"explicit");
-    assert_ne!(inode(&src), inode(&dst), "the file was copied, not linked");
+    assert_eq!(err.raw_os_error(), Some(libc::EPERM));
+    assert!(!dst.exists(), "nothing was written");
 }
 
 /// Only the raw errno tells `EPERM` from `EACCES`; an error built from


### PR DESCRIPTION
## Summary

`Auto` and `CloneOrCopy` treated every `PermissionDenied` from a hardlink or reflink as a malformed call and propagated it. Rust maps both `EACCES` and `EPERM` to that kind, and `EPERM` is what a filesystem returns when it will not perform the operation at all:

- `link(2)` inside a FUSE mount without hardlinks. EdenFS answers every `link()` between two paths in the checkout with errno 1 (measured: EdenFS to EdenFS `EPERM`, EdenFS to btrfs `EXDEV`, btrfs to btrfs succeeds).
- `ioctl(FICLONE)` inside a user namespace with idmapped mounts, which is pnpm/pnpm#14722.

A first install in an EdenFS checkout usually survives, because the store-to-checkout links fail `EXDEV` first and retire the tier before any `file:` package is reached. A repeat install re-imports only the `file:` packages, whose source and target are both inside the checkout, so its first hardlink attempt is `EPERM` and the install dies:

```
× installing dependencies
╰─▶ failed to import ".../nest/libs/auto-logging/src/custom-event-metadata.ts" to
    ".../node_modules/.pnpm/@nest+auto-logging@file+..._pacquet-stage_.../src/custom-event-metadata.ts":
    Operation not permitted (os error 1)
```

Reproduced on 12.3.4 on three hosts, 5 of 5 repeat installs; the same tree under 10.26 and 11.26 installs repeatedly, because pnpm's `linkOrCopy` copies on any hardlink failure except `EEXIST`.

## Change

- `is_call_error` tells the two errnos apart by the raw code: `EPERM` now downgrades the tier the way `EXDEV` and `EOPNOTSUPP` do; `EACCES` keeps propagating.
- The explicit `hardlink` method still surfaces `EPERM`. A filesystem that refuses links would copy every package, which is the disk cost `hardlink` is chosen to avoid, so the error names a method the user can change instead.
- The two syscalls move behind an `FsHardLink` / `FsReflink` seam with a `Host` provider (the DI convention from `CODE_STYLE_GUIDE.md`), so the tests can hand the ladder the errors a CI runner's disk cannot produce. `link_file` and `import_into_fresh_target` keep their signatures.

An explicit `packageImportMethod: clone` or `hardlink` is unchanged and still surfaces `EPERM`; the changeset says so.

## Tests

Seven new tests in `link_file/tests.rs`: `EPERM` from the hardlink tier and from the reflink tier downgrade the `Auto` ladder, `EPERM` downgrades `CloneOrCopy` to copy, the explicit `hardlink` method propagates `EPERM`, `EACCES` still propagates without retiring the tier, a copy failure after the downgrade still surfaces, and the classifier split itself. With only the classification reverted, five of them fail:

```
cargo nextest run -p pnpm-deps-restorer link_file
Summary [0.024s] 38 tests run: 32 passed, 6 failed, 439 skipped   # old classification
Summary [0.021s] 38 tests run: 38 passed, 439 skipped              # this branch
```

The count changed from the original 39 after a rebase onto pnpm/pnpm#14768, which moved `is_cross_device` and its two tests into `pnpm_fs`.

`cargo clippy -p pnpm-deps-restorer --tests` is clean on Linux.

Fixes pnpm/pnpm#14722

Written by an agent (Claude Code, claude-fable-5-1), reviewed and tested by ejc3.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791622896&installation_model_id=426870&pr_number=14771&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14771&signature=3552f3c2118cf978528444a55a9dda0c563c06648cf89e617c19a744e54af955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Installations using automatic import methods now continue when hardlink or reflink operations are not permitted.
  - Explicit hardlink imports now fall back to copying when hardlinks are unavailable.
  - Explicit clone imports retain their existing behavior.
  - Genuine access-denied errors continue to stop the installation.

- **Documentation**
  - Added release documentation describing the updated import fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
