### PR TITLE
fix(peers): resolve workspace: shorthand peer ranges to *

### DIFF
--- a/.changeset/fix-bare-workspace-peer-range.md
+++ b/.changeset/fix-bare-workspace-peer-range.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/deps.peer-range": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Fixed a bare `workspace:` shorthand peer dependency (`workspace:^`, `workspace:~`, or `workspace:` with no version) always being reported as an unmet peer by `pnpm peers check`, regardless of what was actually installed. See pnpm/pnpm#14770.

--- a/.changeset/fix-bare-workspace-peer-range.md
+++ b/.changeset/fix-bare-workspace-peer-range.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-Fixed a bare `workspace:` shorthand peer dependency (`workspace:^`, `workspace:~`, or `workspace:` with no version) always being reported as an unmet peer by `pnpm peers check`, regardless of what was actually installed. See pnpm/pnpm#14770.
+`pnpm peers check` no longer reports a peer dependency declared as `workspace:^`, `workspace:~`, or a bare `workspace:` as unmet. These shorthands carry no version, so pnpm compared the installed version against an unusable range that nothing could satisfy [#14770](https://github.com/pnpm/pnpm/issues/14770).

--- a/.changeset/fix-bare-workspace-peer-range.md
+++ b/.changeset/fix-bare-workspace-peer-range.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-`pnpm peers check` no longer reports a peer dependency declared as `workspace:^`, `workspace:~`, or a bare `workspace:` as unmet. These shorthands carry no version, so pnpm compared the installed version against an unusable range that nothing could satisfy [#14770](https://github.com/pnpm/pnpm/issues/14770).
+`pnpm peers check` no longer reports a peer dependency declared as `workspace:^`, `workspace:~`, or a bare `workspace:` as unmet. pnpm reported these as unmet whatever version the linked workspace project supplied [#14770](https://github.com/pnpm/pnpm/issues/14770).

--- a/pnpm/crates/cli/tests/suite/peers.rs
+++ b/pnpm/crates/cli/tests/suite/peers.rs
@@ -492,6 +492,64 @@ fn auto_installed_workspace_peer_is_resolved_from_the_linked_importer() {
 }
 
 #[test]
+fn a_bare_workspace_shorthand_peer_range_is_met_by_the_linked_project() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "packages:\n  - packages/*\nstrictPeerDependencies: true\n",
+    )
+    .expect("write workspace manifest");
+    fs::write(workspace.join("package.json"), r#"{ "name": "root", "version": "1.0.0" }"#)
+        .expect("write root manifest");
+
+    let peer = workspace.join("packages/peer");
+    fs::create_dir_all(&peer).expect("create the peer project");
+    fs::write(peer.join("package.json"), r#"{ "name": "peer", "version": "2.0.0" }"#)
+        .expect("write the peer manifest");
+
+    let lib = workspace.join("packages/lib");
+    fs::create_dir_all(&lib).expect("create the linked project");
+    fs::write(
+        lib.join("package.json"),
+        serde_json::json!({
+            "name": "lib",
+            "version": "1.0.0",
+            "peerDependencies": { "peer": "workspace:^" },
+        })
+        .to_string(),
+    )
+    .expect("write the linked manifest");
+
+    let app = workspace.join("packages/app");
+    fs::create_dir_all(&app).expect("create the consuming project");
+    fs::write(
+        app.join("package.json"),
+        serde_json::json!({
+            "name": "app",
+            "version": "1.0.0",
+            "dependencies": { "lib": "workspace:*", "peer": "workspace:*" },
+        })
+        .to_string(),
+    )
+    .expect("write the consuming manifest");
+
+    pacquet.with_args(["install", "--lockfile-only"]).assert().success();
+    let issues = run_peers(&workspace, &["peers", "check", "--lockfile-only", "--json"]);
+    for (project, project_issues) in issues.as_object().expect("peer issues by project") {
+        assert_eq!(project_issues["bad"], serde_json::json!({}), "{project}: {project_issues:#}");
+        assert_eq!(
+            project_issues["missing"],
+            serde_json::json!({}),
+            "{project}: {project_issues:#}",
+        );
+    }
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn incompatible_injected_auto_installed_peer_is_reported() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pnpm/crates/resolving-resolver-base/src/peer_range.rs
+++ b/pnpm/crates/resolving-resolver-base/src/peer_range.rs
@@ -28,15 +28,21 @@ pub fn is_acceptable_peer_spec(version: &str) -> bool {
 
 /// The semver range a resolved version is checked against for a peer dependency.
 ///
-/// `workspace:` prefixes are stripped; a named-registry or `npm:` specifier
-/// contributes its version body (`work:5.x.x` → `5.x.x`, `npm:bar@^5` → `^5`);
-/// any other non-semver specifier (git, file, URL) becomes `*`, so the peer is
-/// satisfied by any version while its original specifier still selects the
-/// package to install. Valid semver ranges and `catalog:` specs are returned
-/// unchanged. A `||` union of scheme specifiers — produced when several
-/// consumers' ranges are merged for highest-match auto-installation — is reduced
-/// to the union of its version bodies (`work:^1 || work:^2` → `^1 || ^2`) so the
-/// result stays a comparable range.
+/// `workspace:` prefixes are stripped when the remainder is itself a range
+/// (`workspace:1.2.3` → `1.2.3`); a bare shorthand with no version
+/// (`workspace:^`, `workspace:~`, `workspace:`) falls back to `*` instead,
+/// since there's nothing to build a real range from - a workspace peer is
+/// always resolved to its own current version, so it can never actually
+/// mismatch, and returning the bare operator itself would be an unparsable
+/// range that always reports the peer as unmet. A named-registry or `npm:`
+/// specifier contributes its version body (`work:5.x.x` → `5.x.x`,
+/// `npm:bar@^5` → `^5`); any other non-semver specifier (git, file, URL)
+/// becomes `*`, so the peer is satisfied by any version while its original
+/// specifier still selects the package to install. Valid semver ranges and
+/// `catalog:` specs are returned unchanged. A `||` union of scheme specifiers
+/// — produced when several consumers' ranges are merged for highest-match
+/// auto-installation — is reduced to the union of its version bodies
+/// (`work:^1 || work:^2` → `^1 || ^2`) so the result stays a comparable range.
 #[must_use]
 pub fn get_peer_version_range(version: &str) -> String {
     if version.contains("||") {
@@ -47,7 +53,7 @@ pub fn get_peer_version_range(version: &str) -> String {
             .join(" || ");
     }
     if is_valid_peer_range(version) {
-        return version.strip_prefix("workspace:").unwrap_or(version).to_string();
+        return resolve_workspace_or_catalog_range(version);
     }
     if let Some(colon) = version.find(':').filter(|&colon| colon > 0) {
         let body = &version[colon + 1..];
@@ -61,6 +67,19 @@ pub fn get_peer_version_range(version: &str) -> String {
         }
     }
     "*".to_string()
+}
+
+/// A plain semver range or a `catalog:` spec is already correct as it
+/// stands. A `workspace:` value is stripped down to what follows the
+/// prefix when that remainder is itself a range (`workspace:1.2.3` →
+/// `1.2.3`); the bare shorthand (`workspace:^`, `workspace:~`,
+/// `workspace:`) has no version to build a range from, so it falls back
+/// to `*` instead of the unparsable operator.
+fn resolve_workspace_or_catalog_range(version: &str) -> String {
+    let Some(stripped) = version.strip_prefix("workspace:") else {
+        return version.to_string();
+    };
+    if Range::parse(stripped).is_ok() { stripped.to_string() } else { "*".to_string() }
 }
 
 #[cfg(test)]

--- a/pnpm/crates/resolving-resolver-base/src/peer_range.rs
+++ b/pnpm/crates/resolving-resolver-base/src/peer_range.rs
@@ -28,14 +28,12 @@ pub fn is_acceptable_peer_spec(version: &str) -> bool {
 
 /// The semver range a resolved version is checked against for a peer dependency.
 ///
-/// `workspace:` prefixes are stripped when the remainder is itself a range
-/// (`workspace:1.2.3` → `1.2.3`); a bare shorthand with no version
-/// (`workspace:^`, `workspace:~`, `workspace:`) falls back to `*` instead,
-/// since there's nothing to build a real range from - a workspace peer is
-/// always resolved to its own current version, so it can never actually
-/// mismatch, and returning the bare operator itself would be an unparsable
-/// range that always reports the peer as unmet. A named-registry or `npm:`
-/// specifier contributes its version body (`work:5.x.x` → `5.x.x`,
+/// A `workspace:` prefix is stripped when the remainder is itself a range
+/// (`workspace:1.2.3` → `1.2.3`); the bare shorthand (`workspace:^`,
+/// `workspace:~`, `workspace:`) carries no version to build one from and
+/// becomes `*`, since a `workspace:` peer resolves to the linked project's
+/// own version — whatever that is, it is the wanted one. A named-registry or
+/// `npm:` specifier contributes its version body (`work:5.x.x` → `5.x.x`,
 /// `npm:bar@^5` → `^5`); any other non-semver specifier (git, file, URL)
 /// becomes `*`, so the peer is satisfied by any version while its original
 /// specifier still selects the package to install. Valid semver ranges and
@@ -53,7 +51,7 @@ pub fn get_peer_version_range(version: &str) -> String {
             .join(" || ");
     }
     if is_valid_peer_range(version) {
-        return resolve_workspace_or_catalog_range(version);
+        return desugar_workspace_range(version);
     }
     if let Some(colon) = version.find(':').filter(|&colon| colon > 0) {
         let body = &version[colon + 1..];
@@ -69,13 +67,10 @@ pub fn get_peer_version_range(version: &str) -> String {
     "*".to_string()
 }
 
-/// A plain semver range or a `catalog:` spec is already correct as it
-/// stands. A `workspace:` value is stripped down to what follows the
-/// prefix when that remainder is itself a range (`workspace:1.2.3` →
-/// `1.2.3`); the bare shorthand (`workspace:^`, `workspace:~`,
-/// `workspace:`) has no version to build a range from, so it falls back
-/// to `*` instead of the unparsable operator.
-fn resolve_workspace_or_catalog_range(version: &str) -> String {
+/// The comparable range a value [`is_valid_peer_range`] accepted stands for:
+/// what follows a `workspace:` prefix when that is itself a range, `*` when it
+/// is not, and the value unchanged when it carries no such prefix.
+fn desugar_workspace_range(version: &str) -> String {
     let Some(stripped) = version.strip_prefix("workspace:") else {
         return version.to_string();
     };

--- a/pnpm/crates/resolving-resolver-base/src/peer_range/tests.rs
+++ b/pnpm/crates/resolving-resolver-base/src/peer_range/tests.rs
@@ -36,10 +36,16 @@ fn get_peer_version_range_keeps_valid_peer_ranges() {
 }
 
 #[test]
-fn get_peer_version_range_strips_workspace_prefix() {
-    assert_eq!(get_peer_version_range("workspace:^"), "^");
+fn get_peer_version_range_keeps_an_explicit_workspace_version() {
     assert_eq!(get_peer_version_range("workspace:1.2.3"), "1.2.3");
+}
+
+#[test]
+fn get_peer_version_range_treats_the_workspace_wildcard_tokens_as_star() {
     assert_eq!(get_peer_version_range("workspace:*"), "*");
+    assert_eq!(get_peer_version_range("workspace:^"), "*");
+    assert_eq!(get_peer_version_range("workspace:~"), "*");
+    assert_eq!(get_peer_version_range("workspace:"), "*");
 }
 
 #[test]

--- a/pnpm11/deps/peer-range/src/index.ts
+++ b/pnpm11/deps/peer-range/src/index.ts
@@ -26,22 +26,35 @@ export function isAcceptablePeerSpec (version: string): boolean {
 /**
  * The semver range a resolved version is checked against for a peer dependency.
  *
- * `workspace:` prefixes are stripped; a named-registry or `npm:` specifier
- * contributes its version body (`work:5.x.x` → `5.x.x`, `npm:bar@^5` → `^5`);
- * any other non-semver specifier (git, file, URL) becomes `*`, so the peer is
- * satisfied by any version while its original specifier still selects the
- * package to install. Valid semver ranges and `catalog:` specs are returned
- * unchanged. A `||` union of scheme specifiers — produced when several
- * consumers' ranges are merged for highest-match auto-installation — is reduced
- * to the union of its version bodies (`work:^1 || work:^2` → `^1 || ^2`) so the
- * result stays a comparable range.
+ * `workspace:` prefixes are stripped when the remainder is itself a range
+ * (`workspace:1.2.3` → `1.2.3`); a bare shorthand with no version
+ * (`workspace:^`, `workspace:~`, `workspace:`) falls back to `*` instead,
+ * since there's nothing to build a real range from - a workspace peer is
+ * always resolved to its own current version, so it can never actually
+ * mismatch, and returning the bare operator itself would be an unparsable
+ * range that always reports the peer as unmet. A named-registry or `npm:`
+ * specifier contributes its version body (`work:5.x.x` → `5.x.x`,
+ * `npm:bar@^5` → `^5`); any other non-semver specifier (git, file, URL)
+ * becomes `*`, so the peer is satisfied by any version while its original
+ * specifier still selects the package to install. Valid semver ranges and
+ * `catalog:` specs are returned unchanged. A `||` union of scheme specifiers
+ * — produced when several consumers' ranges are merged for highest-match
+ * auto-installation — is reduced to the union of its version bodies
+ * (`work:^1 || work:^2` → `^1 || ^2`) so the result stays a comparable range.
  */
 export function getPeerVersionRange (version: string): string {
   if (version.includes('||')) {
     return version.split('||').map((part) => getPeerVersionRange(part.trim())).join(' || ')
   }
   if (isValidPeerRange(version)) {
-    return version.replace(/^workspace:/, '')
+    if (!version.startsWith('workspace:')) {
+      return version
+    }
+    const stripped = version.slice('workspace:'.length)
+    // `validRange('')` normalizes the empty string to `'*'` instead of
+    // rejecting it, unlike Rust's range parser - guard it explicitly so both
+    // implementations agree that a truly bare `workspace:` falls back here.
+    return stripped !== '' && validRange(stripped) != null ? stripped : '*'
   }
   const colon = version.indexOf(':')
   if (colon > 0) {

--- a/pnpm11/deps/peer-range/src/index.ts
+++ b/pnpm11/deps/peer-range/src/index.ts
@@ -26,14 +26,12 @@ export function isAcceptablePeerSpec (version: string): boolean {
 /**
  * The semver range a resolved version is checked against for a peer dependency.
  *
- * `workspace:` prefixes are stripped when the remainder is itself a range
- * (`workspace:1.2.3` → `1.2.3`); a bare shorthand with no version
- * (`workspace:^`, `workspace:~`, `workspace:`) falls back to `*` instead,
- * since there's nothing to build a real range from - a workspace peer is
- * always resolved to its own current version, so it can never actually
- * mismatch, and returning the bare operator itself would be an unparsable
- * range that always reports the peer as unmet. A named-registry or `npm:`
- * specifier contributes its version body (`work:5.x.x` → `5.x.x`,
+ * A `workspace:` prefix is stripped when the remainder is itself a range
+ * (`workspace:1.2.3` → `1.2.3`); the bare shorthand (`workspace:^`,
+ * `workspace:~`, `workspace:`) carries no version to build one from and
+ * becomes `*`, since a `workspace:` peer resolves to the linked project's
+ * own version — whatever that is, it is the wanted one. A named-registry or
+ * `npm:` specifier contributes its version body (`work:5.x.x` → `5.x.x`,
  * `npm:bar@^5` → `^5`); any other non-semver specifier (git, file, URL)
  * becomes `*`, so the peer is satisfied by any version while its original
  * specifier still selects the package to install. Valid semver ranges and
@@ -47,13 +45,10 @@ export function getPeerVersionRange (version: string): string {
     return version.split('||').map((part) => getPeerVersionRange(part.trim())).join(' || ')
   }
   if (isValidPeerRange(version)) {
-    if (!version.startsWith('workspace:')) {
-      return version
-    }
+    if (!version.startsWith('workspace:')) return version
     const stripped = version.slice('workspace:'.length)
-    // `validRange('')` normalizes the empty string to `'*'` instead of
-    // rejecting it, unlike Rust's range parser - guard it explicitly so both
-    // implementations agree that a truly bare `workspace:` falls back here.
+    // `validRange('')` accepts the empty string, so it needs its own check to
+    // reach the fallback rather than being returned as an empty range.
     return stripped !== '' && validRange(stripped) != null ? stripped : '*'
   }
   const colon = version.indexOf(':')

--- a/pnpm11/installing/deps-resolver/test/getPeerVersionRange.test.ts
+++ b/pnpm11/installing/deps-resolver/test/getPeerVersionRange.test.ts
@@ -32,10 +32,15 @@ test('getPeerVersionRange keeps valid peer ranges unchanged', () => {
   expect(getPeerVersionRange('catalog:')).toBe('catalog:')
 })
 
-test('getPeerVersionRange strips a leading workspace: prefix', () => {
-  expect(getPeerVersionRange('workspace:^')).toBe('^')
+test('getPeerVersionRange keeps an explicit workspace: version', () => {
   expect(getPeerVersionRange('workspace:1.2.3')).toBe('1.2.3')
+})
+
+test('getPeerVersionRange treats the workspace: wildcard tokens as *', () => {
   expect(getPeerVersionRange('workspace:*')).toBe('*')
+  expect(getPeerVersionRange('workspace:^')).toBe('*')
+  expect(getPeerVersionRange('workspace:~')).toBe('*')
+  expect(getPeerVersionRange('workspace:')).toBe('*')
 })
 
 test('getPeerVersionRange extracts the semver body from named-registry and npm: specifiers', () => {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Fixes pnpm/pnpm#14770.

Bare `workspace:` shorthand (`workspace:^`, `workspace:~`, `workspace:`) has no version to build a range from, so `get_peer_version_range` now falls back to `*` instead of returning the unparseable leftover (`^`, `~`, `""`). Explicit versions (`workspace:1.2.3`) are unaffected.

**Why `*`:** `workspace-range-resolver`, which already handles `workspace:` for regular `dependencies`, treats these same four tokens (`*`, `^`, `~`, `""`) as "match anything" (`is_wildcard`). This just brings peerDependencies in line with that.

**Why it's safe:** `get_peer_version_range` also feeds `hoist_peers.rs`, `resolve_peers/walker.rs`, `cache.rs`, and `context.rs` in the real resolver. In all of them, the bug already made "does version X satisfy" silently return false for bare-shorthand peers, falling back to "pick-highest"/"skip pinning". Since a workspace peer only ever has one real candidate, "pick highest" and "satisfies `*`" resolve to the same version. So this only lets the intended fast paths engage; it doesn't change what gets installed.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
`get_peer_version_range` stripped `workspace:` but left bare shorthand (`workspace:^`/`~`/empty) as an unparseable range that could never satisfy any installed version, so `pnpm peers check` always reported such peers as unmet; falls back to `*` for those tokens instead, matching `workspace-range-resolver`'s existing wildcard handling. Closes pnpm/pnpm#14770.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791625657&installation_model_id=426870&pr_number=14774&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14774&signature=0d7b05ed21bacf710ba338236238672554ae321bdd2de41b2a99218a5d3a2309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of workspace peer version ranges.
  - Explicit versions such as `workspace:1.2.3` continue to resolve to `1.2.3`.
  - Workspace wildcard forms, including `workspace:*`, `workspace:^`, `workspace:~`, and `workspace:`, now consistently resolve to `*`.
  - Prevents incomplete shorthand values from being interpreted as invalid or overly restrictive peer version ranges.
  - `pnpm peers check` now accurately reflects whether the installed peer version satisfies the workspace declaration.
  - Patch releases include this correction for the affected packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->