### PR TITLE
fix(fs): shorten windows permission-error retries

### DIFF
--- a/.changeset/short-windows-permission-retries.md
+++ b/.changeset/short-windows-permission-retries.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/fs.graceful-fs": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Windows filesystem operations now retry permission errors for up to one second. Permanent permission errors previously delayed failure by a minute. Sharing and lock violations retain their one-minute retry budget [pnpm/pnpm#14682](https://github.com/pnpm/pnpm/issues/14682).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5117,6 +5117,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4883,6 +4883,9 @@ importers:
         specifier: 'catalog:'
         version: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
     devDependencies:
+      '@jest/globals':
+        specifier: 'catalog:'
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/fs.graceful-fs':
         specifier: workspace:*
         version: 'link:'

--- a/pnpm/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests.rs
@@ -60,10 +60,6 @@ fn removing_bin_entries_preserves_their_targets() {
 }
 
 #[test]
-#[cfg_attr(
-    windows,
-    ignore = "Windows spends the retry budget on the permanent error: pnpm/pnpm#14682"
-)]
 fn bin_cleanup_and_replacement_preserve_deletion_errors() {
     let tmp = tempdir().unwrap();
     let pkg_dir = tmp.path().join("node_modules/node");

--- a/pnpm/crates/fs/Cargo.toml
+++ b/pnpm/crates/fs/Cargo.toml
@@ -27,5 +27,8 @@ sha2 = { workspace = true }
 [target.'cfg(windows)'.dependencies]
 junction = { workspace = true }
 
+[target.'cfg(windows)'.dev-dependencies]
+windows-sys = { workspace = true, features = ["Win32_Security"] }
+
 [lints]
 workspace = true

--- a/pnpm/crates/fs/src/copy_dirent.rs
+++ b/pnpm/crates/fs/src/copy_dirent.rs
@@ -63,7 +63,7 @@ fn copy_symlink(src: &Path, dst: &Path, file_type: fs::FileType) -> io::Result<(
         if file_type.is_symlink_dir() {
             return std::os::windows::fs::symlink_dir(&target, &dst);
         }
-        return std::os::windows::fs::symlink_file(&target, &dst);
+        std::os::windows::fs::symlink_file(&target, &dst)
     }
     #[cfg(unix)]
     {

--- a/pnpm/crates/fs/src/retry.rs
+++ b/pnpm/crates/fs/src/retry.rs
@@ -6,6 +6,8 @@ use std::time::{Duration, Instant};
 #[cfg(any(windows, test))]
 const RETRY_BUDGET: Duration = Duration::from_mins(1);
 #[cfg(any(windows, test))]
+const PERMISSION_DENIED_RETRY_BUDGET: Duration = Duration::from_secs(1);
+#[cfg(any(windows, test))]
 const RETRY_BACKOFF_CAP: Duration = Duration::from_millis(100);
 
 pub(crate) const ERROR_SHARING_VIOLATION: i32 = 32;
@@ -17,6 +19,8 @@ pub(crate) const ERROR_LOCK_VIOLATION: i32 = 33;
 /// unlucky rename or removal with an access-denied, sharing-violation, or
 /// busy error that clears moments later. Such errors are retried with a
 /// bounded backoff for up to one minute before the last one is returned.
+/// Permission errors have a one-second budget because they can also indicate
+/// permanent ACL, read-only, or destination-type conflicts.
 /// On Unix the operation runs exactly once: the equivalent error kinds
 /// there usually mean a permanent permissions or mount-point problem, so
 /// retrying would only delay the failure.
@@ -107,6 +111,11 @@ where
             Ok(value) => return Ok(value),
             Err(error) => error,
         };
+        if error.kind() == io::ErrorKind::PermissionDenied
+            && !matches!(error.raw_os_error(), Some(ERROR_SHARING_VIOLATION | ERROR_LOCK_VIOLATION))
+        {
+            timing.budget = timing.budget.min(PERMISSION_DENIED_RETRY_BUDGET);
+        }
         if !is_transient(&error) || !wait_for_retry(&mut timing, backoff) {
             return Err(error);
         }

--- a/pnpm/crates/fs/src/retry/tests.rs
+++ b/pnpm/crates/fs/src/retry/tests.rs
@@ -116,3 +116,51 @@ fn remove_dir_all_with_retry_removes_the_tree() {
 
     assert!(!target.exists(), "directory tree should be gone after removal");
 }
+
+#[cfg(windows)]
+mod windows;
+
+#[test]
+fn permission_errors_shorten_the_budget_even_when_errors_change() {
+    for permission_attempt in [0, 3] {
+        let attempts = Cell::new(0);
+        let elapsed = Cell::new(Duration::ZERO);
+        let result: io::Result<()> = retry_fs_operation_with_timing(
+            || {
+                let attempt = attempts.get();
+                attempts.set(attempt + 1);
+                Err(io::Error::from(if attempt == permission_attempt {
+                    io::ErrorKind::PermissionDenied
+                } else {
+                    io::ErrorKind::ResourceBusy
+                }))
+            },
+            |_| true,
+            RetryTiming {
+                budget: Duration::from_mins(1),
+                elapsed: || elapsed.get(),
+                sleep: |delay| elapsed.set(elapsed.get() + delay),
+            },
+        );
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::ResourceBusy);
+        assert_eq!(elapsed.get(), Duration::from_secs(1));
+    }
+}
+
+#[test]
+fn explicit_locks_keep_the_full_budget() {
+    for code in [ERROR_SHARING_VIOLATION, ERROR_LOCK_VIOLATION] {
+        let elapsed = Cell::new(Duration::ZERO);
+        let result: io::Result<()> = retry_fs_operation_with_timing(
+            || Err(io::Error::from_raw_os_error(code)),
+            |_| true,
+            RetryTiming {
+                budget: Duration::from_mins(1),
+                elapsed: || elapsed.get(),
+                sleep: |delay| elapsed.set(elapsed.get() + delay),
+            },
+        );
+        assert_eq!(result.unwrap_err().raw_os_error(), Some(code));
+        assert_eq!(elapsed.get(), Duration::from_mins(1));
+    }
+}

--- a/pnpm/crates/fs/src/retry/tests/windows.rs
+++ b/pnpm/crates/fs/src/retry/tests/windows.rs
@@ -1,0 +1,104 @@
+use crate::{remove_dir_all_with_retry, remove_file_with_retry, rename_with_retry};
+use std::{
+    fs, io,
+    path::Path,
+    process::Command,
+    time::{Duration, Instant},
+};
+use tempfile::tempdir;
+
+fn assert_fails_promptly(operation: impl FnOnce() -> io::Result<()>) {
+    let started = Instant::now();
+    let error = operation().expect_err("the protected entry must not be changed");
+    let elapsed = started.elapsed();
+    assert_eq!(error.raw_os_error(), Some(5));
+    eprintln!("access denied after {elapsed:?}");
+    assert!(elapsed < Duration::from_secs(5));
+}
+
+#[test]
+fn readonly_destination_rename_fails_promptly() {
+    let root = tempdir().unwrap();
+    let tree = root.path().join("tree");
+    fs::create_dir(&tree).unwrap();
+    let protected = tree.join("file");
+    let source = root.path().join("source");
+    fs::write(&protected, "preserved").unwrap();
+    fs::write(&source, "replacement").unwrap();
+    let original = fs::metadata(&protected).unwrap().permissions();
+    let mut readonly = original.clone();
+    readonly.set_readonly(true);
+    fs::set_permissions(&protected, readonly).unwrap();
+
+    assert_fails_promptly(|| rename_with_retry(&source, &protected));
+
+    fs::set_permissions(&protected, original).unwrap();
+    assert_eq!(fs::read_to_string(protected).unwrap(), "preserved");
+    assert_eq!(fs::read_to_string(source).unwrap(), "replacement");
+}
+
+fn icacls(path: &Path, arguments: &[&str]) {
+    let output = Command::new("icacls").arg(path).args(arguments).output().unwrap();
+    assert!(output.status.success(), "icacls failed: {output:?}");
+}
+
+#[test]
+fn restrictive_acls_fail_promptly() {
+    let root = tempdir().unwrap();
+    let tree = root.path().join("tree");
+    fs::create_dir(&tree).unwrap();
+    let protected = tree.join("file");
+    let destination = root.path().join("destination");
+    fs::write(&protected, "preserved").unwrap();
+    icacls(&tree, &["/deny", "*S-1-1-0:(DC)"]);
+    icacls(&protected, &["/deny", "*S-1-1-0:(D)"]);
+
+    assert_fails_promptly(|| remove_file_with_retry(&protected));
+    assert_fails_promptly(|| rename_with_retry(&protected, &destination));
+    assert_fails_promptly(|| remove_dir_all_with_retry(&tree));
+
+    icacls(&protected, &["/remove:d", "*S-1-1-0"]);
+    icacls(&tree, &["/remove:d", "*S-1-1-0"]);
+    assert_eq!(fs::read_to_string(protected).unwrap(), "preserved");
+    assert!(!destination.exists(), "failed rename must not create the destination");
+}
+
+#[test]
+fn directory_destinations_fail_promptly() {
+    let root = tempdir().unwrap();
+    let source = root.path().join("source");
+    let destination = root.path().join("destination");
+    fs::write(&source, "source").unwrap();
+    fs::create_dir(&destination).unwrap();
+    fs::write(destination.join("child"), "preserved").unwrap();
+
+    assert_fails_promptly(|| rename_with_retry(&source, &destination));
+    assert_fails_promptly(|| remove_file_with_retry(&destination));
+
+    assert_eq!(fs::read_to_string(source).unwrap(), "source");
+    assert_eq!(fs::read_to_string(destination.join("child")).unwrap(), "preserved");
+}
+
+#[test]
+fn directory_rename_recovers_after_a_child_handle_closes() {
+    use std::os::windows::fs::OpenOptionsExt as _;
+
+    let root = tempdir().unwrap();
+    let source = root.path().join("source");
+    let destination = root.path().join("destination");
+    fs::create_dir(&source).unwrap();
+    let child = source.join("child");
+    fs::write(&child, "preserved").unwrap();
+    let handle = fs::OpenOptions::new().read(true).share_mode(0x1 | 0x2).open(&child).unwrap();
+    assert_eq!(fs::rename(&source, &destination).unwrap_err().raw_os_error(), Some(5));
+
+    std::thread::scope(|scope| {
+        scope.spawn(move || {
+            std::thread::sleep(Duration::from_millis(100));
+            drop(handle);
+        });
+        rename_with_retry(&source, &destination).unwrap();
+    });
+
+    assert_eq!(fs::read_to_string(destination.join("child")).unwrap(), "preserved");
+}

--- a/pnpm/crates/fs/src/retry/tests/windows.rs
+++ b/pnpm/crates/fs/src/retry/tests/windows.rs
@@ -39,6 +39,7 @@ fn readonly_destination_rename_fails_promptly() {
 
 fn icacls(path: &Path, arguments: &[&str]) {
     let output = Command::new("icacls").arg(path).args(arguments).output().unwrap();
+    eprintln!("icacls {path:?} {arguments:?}: {output:?}");
     assert!(output.status.success(), "icacls failed: {output:?}");
 }
 
@@ -50,15 +51,18 @@ fn restrictive_acls_fail_promptly() {
     let protected = tree.join("file");
     let destination = root.path().join("destination");
     fs::write(&protected, "preserved").unwrap();
-    icacls(&tree, &["/deny", "*S-1-1-0:(DC)"]);
-    icacls(&protected, &["/deny", "*S-1-1-0:(D)"]);
+    icacls(&tree, &["/inheritance:r", "/grant:r", "*S-1-1-0:(RX,WDAC)"]);
+    icacls(&protected, &["/inheritance:r", "/grant:r", "*S-1-1-0:(R,WDAC)"]);
+    icacls(&tree, &[]);
+    icacls(&protected, &[]);
+    assert_eq!(fs::remove_file(&protected).unwrap_err().raw_os_error(), Some(5));
 
     assert_fails_promptly(|| remove_file_with_retry(&protected));
     assert_fails_promptly(|| rename_with_retry(&protected, &destination));
     assert_fails_promptly(|| remove_dir_all_with_retry(&tree));
 
-    icacls(&protected, &["/remove:d", "*S-1-1-0"]);
-    icacls(&tree, &["/remove:d", "*S-1-1-0"]);
+    icacls(&tree, &["/reset"]);
+    icacls(&protected, &["/reset"]);
     assert_eq!(fs::read_to_string(protected).unwrap(), "preserved");
     assert!(!destination.exists(), "failed rename must not create the destination");
 }

--- a/pnpm/crates/fs/src/retry/tests/windows.rs
+++ b/pnpm/crates/fs/src/retry/tests/windows.rs
@@ -1,11 +1,20 @@
 use crate::{remove_dir_all_with_retry, remove_file_with_retry, rename_with_retry};
 use std::{
     fs, io,
+    os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle},
     path::Path,
     process::Command,
+    ptr::{null, null_mut},
     time::{Duration, Instant},
 };
 use tempfile::tempdir;
+use windows_sys::Win32::{
+    Security::{
+        AdjustTokenPrivileges, ImpersonateSelf, RevertToSelf, SecurityImpersonation,
+        TOKEN_ADJUST_PRIVILEGES,
+    },
+    System::Threading::{GetCurrentThread, OpenThreadToken},
+};
 
 fn assert_fails_promptly(operation: impl FnOnce() -> io::Result<()>) {
     let started = Instant::now();
@@ -55,11 +64,12 @@ fn restrictive_acls_fail_promptly() {
     icacls(&protected, &["/inheritance:r", "/grant:r", "*S-1-1-0:(R,WDAC)"]);
     icacls(&tree, &[]);
     icacls(&protected, &[]);
-    assert_eq!(fs::remove_file(&protected).unwrap_err().raw_os_error(), Some(5));
-
-    assert_fails_promptly(|| remove_file_with_retry(&protected));
-    assert_fails_promptly(|| rename_with_retry(&protected, &destination));
-    assert_fails_promptly(|| remove_dir_all_with_retry(&tree));
+    without_thread_privileges(|| {
+        assert_eq!(fs::remove_file(&protected).unwrap_err().raw_os_error(), Some(5));
+        assert_fails_promptly(|| remove_file_with_retry(&protected));
+        assert_fails_promptly(|| rename_with_retry(&protected, &destination));
+        assert_fails_promptly(|| remove_dir_all_with_retry(&tree));
+    });
 
     icacls(&tree, &["/reset"]);
     icacls(&protected, &["/reset"]);
@@ -105,4 +115,46 @@ fn directory_rename_recovers_after_a_child_handle_closes() {
     });
 
     assert_eq!(fs::read_to_string(destination.join("child")).unwrap(), "preserved");
+}
+
+// Elevated test runners can bypass ACLs through backup/restore privileges.
+// Impersonation confines the privilege change to this test's thread.
+fn without_thread_privileges(operation: impl FnOnce()) {
+    struct RevertImpersonation;
+    impl Drop for RevertImpersonation {
+        fn drop(&mut self) {
+            // SAFETY: this guard stays on the thread that called ImpersonateSelf.
+            assert_ne!(unsafe { RevertToSelf() }, 0, "{}", io::Error::last_os_error());
+        }
+    }
+
+    assert_ne!(
+        // SAFETY: SecurityImpersonation is a valid level; no pointers are passed.
+        unsafe { ImpersonateSelf(SecurityImpersonation) },
+        0,
+        "{}",
+        io::Error::last_os_error()
+    );
+    let _revert = RevertImpersonation;
+    let mut token = null_mut();
+    assert_ne!(
+        // SAFETY: GetCurrentThread returns a valid pseudo-handle and token is a writable output.
+        unsafe { OpenThreadToken(GetCurrentThread(), TOKEN_ADJUST_PRIVILEGES, 1, &raw mut token) },
+        0,
+        "{}",
+        io::Error::last_os_error()
+    );
+    // SAFETY: OpenThreadToken succeeded and ownership of its handle transfers exactly once.
+    let token = unsafe { OwnedHandle::from_raw_handle(token) };
+    assert_ne!(
+        // SAFETY: the token has TOKEN_ADJUST_PRIVILEGES access. Disabling all privileges
+        // permits null state/output pointers and a zero buffer length.
+        unsafe {
+            AdjustTokenPrivileges(token.as_raw_handle(), 1, null(), 0, null_mut(), null_mut())
+        },
+        0,
+        "{}",
+        io::Error::last_os_error()
+    );
+    operation();
 }

--- a/pnpm11/fs/graceful-fs/package.json
+++ b/pnpm11/fs/graceful-fs/package.json
@@ -24,15 +24,17 @@
     "!*.map"
   ],
   "scripts": {
-    "lint": "eslint \"src/**/*.ts\"",
-    "test": "pn compile",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "test": "pn compile && pn .test",
     "prepublishOnly": "tsgo --build",
-    "compile": "tsgo --build && pn lint --fix"
+    "compile": "tsgo --build && pn lint --fix",
+    ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"
   },
   "dependencies": {
     "graceful-fs": "catalog:"
   },
   "devDependencies": {
+    "@jest/globals": "catalog:",
     "@pnpm/fs.graceful-fs": "workspace:*",
     "@types/graceful-fs": "catalog:"
   },

--- a/pnpm11/fs/graceful-fs/src/index.ts
+++ b/pnpm11/fs/graceful-fs/src/index.ts
@@ -4,6 +4,7 @@ import util, { promisify } from 'node:util'
 import gfs from 'graceful-fs'
 
 const RENAME_RETRY_BUDGET_MS = 60_000
+const PERMISSION_DENIED_RETRY_BUDGET_MS = 1_000
 const RENAME_RETRY_BACKOFF_CAP_MS = 100
 const renameRetrySleepBuffer = new Int32Array(new SharedArrayBuffer(4))
 
@@ -53,9 +54,10 @@ function withEagainRetry<T extends unknown[], R> (
 }
 
 /**
- * Renames `src` over `dest`, waiting out a Windows sharing violation — an
- * EPERM, EACCES or EBUSY from whoever else holds the file open — for up to a
- * minute before rethrowing it. Every other error is thrown right away.
+ * Renames `src` over `dest`, retrying Windows EBUSY errors for up to a minute.
+ * EPERM and EACCES have a one-second budget because they can also indicate
+ * permanent permission or destination conflicts. Other errors are thrown
+ * right away.
  *
  * `dest` is never removed to make room for the rename: a concurrent install may
  * still be reading that dirent, and a reader has to see either the whole file
@@ -64,19 +66,24 @@ function withEagainRetry<T extends unknown[], R> (
 export function renameFileWithRetry (src: string, dest: string): void {
   const startedAt = Date.now()
   let backoffMs = 0
+  let budgetMs = RENAME_RETRY_BUDGET_MS
   for (;;) {
     try {
       fs.renameSync(src, dest)
       return
     } catch (err) {
-      if (!isTransientRenameError(err) || Date.now() - startedAt >= RENAME_RETRY_BUDGET_MS) throw err
-      if (backoffMs > 0) Atomics.wait(renameRetrySleepBuffer, 0, 0, backoffMs)
+      if (!isTransientRenameError(err)) throw err
+      if (err.code === 'EPERM' || err.code === 'EACCES') budgetMs = Math.min(budgetMs, PERMISSION_DENIED_RETRY_BUDGET_MS)
+      const remainingMs = budgetMs - (Date.now() - startedAt)
+      if (remainingMs <= 0) throw err
+      if (backoffMs > 0) Atomics.wait(renameRetrySleepBuffer, 0, 0, Math.min(backoffMs, remainingMs))
+      if (Date.now() - startedAt >= budgetMs) throw err
       backoffMs = Math.min(backoffMs + 10, RENAME_RETRY_BACKOFF_CAP_MS)
     }
   }
 }
 
-function isTransientRenameError (err: unknown): boolean {
+function isTransientRenameError (err: unknown): err is NodeJS.ErrnoException {
   return process.platform === 'win32' &&
     util.types.isNativeError(err) &&
     'code' in err &&

--- a/pnpm11/fs/graceful-fs/test/processPrivileges.ps1
+++ b/pnpm11/fs/graceful-fs/test/processPrivileges.ps1
@@ -1,0 +1,55 @@
+param([int]$TargetProcessId, [string]$RestoreState)
+
+$ErrorActionPreference = 'Stop'
+Add-Type @'
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+public static class ProcessPrivileges {
+    [DllImport("advapi32.dll", SetLastError = true)]
+    static extern bool OpenProcessToken(IntPtr process, int access, out SafeAccessTokenHandle token);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    static extern bool GetTokenInformation(SafeAccessTokenHandle token, int informationClass,
+        [Out] byte[] information, int length, out int requiredLength);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    static extern bool AdjustTokenPrivileges(SafeAccessTokenHandle token, bool disableAll,
+        byte[] newState, int length, IntPtr previousState, IntPtr requiredLength);
+
+    public static string Set(int processId, string restoreState) {
+        using (var process = Process.GetProcessById(processId)) {
+            SafeAccessTokenHandle token;
+            const int TokenQueryAndAdjustPrivileges = 0x28;
+            if (!OpenProcessToken(process.Handle, TokenQueryAndAdjustPrivileges, out token))
+                throw new Win32Exception();
+            using (token) {
+                byte[] state;
+                bool disableAll = String.IsNullOrEmpty(restoreState);
+                if (disableAll) {
+                    const int TokenPrivileges = 3;
+                    int length;
+                    GetTokenInformation(token, TokenPrivileges, null, 0, out length);
+                    const int ErrorInsufficientBuffer = 122;
+                    if (Marshal.GetLastWin32Error() != ErrorInsufficientBuffer)
+                        throw new Win32Exception();
+                    state = new byte[length];
+                    if (!GetTokenInformation(token, TokenPrivileges, state, state.Length, out length))
+                        throw new Win32Exception();
+                } else {
+                    state = Convert.FromBase64String(restoreState);
+                }
+                if (!AdjustTokenPrivileges(token, disableAll, state, 0, IntPtr.Zero, IntPtr.Zero)
+                    || Marshal.GetLastWin32Error() != 0)
+                    throw new Win32Exception();
+                return Convert.ToBase64String(state);
+            }
+        }
+    }
+}
+'@
+
+[ProcessPrivileges]::Set($TargetProcessId, $RestoreState)

--- a/pnpm11/fs/graceful-fs/test/renameFileWithRetry.test.ts
+++ b/pnpm11/fs/graceful-fs/test/renameFileWithRetry.test.ts
@@ -106,15 +106,22 @@ windowsTest('a restrictive ACL fails promptly and preserves the source', () => {
   try {
     execFileSync('icacls', [root, '/inheritance:r', '/grant:r', '*S-1-1-0:(RX,WDAC)'])
     execFileSync('icacls', [source, '/inheritance:r', '/grant:r', '*S-1-1-0:(R,WDAC)'])
-    expect(() => fs.renameSync(source, destination)).toThrow()
-    const started = Date.now()
-    expect(() => renameFileWithRetry(source, destination)).toThrow()
-    expect(Date.now() - started).toBeLessThan(5_000)
-    expect(fs.readFileSync(source, 'utf8')).toBe('preserved')
-    expect(fs.existsSync(destination)).toBe(false)
+    // Elevated Windows runners can bypass ACLs with backup/restore privileges.
+    const privilegesScript = path.join(__dirname, 'processPrivileges.ps1')
+    const args = ['-NoProfile', '-NonInteractive', '-File', privilegesScript, String(process.pid)]
+    const privileges = execFileSync('powershell.exe', args, { encoding: 'utf8' }).trim()
+    try {
+      expect(() => fs.renameSync(source, destination)).toThrow()
+      const started = Date.now()
+      expect(() => renameFileWithRetry(source, destination)).toThrow()
+      expect(Date.now() - started).toBeLessThan(5_000)
+      expect(fs.readFileSync(source, 'utf8')).toBe('preserved')
+      expect(fs.existsSync(destination)).toBe(false)
+    } finally {
+      execFileSync('powershell.exe', [...args, privileges])
+    }
   } finally {
-    execFileSync('icacls', [root, '/reset'])
-    execFileSync('icacls', [source, '/reset'])
+    execFileSync('icacls', [root, '/reset', '/T'])
     fs.rmSync(root, { recursive: true })
   }
 })

--- a/pnpm11/fs/graceful-fs/test/renameFileWithRetry.test.ts
+++ b/pnpm11/fs/graceful-fs/test/renameFileWithRetry.test.ts
@@ -1,0 +1,135 @@
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, expect, jest, test } from '@jest/globals'
+import { renameFileWithRetry } from '@pnpm/fs.graceful-fs'
+
+const platform = Object.getOwnPropertyDescriptor(process, 'platform')!
+
+afterEach(() => {
+  jest.restoreAllMocks()
+  Object.defineProperty(process, 'platform', platform)
+})
+
+test.each(['EPERM', 'EACCES', 'EBUSY'])('%s uses its bounded Windows retry budget', (code) => {
+  Object.defineProperty(process, 'platform', { value: 'win32' })
+  let elapsed = 0
+  jest.spyOn(Date, 'now').mockImplementation(() => elapsed)
+  jest.spyOn(Atomics, 'wait').mockImplementation((_array, _index, _value, delay) => {
+    elapsed += delay!
+    return 'timed-out'
+  })
+  const error = Object.assign(new Error('rename failed'), { code })
+  jest.spyOn(fs, 'renameSync').mockImplementation(() => {
+    throw error
+  })
+
+  expect(() => renameFileWithRetry('source', 'destination')).toThrow(error)
+  expect(elapsed).toBe(code === 'EBUSY' ? 60_000 : 1_000)
+})
+
+test('a permission error keeps the short deadline when subsequent errors are busy', () => {
+  Object.defineProperty(process, 'platform', { value: 'win32' })
+  let elapsed = 0
+  jest.spyOn(Date, 'now').mockImplementation(() => elapsed)
+  jest.spyOn(Atomics, 'wait').mockImplementation((_array, _index, _value, delay) => {
+    elapsed += delay!
+    return 'timed-out'
+  })
+  const denied = Object.assign(new Error('denied'), { code: 'EPERM' })
+  const busy = Object.assign(new Error('busy'), { code: 'EBUSY' })
+  jest.spyOn(fs, 'renameSync')
+    .mockImplementationOnce(() => {
+      throw denied
+    })
+    .mockImplementation(() => {
+      throw busy
+    })
+
+  expect(() => renameFileWithRetry('source', 'destination')).toThrow(busy)
+  expect(elapsed).toBe(1_000)
+})
+
+test('rename recovers from a temporary permission error', () => {
+  Object.defineProperty(process, 'platform', { value: 'win32' })
+  const rename = jest.spyOn(fs, 'renameSync')
+    .mockImplementationOnce(() => {
+      throw Object.assign(new Error('denied'), { code: 'EPERM' })
+    })
+    .mockImplementation(() => {})
+
+  renameFileWithRetry('source', 'destination')
+  expect(rename).toHaveBeenCalledTimes(2)
+})
+
+test('Unix permission errors are returned immediately', () => {
+  Object.defineProperty(process, 'platform', { value: 'linux' })
+  const error = Object.assign(new Error('denied'), { code: 'EACCES' })
+  const rename = jest.spyOn(fs, 'renameSync').mockImplementation(() => {
+    throw error
+  })
+
+  expect(() => renameFileWithRetry('source', 'destination')).toThrow(error)
+  expect(rename).toHaveBeenCalledTimes(1)
+})
+
+const windowsTest = process.platform === 'win32' ? test : test.skip
+
+windowsTest('a read-only destination fails promptly and preserves both files', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rename-retry-'))
+  const source = path.join(root, 'source')
+  const destination = path.join(root, 'destination')
+  try {
+    fs.writeFileSync(source, 'replacement')
+    fs.writeFileSync(destination, 'preserved')
+    fs.chmodSync(destination, 0o444)
+    const started = Date.now()
+    expect(() => renameFileWithRetry(source, destination)).toThrow()
+    expect(Date.now() - started).toBeLessThan(5_000)
+    expect(fs.readFileSync(source, 'utf8')).toBe('replacement')
+    expect(fs.readFileSync(destination, 'utf8')).toBe('preserved')
+  } finally {
+    fs.chmodSync(destination, 0o666)
+    fs.rmSync(root, { recursive: true })
+  }
+})
+
+windowsTest('a restrictive ACL fails promptly and preserves the source', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rename-retry-'))
+  const source = path.join(root, 'source')
+  const destination = path.join(root, 'destination')
+  fs.writeFileSync(source, 'preserved')
+  try {
+    execFileSync('icacls', [root, '/deny', '*S-1-1-0:(DC)'])
+    execFileSync('icacls', [source, '/deny', '*S-1-1-0:(D)'])
+    const started = Date.now()
+    expect(() => renameFileWithRetry(source, destination)).toThrow()
+    expect(Date.now() - started).toBeLessThan(5_000)
+    expect(fs.readFileSync(source, 'utf8')).toBe('preserved')
+    expect(fs.existsSync(destination)).toBe(false)
+  } finally {
+    execFileSync('icacls', [source, '/remove:d', '*S-1-1-0'])
+    execFileSync('icacls', [root, '/remove:d', '*S-1-1-0'])
+    fs.rmSync(root, { recursive: true })
+  }
+})
+
+windowsTest('a directory destination fails promptly and preserves its children', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rename-retry-'))
+  const source = path.join(root, 'source')
+  const destination = path.join(root, 'destination')
+  try {
+    fs.writeFileSync(source, 'source')
+    fs.mkdirSync(destination)
+    fs.writeFileSync(path.join(destination, 'child'), 'preserved')
+    const started = Date.now()
+    expect(() => renameFileWithRetry(source, destination)).toThrow()
+    expect(Date.now() - started).toBeLessThan(5_000)
+    expect(fs.readFileSync(source, 'utf8')).toBe('source')
+    expect(fs.readFileSync(path.join(destination, 'child'), 'utf8')).toBe('preserved')
+  } finally {
+    fs.rmSync(root, { recursive: true })
+  }
+})

--- a/pnpm11/fs/graceful-fs/test/renameFileWithRetry.test.ts
+++ b/pnpm11/fs/graceful-fs/test/renameFileWithRetry.test.ts
@@ -1,5 +1,6 @@
 // cspell:ignore WDAC
-import { execFileSync } from 'node:child_process'
+import { execFileSync, spawn } from 'node:child_process'
+import { once } from 'node:events'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -132,6 +133,71 @@ windowsTest('a directory destination fails promptly and preserves its children',
     expect(fs.readFileSync(source, 'utf8')).toBe('source')
     expect(fs.readFileSync(path.join(destination, 'child'), 'utf8')).toBe('preserved')
   } finally {
+    fs.rmSync(root, { recursive: true })
+  }
+})
+
+windowsTest('rename recovers after a child process releases a real directory lock', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rename-retry-'))
+  const source = path.join(root, 'source')
+  const destination = path.join(root, 'destination')
+  const lockedFile = path.join(source, 'child')
+  const releaseFile = path.join(root, 'release')
+  fs.mkdirSync(source)
+  fs.writeFileSync(lockedFile, 'preserved')
+  const child = spawn('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', `
+    $ErrorActionPreference = 'Stop'
+    $handle = [System.IO.File]::Open($env:PNPM_TEST_LOCK_FILE, 'Open', 'Read', 'ReadWrite')
+    try {
+      Write-Output 'ready'
+      $deadline = [DateTime]::UtcNow.AddSeconds(10)
+      while (-not (Test-Path -LiteralPath $env:PNPM_TEST_RELEASE_FILE)) {
+        if ([DateTime]::UtcNow -ge $deadline) { throw 'Lock release timed out' }
+        Start-Sleep -Milliseconds 10
+      }
+    } finally {
+      $handle.Dispose()
+    }
+  `], {
+    env: { ...process.env, PNPM_TEST_LOCK_FILE: lockedFile, PNPM_TEST_RELEASE_FILE: releaseFile },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  let stderr = ''
+  child.stderr.on('data', (chunk) => {
+    stderr += String(chunk)
+  })
+  const exited = new Promise<number | Error | null>((resolve) => {
+    child.once('error', resolve)
+    child.once('exit', resolve)
+  })
+  try {
+    await Promise.race([
+      once(child.stdout, 'data').then(([chunk]) => {
+        expect(String(chunk).trim()).toBe('ready')
+      }),
+      exited.then((code) => {
+        throw new Error(`Lock holder exited early (${code}): ${stderr}`)
+      }),
+    ])
+    const rename = fs.renameSync
+    const failures: unknown[] = []
+    jest.spyOn(fs, 'renameSync').mockImplementation((from, to) => {
+      try {
+        rename(from, to)
+      } catch (error) {
+        failures.push(error)
+        fs.writeFileSync(releaseFile, '')
+        throw error
+      }
+    })
+    renameFileWithRetry(source, destination)
+    expect(failures.length).toBeGreaterThan(0)
+    expect(failures[0]).toMatchObject({ code: 'EPERM' })
+    expect(await exited).toBe(0)
+    expect(fs.readFileSync(path.join(destination, 'child'), 'utf8')).toBe('preserved')
+  } finally {
+    child.kill()
+    await exited
     fs.rmSync(root, { recursive: true })
   }
 })

--- a/pnpm11/fs/graceful-fs/test/renameFileWithRetry.test.ts
+++ b/pnpm11/fs/graceful-fs/test/renameFileWithRetry.test.ts
@@ -9,6 +9,7 @@ import { afterEach, expect, jest, test } from '@jest/globals'
 import { renameFileWithRetry } from '@pnpm/fs.graceful-fs'
 
 const platform = Object.getOwnPropertyDescriptor(process, 'platform')!
+const privilegesScript = path.join(import.meta.dirname, 'processPrivileges.ps1')
 
 afterEach(() => {
   jest.restoreAllMocks()
@@ -107,7 +108,6 @@ windowsTest('a restrictive ACL fails promptly and preserves the source', () => {
     execFileSync('icacls', [root, '/inheritance:r', '/grant:r', '*S-1-1-0:(RX,WDAC)'])
     execFileSync('icacls', [source, '/inheritance:r', '/grant:r', '*S-1-1-0:(R,WDAC)'])
     // Elevated Windows runners can bypass ACLs with backup/restore privileges.
-    const privilegesScript = path.join(__dirname, 'processPrivileges.ps1')
     const args = ['-NoProfile', '-NonInteractive', '-File', privilegesScript, String(process.pid)]
     const privileges = execFileSync('powershell.exe', args, { encoding: 'utf8' }).trim()
     try {

--- a/pnpm11/fs/graceful-fs/test/renameFileWithRetry.test.ts
+++ b/pnpm11/fs/graceful-fs/test/renameFileWithRetry.test.ts
@@ -1,3 +1,4 @@
+// cspell:ignore WDAC
 import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
@@ -102,16 +103,17 @@ windowsTest('a restrictive ACL fails promptly and preserves the source', () => {
   const destination = path.join(root, 'destination')
   fs.writeFileSync(source, 'preserved')
   try {
-    execFileSync('icacls', [root, '/deny', '*S-1-1-0:(DC)'])
-    execFileSync('icacls', [source, '/deny', '*S-1-1-0:(D)'])
+    execFileSync('icacls', [root, '/inheritance:r', '/grant:r', '*S-1-1-0:(RX,WDAC)'])
+    execFileSync('icacls', [source, '/inheritance:r', '/grant:r', '*S-1-1-0:(R,WDAC)'])
+    expect(() => fs.renameSync(source, destination)).toThrow()
     const started = Date.now()
     expect(() => renameFileWithRetry(source, destination)).toThrow()
     expect(Date.now() - started).toBeLessThan(5_000)
     expect(fs.readFileSync(source, 'utf8')).toBe('preserved')
     expect(fs.existsSync(destination)).toBe(false)
   } finally {
-    execFileSync('icacls', [source, '/remove:d', '*S-1-1-0'])
-    execFileSync('icacls', [root, '/remove:d', '*S-1-1-0'])
+    execFileSync('icacls', [root, '/reset'])
+    execFileSync('icacls', [source, '/reset'])
     fs.rmSync(root, { recursive: true })
   }
 })

--- a/pnpm11/fs/graceful-fs/test/tsconfig.json
+++ b/pnpm11/fs/graceful-fs/test/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "../node_modules/.test.lib",
+    "rootDir": "..",
+    "isolatedModules": true
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pnpm11/installing/commands/test/fetch.ts
+++ b/pnpm11/installing/commands/test/fetch.ts
@@ -8,7 +8,7 @@ import { prepare } from '@pnpm/prepare'
 import { closeAllStoreIndexes } from '@pnpm/store.index'
 import { fixtures } from '@pnpm/test-fixtures'
 import { REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
-import { finishWorkers } from '@pnpm/worker'
+import { restartWorkerPool } from '@pnpm/worker'
 import { rimrafSync } from '@zkochan/rimraf'
 
 const REGISTRY_URL = `http://localhost:${REGISTRY_MOCK_PORT}`
@@ -209,7 +209,7 @@ test('fetch populates global virtual store links/', async () => {
   })
 
   // Drain workers and close SQLite connections before removing the store (required on Windows)
-  await finishWorkers()
+  await restartWorkerPool()
   closeAllStoreIndexes()
 
   // Remove the store — simulate a cold start with only the lockfile


### PR DESCRIPTION
## Summary

Limit Windows permission-error retries to one second in pnpm v12's shared filesystem retry policy and pnpm v11's file-rename helper. Explicit sharing/lock violations and busy errors retain the one-minute budget. A permission error shortens the existing deadline permanently, even if subsequent attempts return different errors.

Access-denied locks lasting longer than one second now fail sooner. This preserves recovery from short-lived access-denied locks while avoiding minute-long waits for restrictive ACLs, read-only rename destinations, and directories occupying file destinations. The policy only changes retry timing; it preserves filesystem errors and never adjusts permissions or deletes a destination to force a rename.

Validation: `just ready` passed all 11,006 tests (13 skipped), and the full TypeScript build passed. All 10 v11 filesystem tests passed on native Windows, including restrictive ACLs (1.48 seconds including fixture setup), read-only and directory conflicts (about one second each), and real child-process lock recovery. Restoring the old v11 helper makes four deadline assertions fail. Rust CI passed on Windows, macOS, and Linux, including the native ACL regression and re-enabled shim test.

The native ACL fixtures temporarily disable elevated runner privileges so they cannot bypass the permissions under test. Rust uses a scoped thread impersonation token with the workspace's existing `windows-sys` dependency. The v11 test uses a test-only PowerShell helper to save, disable, and restore the Node process privileges. Windows-targeted compilation and clippy also pass locally.

Fixed a worker-pool lifecycle error exposed by the Node 26 fetch tests in CI. The test now restarts the pool after draining it. With one worker, the fetch test file reproduced two timeouts before the change and passed all eight tests afterward. The complete Node 26 CI suite also passed with this fix.

Closes pnpm/pnpm#14682.

## Squash Commit Body

```text
Windows access denied is ambiguous: an open child handle can prevent a
rename, but permanent ACL and destination conflicts report the same error.
Use a one-second budget for permission errors while retaining one minute
for explicit sharing/lock violations and busy errors. Apply the short
budget to the original operation start and never extend it after a later
error changes kind. Cap sleeps to the deadline and return the last error.

Apply the same policy to v11's synchronous file-rename helper. Add fake-clock
budget tests and native Windows tests for restrictive ACLs, read-only
rename destinations, directory destinations, and temporary child handles.
Enable the Windows shim deletion-error regression test. Isolate the ACL
tests from elevated runner privileges with scoped token changes. Restore the
Node process privileges after the TypeScript ACL assertions.
Remove a redundant return caught by Windows-targeted clippy. Restart the
fetch test worker pool after draining it so later tests can use it.

Closes pnpm/pnpm#14682.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-6).
