### PR TITLE
fix(deps-restorer): copy a source that has run out of hard links

### DIFF
--- a/.changeset/copy-a-source-out-of-hard-links.md
+++ b/.changeset/copy-a-source-out-of-hard-links.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` now copies a package file whose store entry has reached the filesystem's limit on hard links to one file. NTFS allows 1024 and ext4 allows 65000, and a store shared by enough projects reaches the NTFS limit. Such a file failed the install under `packageImportMethod: hardlink`. Under `auto` it stopped pnpm hard linking for the rest of the install.

--- a/.changeset/copy-a-source-out-of-hard-links.md
+++ b/.changeset/copy-a-source-out-of-hard-links.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm install` now copies a package file whose store entry has reached the filesystem's limit on hard links to one file. NTFS allows 1024 and ext4 allows 65000, and a store shared by enough projects reaches the NTFS limit. Such a file failed the install under `packageImportMethod: hardlink`. Under `auto` it stopped pnpm hard linking for the rest of the install.
+`pnpm install` now copies a package file whose store entry has reached the filesystem's limit on hard links to one file. NTFS allows 1024 names per file and ext4 allows 65000. Such a file failed the install under `packageImportMethod: hardlink`. Under `auto` it stopped pnpm hard linking for the rest of the install.

--- a/pnpm/crates/deps-restorer/src/link_file.rs
+++ b/pnpm/crates/deps-restorer/src/link_file.rs
@@ -327,7 +327,9 @@ fn try_import<Reporter: self::Reporter, Sys: FsHardLink + FsReflink>(
         // which copies on any link failure other than `EEXIST`. Only
         // `EXDEV` copies here: a store on a different device from
         // `node_modules` is a placement the user can change, and one
-        // package's copy is cheap. Everything else surfaces, `EPERM`
+        // package's copy is cheap. A source that has run out of names
+        // ([`is_too_many_links`]) copies for the same reason: it costs
+        // one file, not the install. Everything else surfaces, `EPERM`
         // included — a filesystem that refuses links would copy every
         // package, which is the disk cost `hardlink` was chosen to
         // avoid, so the user gets an error naming the method instead of
@@ -339,7 +341,7 @@ fn try_import<Reporter: self::Reporter, Sys: FsHardLink + FsReflink>(
                 log_method_once::<Reporter>(logged, LOG_FLAG_HARDLINK, WireImportMethod::Hardlink);
                 Ok(())
             }
-            Err(error) if is_cross_device(&error) => {
+            Err(error) if is_cross_device(&error) || is_too_many_links(&error) => {
                 copy_file(source_file, target_link).inspect(|()| {
                     log_method_once::<Reporter>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
                 })
@@ -439,6 +441,20 @@ fn is_operation_not_permitted(err: &io::Error) -> bool {
     }
 }
 
+/// The source file already carries every name the filesystem will give
+/// it: 1024 on NTFS, 65000 on ext4. Unlike [`is_cross_device`] and
+/// [`is_operation_not_permitted`], this is a property of one file
+/// rather than of the filesystem, so it must not retire a tier — every
+/// other file in the install can still be hardlinked, and only this one
+/// has to be materialized another way. Copying is the only thing that
+/// helps, and it is what pnpm's `linkOrCopy` does here.
+///
+/// `std` maps `EMLINK` and `ERROR_TOO_MANY_LINKS` to the same kind, so
+/// unlike its peers this one needs no raw code.
+fn is_too_many_links(err: &io::Error) -> bool {
+    err.kind() == io::ErrorKind::TooManyLinks
+}
+
 /// Errors that indicate the call itself is malformed (missing source,
 /// access denied, target already exists) — propagate these from
 /// the downgrade cache instead of advancing to the next tier. A
@@ -530,7 +546,10 @@ fn clone_tier<Reporter: self::Reporter, Sys: FsReflink>(
 }
 
 /// Hardlink `source` to `target`, with the same downgrade contract as
-/// [`clone_tier`].
+/// [`clone_tier`], plus one outcome [`clone_tier`] has no equivalent
+/// for: a source out of names copies here and reports the tier still
+/// usable, because [`is_too_many_links`] says nothing about the next
+/// file.
 fn hardlink_tier<Reporter: self::Reporter, Sys: FsHardLink>(
     logged: &AtomicU8,
     source: &Path,
@@ -541,6 +560,11 @@ fn hardlink_tier<Reporter: self::Reporter, Sys: FsHardLink>(
             log_method_once::<Reporter>(logged, LOG_FLAG_HARDLINK, WireImportMethod::Hardlink);
             Ok(true)
         }
+        Err(err) if is_too_many_links(&err) => copy_file(source, target)
+            .inspect(|()| {
+                log_method_once::<Reporter>(logged, LOG_FLAG_COPY, WireImportMethod::Copy);
+            })
+            .map(|()| true),
         Err(err) if is_call_error(&err) => Err(err),
         Err(_) => Ok(false),
     }

--- a/pnpm/crates/deps-restorer/src/link_file/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_file/tests.rs
@@ -1,13 +1,10 @@
 use super::{
-    AUTO_FIRST_TIER, Host, LINK_STATE_CLONE, LINK_STATE_HARDLINK, LinkFileError, auto_link,
-    clone_or_copy_link, downgrade_auto_tier, is_call_error, link_file, next_auto_tier,
-    recover_from_concurrent_import,
+    AUTO_FIRST_TIER, FsHardLink, FsReflink, Host, LINK_STATE_CLONE, LINK_STATE_HARDLINK,
+    LinkFileError, auto_link, clone_or_copy_link, downgrade_auto_tier, is_call_error, link_file,
+    next_auto_tier, recover_from_concurrent_import, try_import,
 };
 #[cfg(unix)]
-use super::{
-    FsHardLink, FsReflink, LINK_STATE_COPY, import_into_fresh_target, is_operation_not_permitted,
-    try_import,
-};
+use super::{LINK_STATE_COPY, import_into_fresh_target, is_operation_not_permitted};
 use pnpm_config::PackageImportMethod;
 use pnpm_reporter::SilentReporter;
 use pretty_assertions::assert_eq;
@@ -973,4 +970,67 @@ fn eperm_downgrade_still_surfaces_a_failed_copy() {
     assert_eq!(err.kind(), io::ErrorKind::NotFound);
     assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_COPY, "both link tiers were retired");
     assert!(!dst.exists());
+}
+
+/// A source that has run out of names: `EMLINK` on Unix,
+/// `ERROR_TOO_MANY_LINKS` on Windows, one [`io::ErrorKind`] either way.
+/// A store file linked into enough projects reaches NTFS's cap of 1024
+/// names long before ext4's 65000.
+struct OutOfLinks;
+
+impl FsHardLink for OutOfLinks {
+    fn hard_link(_source: &Path, _target: &Path) -> io::Result<()> {
+        Err(io::Error::from(io::ErrorKind::TooManyLinks))
+    }
+}
+
+impl FsReflink for OutOfLinks {
+    fn reflink(_source: &Path, _target: &Path) -> io::Result<()> {
+        unreachable!("the hardlink tier materializes the file itself, so no tier follows it")
+    }
+}
+
+/// The link limit belongs to one file, so the `Auto` ladder copies that
+/// file and keeps hardlinking everything after it. Retiring the tier
+/// would make one popular store entry downgrade the whole install.
+#[test]
+fn too_many_links_copies_one_file_and_keeps_the_hardlink_tier() {
+    let state = AtomicU8::new(LINK_STATE_HARDLINK);
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "src.txt", b"out of names");
+    let dst = tmp.path().join("dst.txt");
+
+    auto_link::<SilentReporter, OutOfLinks>(&AtomicU8::new(0), &state, &src, &dst)
+        .expect("a source out of names is copied, not failed");
+
+    assert_eq!(fs::read(&dst).unwrap(), b"out of names");
+    assert_eq!(
+        state.load(Ordering::Relaxed),
+        LINK_STATE_HARDLINK,
+        "the tier stays: the next file has names left",
+    );
+    fs::write(&src, b"rewritten").unwrap();
+    assert_eq!(fs::read(&dst).unwrap(), b"out of names", "the copy is independent of the source");
+}
+
+/// The explicit `hardlink` method copies here for the same reason it
+/// copies on `EXDEV`: it costs one file rather than the install, so it
+/// is not the silent whole-install copy that `EPERM` would be.
+#[test]
+fn explicit_hardlink_copies_on_too_many_links() {
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "src.txt", b"explicit");
+    let dst = tmp.path().join("dst.txt");
+
+    try_import::<SilentReporter, OutOfLinks>(
+        PackageImportMethod::Hardlink,
+        &AtomicU8::new(0),
+        &src,
+        &dst,
+    )
+    .expect("a source out of names is copied, not failed");
+
+    assert_eq!(fs::read(&dst).unwrap(), b"explicit");
+    fs::write(&src, b"rewritten").unwrap();
+    assert_eq!(fs::read(&dst).unwrap(), b"explicit", "the copy is independent of the source");
 }


### PR DESCRIPTION
## Summary

A filesystem caps how many names one file may carry: **1024 on NTFS**, 65000 on ext4. pnpm's store is shared across every project on the machine, and each project that installs a package adds a name to that store entry, so a popular entry accumulates names until it reaches the cap. The link then fails with `EMLINK` / `ERROR_TOO_MANY_LINKS`.

Neither stack recognises that error today. In pnpm 12:

- Under `packageImportMethod: hardlink`, it is not `EXDEV`, so it propagates and **the install fails**.
- Under `auto`, `is_call_error` returns false, so it is read as the filesystem refusing links and **the hardlink tier is retired for the rest of the process**. One popular store entry downgrades every package imported after it.

This is the one link failure where copying is both necessary and sufficient. The limit belongs to the *source file*, not to the filesystem: no retry and no other tier can add a name to that file, and every other file in the install still links fine. So the fix copies that one file and leaves the tier alone — which is what pnpm v11's `linkOrCopy` ends up doing here, and the case where v11's blanket fallback is genuinely right.

That per-file property is what makes this different from `EPERM`, which pnpm/pnpm#14771 deliberately left surfacing under an explicit `hardlink`: `EPERM` means *no* file can be linked, so copying on it would silently copy the whole install.

`std` maps `EMLINK` and `ERROR_TOO_MANY_LINKS` to the same `io::ErrorKind::TooManyLinks`, so the check needs no raw OS codes and no `cfg`, unlike its peers `is_cross_device` and `is_operation_not_permitted`.

## Squash Commit Body

```text
A filesystem caps how many names one file may carry: 1024 on NTFS,
65000 on ext4. pnpm's store is shared across projects, so a popular
entry accumulates a name per project that installs it and eventually
reaches the cap. Nothing in either stack recognised the resulting
`EMLINK` / `ERROR_TOO_MANY_LINKS`, so an explicit
`packageImportMethod: hardlink` failed the install on it, and `auto`
read it as the filesystem refusing links and retired the hardlink tier
for the rest of the process — one popular file downgrading every
package after it.

The limit belongs to the source file, not to the filesystem, so it is
the one link failure where copying is both necessary and sufficient: no
retry and no other tier can add a name to that file, and every other
file still links. Both import methods now copy it and carry on, which
is what pnpm v11's `linkOrCopy` ends up doing.

`std` maps `EMLINK` and `ERROR_TOO_MANY_LINKS` to
`io::ErrorKind::TooManyLinks`, so the check needs no raw code and the
tests run on every platform.
```

## Tests

Two tests in `link_file/tests.rs`, driving the `FsHardLink` seam from pnpm/pnpm#14771 with a fake that reports the limit. Both run on **every** platform, since the error kind is portable:

- `too_many_links_copies_one_file_and_keeps_the_hardlink_tier` — the `Auto` ladder copies the file and leaves the tier at `LINK_STATE_HARDLINK`. This is the assertion that pins the per-file semantics.
- `explicit_hardlink_copies_on_too_many_links` — the explicit method copies rather than failing.

Both assert the result is an independent copy, by rewriting the source afterwards and checking the destination does not follow. Both fail with the fix reverted.

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

<!-- Note on the version-coverage checkbox: pnpm v11 does not have this bug.
Its `linkOrCopy` copies on any link failure except `EEXIST`, which covers the
link limit incidentally. This is a v12-only fix. -->

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwGbBP6STCXyYD2QfLxrQi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `pnpm install` now copies package files when the filesystem’s hard-link limit is reached, instead of failing.
  - The `auto` import method continues using hard links for eligible files after encountering a file at the link limit.
  - Permission-related errors are handled more accurately during package imports, helping distinguish unsupported operations from genuine access restrictions.
  - Clone, hard-link, and copy-based package import methods now handle filesystem limitations more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->