### PR TITLE
perf(cmd-shim): skip the shim read in a bin directory this run created

### DIFF
--- a/.changeset/shim-creation-syscalls.md
+++ b/.changeset/shim-creation-syscalls.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+pnpm does less filesystem work when an install creates the command shims in `node_modules/.bin`. A warm install of a 76 project workspace makes about 1,500 fewer filesystem calls [#14540](https://github.com/pnpm/pnpm/issues/14540).

--- a/pnpm/crates/cmd-shim/src/capabilities.rs
+++ b/pnpm/crates/cmd-shim/src/capabilities.rs
@@ -96,10 +96,38 @@ pub trait FsWalkFiles {
     fn walk_files(path: &Path) -> io::Result<impl Iterator<Item = PathBuf>>;
 }
 
+/// Whether a directory was created by the call that reports it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirCreation {
+    /// The call created it rather than finding it.
+    Created,
+    /// It was already there, or the provider does not tell the two
+    /// apart.
+    Unknown,
+}
+
 /// Create a directory and any missing ancestors. Used to prepare
 /// `<modules_dir>/.bin` and per-slot `node_modules/.bin` directories.
 pub trait FsCreateDirAll {
     fn create_dir_all(path: &Path) -> io::Result<()>;
+
+    /// [`create_dir_all`](Self::create_dir_all), reporting whether the
+    /// directory is one this call created. The shim writer uses
+    /// [`DirCreation::Created`] to write each shim straight out instead
+    /// of first reading a path that almost certainly holds nothing.
+    ///
+    /// Almost, because the answer is a hint about which order is
+    /// cheaper and never a guarantee that the directory is still empty:
+    /// a concurrent installer can populate one this call created, and
+    /// can create one it reports as `Unknown`. Either way the exclusive
+    /// create the shim writer attempts refuses whatever turned up, so
+    /// a wrong guess costs an ordering and nothing else.
+    ///
+    /// The default reports [`DirCreation::Unknown`], so a fake need not
+    /// model the distinction.
+    fn create_dir_all_reporting(path: &Path) -> io::Result<DirCreation> {
+        Self::create_dir_all(path).map(|()| DirCreation::Unknown)
+    }
 }
 
 /// Write `bytes` to `path`, replacing the file's contents if it
@@ -227,6 +255,23 @@ impl FsWalkFiles for Host {
 impl FsCreateDirAll for Host {
     fn create_dir_all(path: &Path) -> io::Result<()> {
         std::fs::create_dir_all(path)
+    }
+
+    fn create_dir_all_reporting(path: &Path) -> io::Result<DirCreation> {
+        // One `mkdir` answers both questions when the parent is already
+        // there, which is the common case: the bin dir's parent is the
+        // `node_modules` the install just populated.
+        match std::fs::create_dir(path) {
+            Ok(()) => Ok(DirCreation::Created),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                std::fs::create_dir_all(path).map(|()| DirCreation::Created)
+            }
+            // Already there, or occupied by something that is not a
+            // directory. `create_dir_all` owns the rule for telling
+            // those apart, and its error is the one this has always
+            // reported.
+            Err(_) => Self::create_dir_all(path).map(|()| DirCreation::Unknown),
+        }
     }
 }
 

--- a/pnpm/crates/cmd-shim/src/link_bins.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins.rs
@@ -1,8 +1,8 @@
 use crate::{
     bin_resolver::{Command, get_bins_from_package_manifest, pkg_owns_bin},
     capabilities::{
-        FsCreateDirAll, FsEnsureExecutableBits, FsReadDir, FsReadFile, FsReadHead, FsReadToString,
-        FsSetExecutable, FsWalkFiles, FsWrite,
+        DirCreation, FsCreateDirAll, FsEnsureExecutableBits, FsReadDir, FsReadFile, FsReadHead,
+        FsReadToString, FsSetExecutable, FsWalkFiles, FsWrite,
     },
     shim::{
         ScriptRuntime, generate_cmd_shim, generate_pwsh_shim, generate_sh_shim,
@@ -474,7 +474,7 @@ where
         return Ok(());
     }
 
-    Sys::create_dir_all(bins_dir)
+    let bin_dir = Sys::create_dir_all_reporting(bins_dir)
         .map_err(|error| LinkBinsError::CreateBinDir { dir: bins_dir.to_path_buf(), error })?;
 
     // Each shim's read-shebang + write-file + chmod sequence is independent
@@ -515,6 +515,7 @@ where
                 node_path: &node_path,
                 prefer_symlinked_executables: options.prefer_symlinked_executables,
                 make_powershell_shim: wants_powershell_shim(pkg_name),
+                bin_dir,
             },
             cache,
         )
@@ -653,6 +654,9 @@ struct ShimSpec<'a> {
     node_path: &'a [String],
     prefer_symlinked_executables: bool,
     make_powershell_shim: bool,
+    /// Whether this run created the bin directory. Read by
+    /// [`read_or_create_shim`], which documents what it is worth.
+    bin_dir: DirCreation,
 }
 
 fn write_shim<Sys>(spec: ShimSpec<'_>, cache: &ShimTargetCache) -> Result<(), LinkBinsError>
@@ -754,6 +758,13 @@ enum ExistingShim {
 /// One read feeds both paths: `NotFound` means nothing occupies the shim path,
 /// so a fresh install skips every stale-entry probe; existing content feeds the
 /// marker checks without a second read.
+///
+/// In a bin directory this run created, that read almost never finds
+/// anything, so the write goes first and falls back to the read when it
+/// fails — see [`FsCreateDirAll::create_dir_all_reporting`] for what
+/// makes it "almost". Trying the write first anywhere else would add a
+/// failed create to every shim already in place, which is what an
+/// ordinary reinstall is made of.
 fn read_or_create_shim<Sys>(
     spec: &ShimSpec<'_>,
     cache: &ShimTargetCache,
@@ -761,15 +772,27 @@ fn read_or_create_shim<Sys>(
 where
     Sys: FsReadToString + FsReadHead + FsWrite + FsSetExecutable + FsEnsureExecutableBits,
 {
+    if spec.bin_dir == DirCreation::Created
+        && fresh_write_applies(spec)
+        && write_shim_fresh::<Sys>(spec, cache)?
+    {
+        return Ok(ExistingShim::Written);
+    }
     let error = match Sys::read_to_string(spec.shim_path) {
         Ok(existing) => return Ok(ExistingShim::Present(existing)),
         Err(error) => error,
     };
     let fresh = error.kind() == io::ErrorKind::NotFound
-        && !is_node_bin_name(spec.shim_path)
-        && !(spec.prefer_symlinked_executables && cfg!(unix))
+        && fresh_write_applies(spec)
         && write_shim_fresh::<Sys>(spec, cache)?;
     Ok(if fresh { ExistingShim::Written } else { ExistingShim::Absent })
+}
+
+/// Whether the shim is one [`write_shim_fresh`] can produce. The node
+/// runtime is linked rather than shimmed, and
+/// `preferSymlinkedExecutables` links every bin on Unix.
+fn fresh_write_applies(spec: &ShimSpec<'_>) -> bool {
+    !(is_node_bin_name(spec.shim_path) || (spec.prefer_symlinked_executables && cfg!(unix)))
 }
 
 /// The Windows sibling shims a write produces.

--- a/pnpm/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests.rs
@@ -4,8 +4,8 @@ use super::{
 };
 use crate::{
     capabilities::{
-        FsCreateDirAll, FsEnsureExecutableBits, FsReadDir, FsReadFile, FsReadHead, FsReadToString,
-        FsSetExecutable, FsWalkFiles, FsWrite, Host,
+        DirCreation, FsCreateDirAll, FsEnsureExecutableBits, FsReadDir, FsReadFile, FsReadHead,
+        FsReadToString, FsSetExecutable, FsWalkFiles, FsWrite, Host,
     },
     shim::is_shim_pointing_at,
 };
@@ -1722,6 +1722,93 @@ fn dangling_symlink_at_shim_path_is_replaced_with_a_shim() {
 
     let body = read_to_string(bins_dir.join("foo")).expect("real shim replaces the dangling link");
     assert!(is_shim_pointing_at(&body, &pkg.join("cli.js")));
+}
+
+/// A bin directory this run created holds nothing, so the shim goes
+/// straight out. One that was already there is read first, because
+/// that is where an ordinary reinstall finds its shims.
+#[test]
+fn a_shim_in_a_freshly_created_bin_dir_is_written_without_reading_it_first() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static SHIM_READS: AtomicUsize = AtomicUsize::new(0);
+
+    struct ReadCountingHost;
+    impl FsReadHead for ReadCountingHost {
+        fn read_head(path: &Path, offset: u64, buf: &mut [u8]) -> io::Result<usize> {
+            <Host as FsReadHead>::read_head(path, offset, buf)
+        }
+    }
+    impl FsReadToString for ReadCountingHost {
+        fn read_to_string(path: &Path) -> io::Result<String> {
+            if path.file_name().is_some_and(|name| name == "foo") {
+                SHIM_READS.fetch_add(1, Ordering::Relaxed);
+            }
+            <Host as FsReadToString>::read_to_string(path)
+        }
+    }
+    impl FsCreateDirAll for ReadCountingHost {
+        fn create_dir_all(path: &Path) -> io::Result<()> {
+            <Host as FsCreateDirAll>::create_dir_all(path)
+        }
+        fn create_dir_all_reporting(path: &Path) -> io::Result<DirCreation> {
+            <Host as FsCreateDirAll>::create_dir_all_reporting(path)
+        }
+    }
+    impl FsWalkFiles for ReadCountingHost {
+        fn walk_files(path: &Path) -> io::Result<impl Iterator<Item = PathBuf>> {
+            <Host as FsWalkFiles>::walk_files(path)
+        }
+    }
+    impl FsWrite for ReadCountingHost {
+        fn write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+            <Host as FsWrite>::write(path, bytes)
+        }
+        fn write_new(path: &Path, bytes: &[u8]) -> io::Result<()> {
+            <Host as FsWrite>::write_new(path, bytes)
+        }
+    }
+    impl FsSetExecutable for ReadCountingHost {
+        fn set_executable(path: &Path) -> io::Result<()> {
+            <Host as FsSetExecutable>::set_executable(path)
+        }
+    }
+    impl FsEnsureExecutableBits for ReadCountingHost {
+        fn ensure_executable_bits(path: &Path) -> io::Result<()> {
+            <Host as FsEnsureExecutableBits>::ensure_executable_bits(path)
+        }
+    }
+
+    let manifest = serde_json::json!({"name": "foo", "bin": "cli.js"});
+    let tmp = tempdir().unwrap();
+    let pkg = tmp.path().join("foo");
+    create_dir_all(&pkg).unwrap();
+    write_file(pkg.join("cli.js"), "#!/usr/bin/env node\n").unwrap();
+    let link = |bins_dir: &Path| {
+        link_bins_of_packages::<ReadCountingHost>(
+            &[PackageBinSource::new(pkg.clone(), Arc::new(manifest.clone()))],
+            bins_dir,
+            &LinkBinsOptions::default(),
+        )
+        .unwrap();
+    };
+
+    let fresh_bins = tmp.path().join("fresh/.bin");
+    link(&fresh_bins);
+    assert!(is_shim_pointing_at(
+        &read_to_string(fresh_bins.join("foo")).unwrap(),
+        &pkg.join("cli.js"),
+    ));
+    assert_eq!(SHIM_READS.load(Ordering::Relaxed), 0, "nothing can occupy a dir we just made");
+
+    let existing_bins = tmp.path().join("existing/.bin");
+    create_dir_all(&existing_bins).unwrap();
+    link(&existing_bins);
+    assert!(is_shim_pointing_at(
+        &read_to_string(existing_bins.join("foo")).unwrap(),
+        &pkg.join("cli.js"),
+    ));
+    assert_eq!(SHIM_READS.load(Ordering::Relaxed), 1, "a pre-existing dir is read first");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Related to pnpm/pnpm#14540 (the warm restore's filesystem-call budget). Follow-up to pnpm/pnpm#14769.

Linking a project's bins read every shim path before writing it, to find out whether something already occupied it. In a `node_modules/.bin` this run created, nothing can. On a warm restore of the issue's 76-project workspace that read is 19 failing opens per project, about 1,500 calls that can only report `NotFound`.

`create_dir_all_reporting` says whether this run created the bin directory. When it did, the shim write goes first, and the read happens only if the exclusive create finds an entry after all, which keeps the answer right when a concurrent install populates the directory in between. Anywhere else the read still goes first, so an ordinary reinstall does not pay a failed create for every shim already in place.

Per warm restore of the reproduction, counted with a dyld interposer:

| | main | this PR |
|---|---:|---:|
| `open` | 3,509 | 2,032 |

**On measurement.** Wall time and system CPU are unchanged within noise on my M-series Mac (0.75 s median either way over seven alternating runs). That machine does not reproduce the gap the issue reports, and has not in any round of this issue: the reporter's profile shows the cost as contention on filesystem calls, so fewer calls is the lever available here. I am not claiming a speedup, only less work.

**Dropped from the first revision.** This PR originally also created each shim with mode `0o755` so the chmod after it could be skipped. Both reviewers pointed out that this publishes an executable file that is still empty until `write_all` returns, so a concurrent `pnpm exec` could run a truncated script rather than fail cleanly on permissions. That is worse than what it replaced, and a microbenchmark put the chmod it saved at about 10 ms per 1,484 shims on this filesystem, so I removed it rather than work around it.

## Squash Commit Body

```text
Linking a project's bins read every shim path before writing it, to find
out whether something already occupied it. In a `node_modules/.bin` this
run created, nothing can, and the read is 19 failing opens per project
on a warm restore of the issue's 76-project workspace.

`create_dir_all_reporting` says whether this run created the bin
directory. When it did, the shim write goes first and the read happens
only if the exclusive create finds an entry after all, which keeps the
answer right when a concurrent install populates the directory in
between. Anywhere else the read still goes first, so an ordinary
reinstall does not pay a failed create for every shim already in place.

Per warm restore of the repro: opens 3,509 -> 2,032. Wall time and
system CPU are unchanged within noise on an M-series Mac, which does not
reproduce the gap the issue reports.

Related to pnpm/pnpm#14540.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved package installation efficiency by reducing unnecessary filesystem operations when creating command shims, particularly in newly created binary directories.
* **Bug Fixes**
  * Ensured command shims in newly created binary directories are written correctly without an unnecessary preliminary read.
  * Preserved the existing read-and-update behavior for shims in directories that already exist.
  * Improved reliability when creating command shims during package installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->