### PR TITLE
fix(network): use bundled roots on android

### DIFF
--- a/.changeset/fix-android-tls.md
+++ b/.changeset/fix-android-tls.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed registry requests crashing on Android. pnpm now uses bundled CA certificates on Android [pnpm/pnpm#14777](https://github.com/pnpm/pnpm/issues/14777).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5456,6 +5456,7 @@ dependencies = [
  "pnpm-testing-utils",
  "pretty_assertions",
  "reqwest",
+ "rustls",
  "tokio",
  "tracing",
  "webpki-root-certs",

--- a/pnpm/crates/cli/tests/suite/ping.rs
+++ b/pnpm/crates/cli/tests/suite/ping.rs
@@ -19,7 +19,6 @@ use mockito::Matcher;
 use pnpm_testing_utils::bin::CommandTempCwd;
 use std::{
     fs,
-    net::TcpListener,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -50,17 +49,6 @@ fn ping_mock(server: &mut mockito::Server, path_prefix: &str) -> mockito::Mock {
     server
         .mock("GET", format!("{path_prefix}/-/ping").as_str())
         .match_query(Matcher::UrlEncoded("write".into(), "true".into()))
-}
-
-/// A loopback registry URL with nothing listening: bind an ephemeral port,
-/// then drop the listener so a connection is refused immediately. Avoids
-/// assuming a fixed port is free and keeps the network-failure test fast — a
-/// closed loopback port returns `ECONNREFUSED` rather than stalling on connect.
-fn unreachable_registry() -> String {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind a probe socket");
-    let port = listener.local_addr().expect("read the probe socket address").port();
-    drop(listener);
-    format!("http://127.0.0.1:{port}/")
 }
 
 #[test]
@@ -224,7 +212,9 @@ fn redacts_inline_credentials_in_the_ping_line() {
 fn fails_on_a_network_failure() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
     let auth_file = empty_auth_file(root.path());
-    let registry = unreachable_registry();
+    let socket = tokio::net::TcpSocket::new_v4().expect("create registry socket");
+    socket.bind("127.0.0.1:0".parse().expect("loopback address")).expect("reserve registry port");
+    let registry = format!("http://{}/", socket.local_addr().expect("registry socket address"));
 
     let output = run_ping(&workspace, &auth_file, Some(&registry));
 

--- a/pnpm/crates/network/Cargo.toml
+++ b/pnpm/crates/network/Cargo.toml
@@ -25,6 +25,7 @@ webpki-root-certs = { workspace = true }
 mockito            = { workspace = true }
 pnpm-testing-utils = { workspace = true }
 pretty_assertions  = { workspace = true }
+rustls             = { workspace = true }
 tokio              = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -496,6 +496,7 @@ impl ThrottledClient {
     /// * **Trust store.** The platform's, falling back to the Mozilla
     ///   roots bundled into the binary when the platform verifier
     ///   cannot be constructed (a system with no trust store at all).
+    ///   Android always uses the bundled roots because the CLI has no JVM.
     ///
     /// Returns [`ProxyError::InvalidProxy`] when either configured
     /// proxy URL fails to parse even after the auto-`http://` prefix
@@ -924,7 +925,8 @@ fn client_builder(
         builder = builder.add_root_certificate(cert.clone());
     }
     builder = apply_tls(builder, effective_tls)?;
-    if trust_roots == TrustRoots::Bundled {
+    // Android's platform verifier requires a JVM, which the standalone CLI does not have.
+    if cfg!(target_os = "android") || trust_roots == TrustRoots::Bundled {
         builder = builder.tls_certs_only(bundled_root_certs().iter().cloned());
     }
     Ok(apply_redirect_policy(builder, inputs.redirect_guard, forbid_redirects))
@@ -1078,15 +1080,10 @@ enum TrustRoots {
     /// installed system-wide, which the bundled set cannot.
     Platform,
 
-    /// The Mozilla root set compiled into the binary. Used only when
-    /// the platform verifier cannot be constructed at all — on a
-    /// machine with no system trust store, `rustls-platform-verifier`
-    /// fails the client build outright rather than degrading, and
-    /// pnpm-on-Node keeps working there because Node ships the same
-    /// bundled roots. Falling back restores that parity; it is never
-    /// preferred over the platform store, so a user who deliberately
-    /// distrusts a Mozilla root system-wide keeps that decision as
-    /// long as their store loads at all.
+    /// The Mozilla root set compiled into the binary. Used on Android,
+    /// where the platform verifier requires a JVM, and as a fallback when
+    /// the platform trust store cannot be loaded. On other platforms a
+    /// loadable system store retains its administrator's trust decisions.
     Bundled,
 }
 

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -937,12 +937,64 @@ fn node_extra_ca_certs_is_loaded_and_failures_are_non_fatal() {
     // `env` restores NODE_EXTRA_CA_CERTS on drop.
 }
 
+#[tokio::test]
+async fn default_tls_rejects_an_untrusted_certificate_without_panicking() {
+    use rustls::{ServerConfig, ServerConnection, pki_types::pem::PemObject};
+    use std::net::TcpListener;
+
+    let env = EnvGuard::snapshot(["NODE_EXTRA_CA_CERTS"]);
+    for extra_ca in ["", "/pacquet/does-not-exist.pem"] {
+        env.set("NODE_EXTRA_CA_CERTS", extra_ca);
+        let client = ThrottledClient::for_installs(
+            &ProxyConfig::default(),
+            &TlsConfig::default(),
+            &PerRegistryTls::default(),
+            &NetworkSettings::default(),
+        )
+        .expect("build client without a JVM or extra CA certificates");
+        let cert = rustls::pki_types::CertificateDer::from_pem_slice(include_bytes!(
+            "../tests/fixtures/test-client-pkcs1.crt"
+        ))
+        .expect("parse server certificate");
+        let key = rustls::pki_types::PrivateKeyDer::from_pem_slice(include_bytes!(
+            "../tests/fixtures/test-client-pkcs1.key"
+        ))
+        .expect("parse server key");
+        let config = ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert], key)
+            .expect("configure untrusted TLS server");
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind TLS server");
+        let address = listener.local_addr().expect("TLS server address");
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept TLS connection");
+            stream.set_read_timeout(Some(Duration::from_secs(10))).expect("set read timeout");
+            stream.set_write_timeout(Some(Duration::from_secs(10))).expect("set write timeout");
+            ServerConnection::new(Arc::new(config))
+                .expect("create TLS connection")
+                .complete_io(&mut stream)
+                .expect_err("client rejects the untrusted server certificate");
+        });
+
+        let error = client
+            .acquire()
+            .await
+            .get(format!("https://{address}/"))
+            .send()
+            .await
+            .expect_err("untrusted certificate must fail verification");
+        eprintln!("TLS error: {error:?}");
+        assert!(error.is_connect(), "expected a TLS connection error: {error:?}");
+        server.join().expect("TLS server thread");
+    }
+}
+
 // `SSL_CERT_FILE` alone switches `rustls-native-certs` to env-only
 // loading, so pointing it at an empty file is a portable stand-in for a
 // machine whose system trust store holds nothing — the nixpkgs sandbox
 // of pnpm/pnpm#13588. Only the Linux/BSD platform verifier reads that
 // variable; the Apple and Windows ones go to the OS keychain.
-#[cfg(all(unix, not(target_vendor = "apple")))]
+#[cfg(all(unix, not(target_vendor = "apple"), not(target_os = "android")))]
 #[test]
 fn for_installs_falls_back_to_bundled_roots_without_a_system_trust_store() {
     let env = EnvGuard::snapshot(["SSL_CERT_FILE", "SSL_CERT_DIR", "NODE_EXTRA_CA_CERTS"]);

--- a/pnpm/crates/network/src/tls.rs
+++ b/pnpm/crates/network/src/tls.rs
@@ -27,6 +27,7 @@
 //! * The default trust store is the platform's, but pacquet falls back
 //!   to the Mozilla roots bundled into the binary when the platform
 //!   verifier cannot be built at all (see `TrustRoots` in `lib.rs`).
+//!   Android always uses bundled roots because the CLI has no JVM.
 //!   Node ships those same roots, so the fallback keeps installs
 //!   working on a machine with no system trust store, exactly as
 //!   pnpm-on-Node does.


### PR DESCRIPTION
## Summary

Fixes registry requests panicking in the pnpm v12 Android binary when run without a JVM, as in Termux. Android now uses the existing bundled Mozilla CA roots, with configured CA certificates still added to the trust store. Other platforms retain their current platform-store and fallback behavior.

Closes pnpm/pnpm#14777.

The TypeScript v11 CLI uses Node's TLS stack and is unaffected.

Also stabilize the `ping` network-failure test exposed by the full suite:
reserve a bound, non-listening socket so another test cannot take its port.

## Squash Commit Body

```text
The Android rustls platform verifier requires JNI initialization. Its
constructor succeeds without a JVM, but certificate verification panics,
so retrying a failed client build with bundled roots cannot help.

Select bundled roots in the shared client builder on Android. This covers
default, per-registry, and no-redirect clients while preserving additional
CA certificates and strict-ssl configuration.

Add a local TLS handshake regression test covering an empty extra
CA bundle and a nonexistent NODE_EXTRA_CA_CERTS file. It reproduces the
reported JNI initialization panic under Android emulation without the fix
and rejects the untrusted certificate normally with the fix. Exclude
Android from the Linux/BSD empty-system-store test, whose precondition
does not apply to Android's JNI verifier.

Keep the ping network-failure test's port reserved until the request
finishes. Dropping the probe listener before making the request allowed
another test server to reuse the port and make ping unexpectedly succeed.

Closes pnpm/pnpm#14777.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

Validation: `just ready`; local TLS regression on Linux and aarch64 Android
under the cross image's QEMU runner. The Android test fails with the exact
reported panic when the implementation fix is removed.

---
Written by an agent (Codex, GPT-6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791632371&installation_model_id=426870&pr_number=14783&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14783&signature=3f434e6d368069b343ea42ca3553dc7a98606f2d54d0c3afdfb8e6b8e4524e68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Android registry requests that could crash when the platform trust store was unavailable.
  - Android now uses bundled Mozilla root certificates for secure connections.
  - Improved handling of untrusted certificates so requests fail with a clear TLS error instead of crashing.

- **Documentation**
  - Updated TLS and installation documentation to describe Android certificate behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->