### PR TITLE
fix(deps-restorer): fall back to copying on EACCES

### DIFF
--- a/.changeset/fix-termux-package-import.md
+++ b/.changeset/fix-termux-package-import.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm install` and `pnpm dlx` failing with "Permission denied" on Android when the filesystem denies hardlinks or reflinks. Automatic package imports now fall back to copying on `EACCES` [pnpm/pnpm#14780](https://github.com/pnpm/pnpm/issues/14780).

--- a/pnpm/crates/deps-restorer/src/link_file.rs
+++ b/pnpm/crates/deps-restorer/src/link_file.rs
@@ -408,32 +408,13 @@ impl FsReflink for Host {
     }
 }
 
-/// `EPERM`, "operation not permitted". For the link syscalls it means
-/// the filesystem will not perform *this operation* on *these paths*,
-/// as opposed to `EACCES`, which means the caller was denied an access
-/// the operation needed:
-///
-/// * `link(2)` returns it from filesystems that have no hardlinks. FUSE
-///   filesystems such as `EdenFS` answer every `link()` inside the mount
-///   this way, so an install whose `node_modules` and `file:` sources
-///   both live in the checkout gets `EPERM` from the first hardlink
-///   attempt. `fs.protected_hardlinks=1` returns it too, for a source
-///   the caller does not own and cannot both read and write.
-/// * `ioctl(FICLONE)` returns it in the rootless-container and
-///   unprivileged-LXC setups reported in pnpm/pnpm#14722.
-///
-/// Rust folds both errnos into `ErrorKind::PermissionDenied`, so the
-/// two have to be told apart by the raw code. A copy needs neither
-/// hardlinks nor clones, so `EPERM` downgrades like `EXDEV` does and the
-/// copy tier reports whatever is genuinely wrong with the paths. That
-/// is what pnpm's TypeScript importer ends up doing too: its
-/// `linkOrCopy` copies on any hardlink failure except `EEXIST`. `EACCES`
-/// keeps propagating here, one step more conservative than pnpm: a
-/// lower tier may or may not get past a denied path, and surfacing the
-/// denial is the reading that hides nothing.
-fn is_operation_not_permitted(err: &io::Error) -> bool {
+/// Unix permission errors that may deny linking while still allowing copying.
+/// Android's `SELinux` policy can reject hardlinks with `EACCES`; filesystems
+/// without link support and restricted containers can return `EPERM`.
+/// The copy tier reports any remaining access error on the paths.
+fn is_link_permission_error(err: &io::Error) -> bool {
     #[cfg(unix)]
-    return err.raw_os_error() == Some(libc::EPERM);
+    return matches!(err.raw_os_error(), Some(libc::EPERM | libc::EACCES));
     #[cfg(not(unix))]
     {
         let _ = err;
@@ -443,7 +424,7 @@ fn is_operation_not_permitted(err: &io::Error) -> bool {
 
 /// The source file already carries every name the filesystem will give
 /// it: 1024 on NTFS, 65000 on ext4. Unlike [`is_cross_device`] and
-/// [`is_operation_not_permitted`], this is a property of one file
+/// [`is_link_permission_error`], this is a property of one file
 /// rather than of the filesystem, so it must not retire a tier — every
 /// other file in the install can still be hardlinked, and only this one
 /// has to be materialized another way. Copying is the only thing that
@@ -455,29 +436,17 @@ fn is_too_many_links(err: &io::Error) -> bool {
     err.kind() == io::ErrorKind::TooManyLinks
 }
 
-/// Errors that indicate the call itself is malformed (missing source,
-/// access denied, target already exists) — propagate these from
-/// the downgrade cache instead of advancing to the next tier. A
-/// different tier won't fix an invalid call, and downgrading on a
-/// one-off `NotFound` would permanently disable reflink / hardlink for
-/// every other file in the install. `EPERM` is the one
-/// `PermissionDenied` that is a capability signal rather than a call
-/// error; see [`is_operation_not_permitted`].
+/// Errors that must propagate without advancing the cached import tier.
+/// Missing paths and existing targets cannot be fixed by changing methods.
+/// Unix link permission errors permit fallback; see [`is_link_permission_error`].
+/// Other permission errors remain terminal.
 ///
-/// Everything else — including the grab-bag of errno / Windows codes
-/// kernels use to signal "filesystem can't do this operation"
-/// (`EOPNOTSUPP`, `ENOTTY`, `ENOSYS`, `ERROR_INVALID_FUNCTION`, ...) —
-/// triggers the fallback. This is the deny-list the `reflink-copy`
-/// crate uses in its own `reflink_or_copy` fallback logic, with `EPERM`
-/// carved out of it for the reasons above. A deny-list is required
-/// rather than an allow-list because Windows's `ERROR_INVALID_FUNCTION`
-/// (raw OS `1`, which Rust surfaces as `ErrorKind::InvalidInput`) for
-/// NTFS's rejection of `FSCTL_DUPLICATE_EXTENTS_TO_FILE` must trigger
-/// the fallback.
+/// All other errors allow fallback, including Windows's `ERROR_INVALID_FUNCTION`
+/// (`InvalidInput`) when NTFS rejects `FSCTL_DUPLICATE_EXTENTS_TO_FILE`.
 fn is_call_error(err: &io::Error) -> bool {
     match err.kind() {
         io::ErrorKind::NotFound | io::ErrorKind::AlreadyExists => true,
-        io::ErrorKind::PermissionDenied => !is_operation_not_permitted(err),
+        io::ErrorKind::PermissionDenied => !is_link_permission_error(err),
         _ => false,
     }
 }

--- a/pnpm/crates/deps-restorer/src/link_file/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_file/tests.rs
@@ -4,7 +4,7 @@ use super::{
     next_auto_tier, recover_from_concurrent_import, try_import,
 };
 #[cfg(unix)]
-use super::{LINK_STATE_COPY, import_into_fresh_target, is_operation_not_permitted};
+use super::{LINK_STATE_COPY, import_into_fresh_target, is_link_permission_error};
 use pnpm_config::PackageImportMethod;
 use pnpm_reporter::SilentReporter;
 use pretty_assertions::assert_eq;
@@ -432,7 +432,7 @@ fn live_symlink_short_circuits() {
     assert_eq!(fs::read(&real_target).unwrap(), b"old", "target must not be overwritten");
 }
 
-/// A one-off `NotFound` / `PermissionDenied` / `AlreadyExists` on
+/// A one-off `NotFound` / `AlreadyExists` on
 /// a single file must not downgrade the cache — those are
 /// per-call errors, not capability errors. A different source /
 /// target later in the install would still succeed at the current
@@ -659,15 +659,13 @@ fn is_call_error_rejects_capability_codes() {
         assert!(!is_call_error(&err), "{err:?} should trigger fallback, not propagate");
     }
 
-    // The two errnos behind `PermissionDenied` split: EPERM is the
-    // filesystem refusing the operation (fall through), EACCES is the
-    // caller lacking access to the paths (propagate).
+    // Link permissions can be denied while ordinary copying is allowed.
     #[cfg(unix)]
     {
         let eperm = io::Error::from_raw_os_error(libc::EPERM);
         assert!(!is_call_error(&eperm), "EPERM is a capability signal, not a call error");
         let eacces = io::Error::from_raw_os_error(libc::EACCES);
-        assert!(is_call_error(&eacces), "EACCES is a call error");
+        assert!(!is_call_error(&eacces), "EACCES should allow a copy fallback");
     }
 }
 
@@ -810,9 +808,6 @@ impl FsReflink for EpermLinks {
     }
 }
 
-/// `EACCES`: the caller was denied an access the link needed. Whether
-/// a copy would get past that is unknown, so the ladder surfaces it
-/// rather than guessing; it stays a call error.
 #[cfg(unix)]
 struct EaccesHardLink;
 
@@ -898,25 +893,105 @@ fn eperm_from_reflink_downgrades_clone_or_copy_to_copy() {
     assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_COPY);
 }
 
-/// `EACCES` shares `ErrorKind::PermissionDenied` with `EPERM` and must
-/// keep propagating: the tier stays, the error surfaces, nothing is
-/// written.
 #[test]
 #[cfg(unix)]
-fn eacces_from_hard_link_propagates_without_downgrading() {
+fn eacces_from_hard_link_downgrades_the_auto_ladder() {
     let state = AtomicU8::new(LINK_STATE_HARDLINK);
     let tmp = tempdir().unwrap();
-    let src = write_source(tmp.path(), "src.txt", b"forbidden");
-    let dst = tmp.path().join("nested/dst.txt");
-    fs::create_dir_all(dst.parent().unwrap()).unwrap();
+    let src = write_source(tmp.path(), "src.txt", b"no hardlinks here");
+    let dst = tmp.path().join("dst.txt");
 
-    let err = auto_link::<SilentReporter, EaccesHardLink>(&AtomicU8::new(0), &state, &src, &dst)
-        .expect_err("EACCES is a call error");
+    auto_link::<SilentReporter, EaccesHardLink>(&AtomicU8::new(0), &state, &src, &dst)
+        .expect("EACCES on the hardlink tier falls through");
 
-    assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
-    assert_eq!(err.raw_os_error(), Some(libc::EACCES));
-    assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_HARDLINK, "the tier is not retired");
-    assert!(!dst.exists(), "nothing was written");
+    assert_eq!(fs::read(&dst).unwrap(), b"no hardlinks here");
+    assert_ne!(inode(&src), inode(&dst), "the file was not hardlinked");
+    assert_ne!(state.load(Ordering::Relaxed), LINK_STATE_HARDLINK, "hardlinks are retired");
+}
+
+#[cfg(unix)]
+struct EaccesLinks;
+
+#[cfg(unix)]
+impl FsHardLink for EaccesLinks {
+    fn hard_link(source: &Path, target: &Path) -> io::Result<()> {
+        EaccesHardLink::hard_link(source, target)
+    }
+}
+
+#[cfg(unix)]
+impl FsReflink for EaccesLinks {
+    fn reflink(_source: &Path, _target: &Path) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::EACCES))
+    }
+}
+
+#[test]
+#[cfg(unix)]
+fn eacces_from_both_link_tiers_copies_and_restores_exec_bits() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "source-exec", b"executable");
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o644)).unwrap();
+
+    for first_tier in [LINK_STATE_CLONE, LINK_STATE_HARDLINK] {
+        let state = AtomicU8::new(first_tier);
+        let logged = AtomicU8::new(0);
+        let dst = tmp.path().join(format!("target-{first_tier}"));
+        auto_link::<SilentReporter, EaccesLinks>(&logged, &state, &src, &dst)
+            .expect("copy works when link permissions are denied");
+
+        assert_eq!(fs::read(&dst).unwrap(), b"executable");
+        assert_ne!(inode(&src), inode(&dst), "copy has its own inode");
+        assert_eq!(fs::metadata(&dst).unwrap().permissions().mode() & 0o111, 0o111);
+        assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_COPY);
+        assert_eq!(logged.load(Ordering::Relaxed), super::LOG_FLAG_COPY);
+    }
+}
+
+#[test]
+#[cfg(unix)]
+fn eacces_from_reflink_downgrades_clone_or_copy() {
+    let state = AtomicU8::new(LINK_STATE_CLONE);
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "src.txt", b"copied");
+    let dst = tmp.path().join("dst.txt");
+
+    clone_or_copy_link::<SilentReporter, EaccesLinks>(&AtomicU8::new(0), &state, &src, &dst)
+        .expect("copy works when reflink permissions are denied");
+
+    assert_eq!(fs::read(&dst).unwrap(), b"copied");
+    assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_COPY);
+}
+
+#[test]
+#[cfg(unix)]
+fn eacces_downgrade_still_surfaces_a_failed_copy() {
+    let state = AtomicU8::new(AUTO_FIRST_TIER);
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "src.txt", b"unreachable target");
+    let dst = tmp.path().join("missing-parent/dst.txt");
+
+    let err = auto_link::<SilentReporter, EaccesLinks>(&AtomicU8::new(0), &state, &src, &dst)
+        .expect_err("copy cannot create a file under a missing directory");
+
+    assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    assert_eq!(state.load(Ordering::Relaxed), LINK_STATE_COPY);
+}
+
+#[test]
+#[cfg(unix)]
+fn explicit_link_methods_propagate_eacces() {
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "src.txt", b"explicit");
+    let dst = tmp.path().join("dst.txt");
+
+    for method in [PackageImportMethod::Hardlink, PackageImportMethod::Clone] {
+        let err = try_import::<SilentReporter, EaccesLinks>(method, &AtomicU8::new(0), &src, &dst)
+            .expect_err("explicit link methods must surface EACCES");
+        assert_eq!(err.raw_os_error(), Some(libc::EACCES));
+    }
 }
 
 /// The explicit `hardlink` method has no ladder to downgrade, and it
@@ -942,14 +1017,12 @@ fn explicit_hardlink_propagates_eperm() {
     assert!(!dst.exists(), "nothing was written");
 }
 
-/// Only the raw errno tells `EPERM` from `EACCES`; an error built from
-/// the kind alone carries no errno and stays a call error.
 #[test]
 #[cfg(unix)]
-fn is_operation_not_permitted_is_eperm_only() {
-    assert!(is_operation_not_permitted(&io::Error::from_raw_os_error(libc::EPERM)));
-    assert!(!is_operation_not_permitted(&io::Error::from_raw_os_error(libc::EACCES)));
-    assert!(!is_operation_not_permitted(&io::Error::from(io::ErrorKind::PermissionDenied)));
+fn is_link_permission_error_accepts_only_eperm_and_eacces() {
+    assert!(is_link_permission_error(&io::Error::from_raw_os_error(libc::EPERM)));
+    assert!(is_link_permission_error(&io::Error::from_raw_os_error(libc::EACCES)));
+    assert!(!is_link_permission_error(&io::Error::from(io::ErrorKind::PermissionDenied)));
 }
 
 /// Downgrading on `EPERM` does not swallow what the copy tier then


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14780. `pnpm dlx` and installs can now fall back to copying when Unix hardlink or reflink calls fail with `EACCES`, as reported on Termux.

The fix applies to pnpm v12. The v11 importer already falls back after these link failures. Regression tests inject the reported errno and use real filesystem copies; an Android device was not available for an end-to-end Termux run.

## Squash Commit Body

```text
Treat Unix EACCES from the automatic hardlink and reflink tiers as a
fallback signal alongside EPERM. A link permission denial does not imply
that reading the source and copying it to the destination is forbidden.
The copy tier still reports any error that prevents materialization.

Keep explicit hardlink and clone methods strict, and preserve terminal
handling of missing paths, existing targets, and other permission errors.
Reuse the existing filesystem capability traits and downgrade cache.

Cover both automatic starting tiers, clone-or-copy, executable-bit restoration,
copy errors, and explicit methods. The new regression tests fail against
the unchanged importer. All 488 deps-restorer tests pass with the fix.
Workspace validation passed: 11,076 Rust tests, cargo check, and clippy.
The TypeScript v11 importer already handles this fallback.

Fixes pnpm/pnpm#14780.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791633358&installation_model_id=426870&pr_number=14784&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14784&signature=e9cbdd4462bf2fbf9a2ed30c40b69e4daef6d8e8b6e63a55b89978020b3c0295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed package installation and execution on Android when hardlinks or reflinks are blocked by the filesystem.
  - Automatic imports now fall back to copying files when link-based methods are denied.
  - Preserved explicit hardlink or clone mode errors when the requested method cannot be used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->