### PR TITLE
fix(resolver): respect workspace linking depth

### DIFF
--- a/.changeset/fix-workspace-linking-depth.md
+++ b/.changeset/fix-workspace-linking-depth.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` no longer links transitive dependencies with plain version ranges to workspace packages when `linkWorkspacePackages` is `true`, even with `preferWorkspacePackages` enabled. Use `linkWorkspacePackages: deep` to enable these links. Fixes [pnpm/pnpm#14781](https://github.com/pnpm/pnpm/issues/14781).

--- a/pnpm/crates/cli/tests/suite/multiple_importers.rs
+++ b/pnpm/crates/cli/tests/suite/multiple_importers.rs
@@ -282,6 +282,52 @@ fn partial_frozen_install_does_not_remove_dependencies_of_other_workspace_projec
     );
 }
 
+#[test]
+fn workspace_linking_respects_dependency_depth() {
+    for (link_workspace_packages, direct, transitive) in [
+        ("false", "100.1.0", "100.1.0"),
+        ("true", "link:../dep", "100.1.0"),
+        ("deep", "link:../dep", "link:packages/dep"),
+    ] {
+        for prefer_workspace_packages in [false, true] {
+            let fixture = WorkspaceFixture::new();
+            fixture.append_workspace_yaml(&format!(
+                "linkWorkspacePackages: {link_workspace_packages}\npreferWorkspacePackages: {prefer_workspace_packages}\n",
+            ));
+            fixture.project(
+                "project",
+                "project",
+                ManifestDeps {
+                    prod: &[(DEP, "100.1.0"), (PARENT, "100.0.0")],
+                    ..Default::default()
+                },
+            );
+            let dep_project = fixture.project("dep", DEP, ManifestDeps::default());
+            set_version(&dep_project, "100.1.0");
+            fixture.run(["install"]);
+
+            let wanted = fixture.wanted();
+            assert_eq!(importer_version(&wanted, "packages/project", DEP), direct);
+            let parent_snapshots = snapshot_entries(&wanted, PARENT);
+            assert_eq!(parent_snapshots.len(), 1);
+            let subdependency = parent_snapshots[0]
+                .1
+                .dependencies
+                .as_ref()
+                .and_then(|dependencies| {
+                    dependencies.get(&DEP.parse().expect("parse package name"))
+                })
+                .expect("parent snapshot records the subdependency")
+                .to_string();
+            assert_eq!(subdependency, transitive);
+
+            fs::remove_dir_all(fixture.workspace.join("node_modules"))
+                .expect("remove node_modules");
+            fixture.run(["install", "--frozen-lockfile"]);
+        }
+    }
+}
+
 /// TS: `resolve a subdependency from the workspace`
 /// (`multipleImporters.ts:1427`). With `linkWorkspacePackages: deep`, a
 /// transitive resolves to the workspace project as a `link:`, and the

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -734,11 +734,7 @@ pub enum LinkWorkspacePackages {
 
 impl LinkWorkspacePackages {
     /// Whether the npm resolver should consult the workspace map
-    /// when resolving a bare-semver wanted dependency. The deps
-    /// resolver passes the same `ResolveOptions` to every depth — the
-    /// [`Self::DirectOnly`] arm only fires at the importer level
-    /// (`current_depth == 0`); the caller decides which arm
-    /// to expose by passing in the current depth.
+    /// when resolving a bare-semver wanted dependency at the given depth.
     #[must_use]
     pub fn enabled_at_depth(self, current_depth: u32) -> bool {
         match self {

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
@@ -230,8 +230,7 @@ impl SharedResolveOptions<'_> {
             lockfile_dir: self.lockfile_dir.to_path_buf(),
             workspace_packages: self.workspace_packages.clone(),
             block_exotic_subdeps: self.config.block_exotic_subdeps,
-            always_try_workspace_packages: self.config.link_workspace_packages
-                != pnpm_config::LinkWorkspacePackages::Off,
+            link_workspace_packages: self.config.link_workspace_packages,
             inject_workspace_packages: self.config.inject_workspace_packages,
             prefer_workspace_packages: self.config.prefer_workspace_packages,
             update_checksums: self.update_checksums,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tree_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tree_ctx.rs
@@ -7,7 +7,9 @@ use chrono::{DateTime, Utc};
 use pnpm_catalogs_types::Catalogs;
 use pnpm_hooks::PnpmfileHooks;
 use pnpm_patching::PatchGroupRecord;
-use pnpm_resolving_resolver_base::{ResolveOptions, VersionSelectorType, WantedDependency};
+use pnpm_resolving_resolver_base::{
+    LinkWorkspacePackages, ResolveOptions, VersionSelectorType, WantedDependency,
+};
 use std::{
     borrow::Cow,
     path::{Path, PathBuf},
@@ -32,7 +34,7 @@ pub(super) fn project_relative_cache_scope(
 ) -> Option<super::workspace_ctx::PathKey> {
     (wanted.bare_specifier.as_deref().is_some_and(|spec| {
         spec.starts_with("link:") || spec.starts_with("file:") || spec.starts_with("workspace:")
-    }) || (opts.always_try_workspace_packages && opts.workspace_packages.is_some()))
+    }) || (opts.link_workspace_packages.enabled_at_depth(0) && opts.workspace_packages.is_some()))
     .then(|| opts.project_dir.clone().into())
 }
 
@@ -111,9 +113,10 @@ pub struct TreeCtx {
     /// importer by [`Self::with_resolution_mode`].
     direct_opts: ResolveOptions,
     /// [`ResolveOptions`] handed to the resolver for transitive
-    /// dependencies — `depth > 0`. Always picks highest; carries the
+    /// dependencies — `depth > 0`. Disables implicit workspace links
+    /// unless deep linking is enabled. Always picks highest; carries the
     /// `time-based` publish-date cutoff in `published_by`. Built once
-    /// per importer by [`Self::with_resolution_mode`].
+    /// per importer, then adjusted by [`Self::with_resolution_mode`].
     subdep_opts: ResolveOptions,
     /// Workspace catalogs used to resolve `catalog:` children of injected
     /// workspace packages. Other transitive dependencies keep catalog
@@ -161,7 +164,7 @@ impl TreeCtx {
         let lockfile_dir = pnpm_fs::lexical_normalize(&lockfile_dir);
         TreeCtx {
             direct_opts: base_opts.clone(),
-            subdep_opts: base_opts.clone(),
+            subdep_opts: create_subdep_options(&base_opts),
             workspace_resolution_options_key: Arc::new(
                 super::workspace_ctx::WorkspaceResolutionOptionsKey::new(&base_opts),
             ),
@@ -196,7 +199,7 @@ impl TreeCtx {
         let lockfile_dir = pnpm_fs::lexical_normalize(&lockfile_dir);
         TreeCtx {
             direct_opts: base_opts.clone(),
-            subdep_opts: base_opts.clone(),
+            subdep_opts: create_subdep_options(&base_opts),
             workspace_resolution_options_key: Arc::new(
                 super::workspace_ctx::WorkspaceResolutionOptionsKey::new(&base_opts),
             ),
@@ -259,7 +262,8 @@ impl TreeCtx {
         self
     }
 
-    /// Resolve the depth-0 walks that follow with the subdep options.
+    /// Resolve the depth-0 walks that follow with the subdep version policy.
+    /// Workspace linking still follows their depth-0 placement.
     ///
     /// The importer orchestrator calls this once the manifest-declared
     /// direct deps have seeded: every later [`extend_tree`] on this ctx
@@ -272,7 +276,10 @@ impl TreeCtx {
     ///
     /// [`extend_tree`]: super::extend_tree
     pub fn resolve_new_direct_deps_as_subdeps(&mut self) {
-        self.direct_opts = self.subdep_opts.clone();
+        self.direct_opts = ResolveOptions {
+            link_workspace_packages: self.direct_opts.link_workspace_packages,
+            ..self.subdep_opts.clone()
+        };
     }
 
     /// The [`ResolveOptions`] to hand the resolver for a node at the
@@ -460,5 +467,16 @@ impl TreeCtx {
             }
         }
         out
+    }
+}
+
+fn create_subdep_options(base_opts: &ResolveOptions) -> ResolveOptions {
+    ResolveOptions {
+        link_workspace_packages: if base_opts.link_workspace_packages.enabled_at_depth(1) {
+            base_opts.link_workspace_packages
+        } else {
+            LinkWorkspacePackages::Off
+        },
+        ..base_opts.clone()
     }
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -15,9 +15,9 @@ use chrono::{DateTime, TimeZone, Utc};
 use pnpm_lockfile::{DirectoryResolution, LockfileResolution, RegistryContext};
 use pnpm_package_manifest::{DependencyGroup, PackageManifest};
 use pnpm_resolving_resolver_base::{
-    LatestQuery, NoMatchingVersionError, PkgResolutionId, PreferredVersions, RegistryResponseError,
-    RegistryResponseErrorOptions, ResolveError, ResolveFuture, ResolveLatestFuture, ResolveOptions,
-    ResolveResult, Resolver, WantedDependency,
+    LatestQuery, LinkWorkspacePackages, NoMatchingVersionError, PkgResolutionId, PreferredVersions,
+    RegistryResponseError, RegistryResponseErrorOptions, ResolveError, ResolveFuture,
+    ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver, WantedDependency,
 };
 use pretty_assertions::assert_eq;
 
@@ -525,7 +525,7 @@ async fn workspace_resolution_is_shared_and_rendered_per_importer() {
             let mut opts = importer_opts(project_dir, None);
             opts.lockfile_dir = Some(lockfile_dir.clone());
             opts.base_opts.lockfile_dir.clone_from(&lockfile_dir);
-            opts.base_opts.always_try_workspace_packages = true;
+            opts.base_opts.link_workspace_packages = LinkWorkspacePackages::Deep;
             opts.base_opts.workspace_packages = Some(std::sync::Arc::clone(&workspace_packages));
             opts
         })
@@ -561,7 +561,7 @@ async fn workspace_resolution_is_shared_and_rendered_per_importer() {
 
 #[tokio::test]
 async fn semver_workspace_matches_stay_scoped_to_each_importer() {
-    // `always_try_workspace_packages` lets a plain semver range land on a
+    // `link_workspace_packages` lets a plain semver range land on a
     // workspace package too, but only a named `workspace:` selector is
     // guaranteed to depend on the importer solely through the rendered link.
     // A range keeps its per-importer resolution.
@@ -590,7 +590,7 @@ async fn semver_workspace_matches_stay_scoped_to_each_importer() {
             let mut opts = importer_opts(project_dir, None);
             opts.lockfile_dir = Some(lockfile_dir.clone());
             opts.base_opts.lockfile_dir.clone_from(&lockfile_dir);
-            opts.base_opts.always_try_workspace_packages = true;
+            opts.base_opts.link_workspace_packages = LinkWorkspacePackages::Deep;
             opts.base_opts.workspace_packages = Some(std::sync::Arc::clone(&workspace_packages));
             opts
         })
@@ -638,7 +638,7 @@ async fn canonical_snapshot_link_keeps_direct_links_relative_to_each_importer() 
             let mut opts = importer_opts(project_dir, None);
             opts.lockfile_dir = Some(lockfile_dir.clone());
             opts.base_opts.lockfile_dir.clone_from(&lockfile_dir);
-            opts.base_opts.always_try_workspace_packages = true;
+            opts.base_opts.link_workspace_packages = LinkWorkspacePackages::Deep;
             opts.base_opts.workspace_packages = Some(std::sync::Arc::clone(&workspace_packages));
             opts
         })

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -1018,7 +1018,7 @@ fn workspace_packages_active<'o>(
         .as_ref()
         .is_none_or(|current| matches!(current.resolution, LockfileResolution::Directory(_)));
     (spec.revision.is_none()
-        && opts.always_try_workspace_packages
+        && opts.link_workspace_packages.enabled_at_depth(0)
         && (opts.update != UpdateBehavior::Patches || can_keep_workspace_resolution))
         .then_some(opts.workspace_packages.as_ref())
         .flatten()

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -1107,7 +1107,7 @@ fn workspace_resolve_options(packages: WorkspacePackages) -> ResolveOptions {
         project_dir: Path::new("/repo/packages/consumer").to_path_buf(),
         lockfile_dir: Path::new("/repo").to_path_buf(),
         workspace_packages: Some(std::sync::Arc::new(packages)),
-        always_try_workspace_packages: true,
+        link_workspace_packages: pnpm_config::LinkWorkspacePackages::Deep,
         ..ResolveOptions::default()
     }
 }
@@ -1296,7 +1296,7 @@ async fn workspace_shadows_registry_when_name_and_version_match() {
 }
 
 #[tokio::test]
-async fn always_try_workspace_packages_false_skips_workspace_match() {
+async fn link_workspace_packages_off_skips_workspace_match() {
     let mut server = mockito::Server::new_async().await;
     let _mock = server
         .mock("GET", "/acme")
@@ -1312,7 +1312,7 @@ async fn always_try_workspace_packages_false_skips_workspace_match() {
 
     let packages = build_workspace_packages("acme", &["1.0.0"]);
     let mut opts = workspace_resolve_options(packages);
-    opts.always_try_workspace_packages = false;
+    opts.link_workspace_packages = pnpm_config::LinkWorkspacePackages::Off;
 
     let wanted = WantedDependency {
         alias: Some("acme".to_string()),

--- a/pnpm/crates/resolving-resolver-base/src/lib.rs
+++ b/pnpm/crates/resolving-resolver-base/src/lib.rs
@@ -21,6 +21,7 @@ pub use errors::{
     GitResolveError, NoMatchingVersionError, RegistryResponseError, RegistryResponseErrorOptions,
 };
 pub use peer_range::{get_peer_version_range, is_acceptable_peer_spec, is_valid_peer_range};
+pub use pnpm_config::LinkWorkspacePackages;
 pub use publish_time::parse_packument_timestamp;
 pub use resolve::{
     CurrentPkg, DIRECT_DEP_SELECTOR_WEIGHT, DependencyManifest, EXISTING_VERSION_SELECTOR_WEIGHT,

--- a/pnpm/crates/resolving-resolver-base/src/resolve.rs
+++ b/pnpm/crates/resolving-resolver-base/src/resolve.rs
@@ -329,7 +329,7 @@ pub struct ResolveOptions {
     pub default_tag: Option<String>,
     pub pick_lowest_version: bool,
     pub prefer_workspace_packages: bool,
-    pub always_try_workspace_packages: bool,
+    pub link_workspace_packages: pnpm_config::LinkWorkspacePackages,
     pub update: UpdateBehavior,
     /// True only when this specific package matches the user's update
     /// target (e.g. `pnpm up <name>`). Unlike `update`, this is false for


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14781. With `linkWorkspacePackages: true`, pnpm v12 now links direct dependencies to matching workspace packages while resolving transitive plain version ranges from the registry. `linkWorkspacePackages: deep` still permits transitive links, and explicit `workspace:` dependencies continue to work.

This is a v12-only bug. v11 maps `true` to a maximum linking depth of 0 and checks that depth for each dependency. v12 discarded the distinction between `true` and `deep` before walking the dependency tree.

Validation: `just ready` passed, including all 11,059 tests and workspace linting. The focused workspace and peer integration tests also passed, as did the TypeScript build/lint and Rust pre-push checks (including rustdoc and Dylint).

## Squash Commit Body

```text
Carry the existing LinkWorkspacePackages enum through resolver options and
turn off implicit workspace matching in transitive options unless deep
linking is enabled. Preserve depth-0 workspace matching for auto-installed
peers while applying the transitive version-selection policy to them.

Add CLI regression coverage for false, true, and deep, each with and
without preferWorkspacePackages, including direct and transitive uses of
the same package and frozen reinstalls. The regression fails before the
fix because a transitive registry reference becomes a workspace link.

v11 already enforces linking depth and requires no change.

Closes pnpm/pnpm#14781.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected workspace package linking so transitive dependencies are no longer linked by default when `linkWorkspacePackages` is enabled.
  * Deep transitive linking now requires explicitly setting `linkWorkspacePackages: deep`.
  * Preserved direct dependency linking behavior and compatibility with `preferWorkspacePackages`.

* **Tests**
  * Added coverage for workspace linking behavior across dependency depths and configuration combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->