### PR TITLE
fix(install): reject a global-virtual-store slot suffix that is a route

### DIFF
--- a/pnpm/crates/deps-restorer/src/build_modules/allow_build_policy.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules/allow_build_policy.rs
@@ -27,38 +27,6 @@ pub struct AllowBuildPolicy {
 }
 
 impl AllowBuildPolicy {
-    /// Stable digest of everything this policy decides with.
-    ///
-    /// The global-virtual-store layout cache keys on it: the policy
-    /// picks which snapshots keep the engine in their hash payload
-    /// (see [`crate::VirtualStoreLayout`]), so a cache entry derived
-    /// under one policy must not be served to an install running
-    /// another. Sets are hashed in sorted order so the digest does not
-    /// depend on `HashSet` iteration order.
-    #[must_use]
-    pub fn fingerprint(&self) -> String {
-        use sha2::Digest as _;
-        let mut hasher = sha2::Sha256::new();
-        for set in [
-            &self.expanded_allowed,
-            &self.expanded_disallowed,
-            &self.allowed_dep_paths,
-            &self.disallowed_dep_paths,
-            &self.allowed_git_repos,
-            &self.disallowed_git_repos,
-        ] {
-            let mut entries: Vec<&str> = set.iter().map(String::as_str).collect();
-            entries.sort_unstable();
-            hasher.update((entries.len() as u64).to_le_bytes());
-            for entry in entries {
-                hasher.update((entry.len() as u64).to_le_bytes());
-                hasher.update(entry.as_bytes());
-            }
-        }
-        hasher.update([u8::from(self.dangerously_allow_all)]);
-        format!("{:x}", hasher.finalize())
-    }
-
     /// Build a policy from already-expanded `allowed` and
     /// `disallowed` sets and `dangerouslyAllowAllBuilds`. Pure
     /// constructor — no IO — so the policy logic is tested

--- a/pnpm/crates/deps-restorer/src/virtual_store_layout.rs
+++ b/pnpm/crates/deps-restorer/src/virtual_store_layout.rs
@@ -1041,12 +1041,27 @@ mod gvs_layout_cache {
             let (suffix, next) = read_field(&bytes, next)?;
             cursor = next;
             let package_key = package_key.parse::<PackageKey>().ok()?;
-            if !suffix.starts_with(&expected.slot_prefix(&package_key)?) {
+            let digest = suffix.strip_prefix(&expected.slot_prefix(&package_key)?)?;
+            if !is_graph_node_digest(digest) {
                 return None;
             }
             suffixes.insert(package_key, suffix.to_owned());
         }
         expected.snapshots.keys().all(|key| suffixes.contains_key(key)).then_some(suffixes)
+    }
+
+    /// Whether `digest` is the hex `calc_graph_node_hash` produces, and
+    /// so a single path component.
+    ///
+    /// The prefix check above says a suffix names the right package;
+    /// this says the rest of it is a name and not a route. Without it a
+    /// suffix ending `1.2.3/../../../..` passes the prefix check and
+    /// then [`super::join_global_virtual_store_path`] walks it right
+    /// back out of the store, because that function's job is to split a
+    /// suffix into components rather than to judge them.
+    fn is_graph_node_digest(digest: &str) -> bool {
+        digest.len() == 64
+            && digest.bytes().all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
     }
 
     /// The snapshots a cached map has to describe, and the metadata
@@ -1102,7 +1117,11 @@ mod gvs_layout_cache {
         // predictable one would also let anything that can write the
         // cache directory redirect the write through a symlink.
         let Ok(mut file) = tempfile::NamedTempFile::new_in(parent) else { return };
-        if file.write_all(&bytes).is_ok() && file.as_file().sync_all().is_ok() {
+        // No `sync_all`: this runs on the miss path, after the map has
+        // already been derived, and an fsync there is latency spent on
+        // the install this cache exists to speed up. A crash mid-write
+        // costs a torn entry, which `load` refuses and re-derives.
+        if file.write_all(&bytes).is_ok() {
             let _ = file.persist(&path);
         }
     }

--- a/pnpm/crates/deps-restorer/src/virtual_store_layout/tests.rs
+++ b/pnpm/crates/deps-restorer/src/virtual_store_layout/tests.rs
@@ -1268,6 +1268,10 @@ fn layout_cache_fingerprint_tracks_every_derivation_input() {
 /// from a repository's own `pnpm-workspace.yaml`, which makes the file
 /// attacker-writable in a hostile checkout, and a write interrupted by
 /// a crash leaves a shorter one.
+/// A slot's last component is the hex `calc_graph_node_hash` produces.
+const DIGEST_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const DIGEST_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
 #[test]
 fn layout_cache_load_rejects_a_map_it_cannot_vouch_for() {
     let cache_dir = tempfile::tempdir().expect("create cache dir");
@@ -1285,8 +1289,8 @@ fn layout_cache_load_rejects_a_map_it_cannot_vouch_for() {
     ]);
     let expected = super::gvs_layout_cache::Expected { snapshots: &snapshots, packages: None };
     let suffixes = HashMap::from([
-        (foo.clone(), "@scope/foo/1.2.3/deadbeef".to_string()),
-        (bar.clone(), "@/bar/4.5.6/cafebabe".to_string()),
+        (foo.clone(), format!("@scope/foo/1.2.3/{DIGEST_A}")),
+        (bar.clone(), format!("@/bar/4.5.6/{DIGEST_B}")),
     ]);
 
     super::gvs_layout_cache::store(file("fingerprint"), &suffixes);
@@ -1301,7 +1305,7 @@ fn layout_cache_load_rejects_a_map_it_cannot_vouch_for() {
         "an entry derived from other inputs must miss, not be reused",
     );
 
-    let short = HashMap::from([(foo.clone(), "@scope/foo/1.2.3/deadbeef".to_string())]);
+    let short = HashMap::from([(foo.clone(), format!("@scope/foo/1.2.3/{DIGEST_A}"))]);
     super::gvs_layout_cache::store(file("fingerprint"), &short);
     assert_eq!(
         super::gvs_layout_cache::load(file("fingerprint"), expected),
@@ -1310,8 +1314,8 @@ fn layout_cache_load_rejects_a_map_it_cannot_vouch_for() {
     );
 
     let redirected = HashMap::from([
-        (foo.clone(), "@/bar/4.5.6/cafebabe".to_string()),
-        (bar.clone(), "@/bar/4.5.6/cafebabe".to_string()),
+        (foo.clone(), format!("@/bar/4.5.6/{DIGEST_B}")),
+        (bar.clone(), format!("@/bar/4.5.6/{DIGEST_B}")),
     ]);
     super::gvs_layout_cache::store(file("fingerprint"), &redirected);
     assert_eq!(
@@ -1320,9 +1324,24 @@ fn layout_cache_load_rejects_a_map_it_cannot_vouch_for() {
         "a suffix naming a different package must miss, however it got into the cache",
     );
 
+    let traversing = HashMap::from([
+        (
+            "@scope/foo@1.2.3".parse::<PackageKey>().expect("parse key"),
+            "@scope/foo/1.2.3/../../../../../../tmp/evil".to_string(),
+        ),
+        ("bar@4.5.6".parse::<PackageKey>().expect("parse key"), format!("@/bar/4.5.6/{DIGEST_B}")),
+    ]);
+    super::gvs_layout_cache::store(file("fingerprint"), &traversing);
+    assert_eq!(
+        super::gvs_layout_cache::load(file("fingerprint"), expected),
+        None,
+        "a suffix that walks back out of the store must miss: it names the right package, \
+         and `join_global_virtual_store_path` would follow it anyway",
+    );
+
     let downgraded = HashMap::from([
-        (foo, "@scope/foo/9.9.9/deadbeef".to_string()),
-        (bar, "@/bar/4.5.6/cafebabe".to_string()),
+        (foo, format!("@scope/foo/9.9.9/{DIGEST_A}")),
+        (bar, format!("@/bar/4.5.6/{DIGEST_B}")),
     ]);
     super::gvs_layout_cache::store(file("fingerprint"), &downgraded);
     assert_eq!(


### PR DESCRIPTION
## Summary

Three fixes to the global-virtual-store layout cache that pnpm/pnpm#14511 landed. They were reviewed on that PR and verified, but arrived after the merge, so they are here instead.

**The one that matters.** `gvs_layout_cache::load` validated a suffix it read back off disk by checking that it starts with the `<scope>/<name>/<version>/` its snapshot key implies. A prefix is not a whole name: `@scope/foo/1.2.3/../../../../tmp/evil` passes that check, and `join_global_virtual_store_path` then walks it back out of the store, because splitting a suffix into components is that function's job and judging them is not. Slot and `node_modules` creation follow it out.

`cacheDir` is settable from a repository's own `pnpm-workspace.yaml`, so a hostile checkout can ship the entry that gets read. The last component must now be the hex digest `calc_graph_node_hash` produces, which is a name rather than a route.

**`AllowBuildPolicy::fingerprint` has no caller.** The cache key hashes the gating set through `GvsHasher::write_gating_set`; the method is left over from an earlier revision of that key. It is `pub`, so nothing warned, and its documentation still claimed the cache keys on it — which would have misled the next person to change either one.

**The cache write no longer `sync_all`s.** It runs on the miss path, after the map has already been derived, so the fsync is latency spent on the install the cache exists to speed up. A crash mid-write costs a torn entry, which `load` already refuses and re-derives.

No changeset: the layout cache has not been released — its changeset from pnpm/pnpm#14511 is still pending.

## Squash Commit Body

```text
The layout cache validated a suffix it reads back off disk by checking that
it starts with the `<scope>/<name>/<version>/` its snapshot key implies. A
prefix is not a whole name: `@scope/foo/1.2.3/../../../../tmp` passes that
check, and `join_global_virtual_store_path` then walks it back out of the
store, because splitting a suffix into components is that function's job and
judging them is not. `cacheDir` is settable from a repository's own
`pnpm-workspace.yaml`, so a hostile checkout can ship the entry that gets
read. The last component must now be the hex digest `calc_graph_node_hash`
produces.

Removes `AllowBuildPolicy::fingerprint`, which has had no caller since the
cache key moved to `GvsHasher::write_gating_set`, and whose documentation
still claimed the cache keys on it.

Drops the `sync_all` from the cache write: it runs on the miss path, after
the map has been derived, so the fsync is latency spent on the install the
cache exists to speed up, and a torn entry is one `load` already refuses and
re-derives.

Follow-up to pnpm/pnpm#14511. No changeset — that feature has not shipped.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version. (v12-only: the cache exists only
  in pacquet.)
- [x] Added a changeset if this PR changes any published package. (Not
  needed — the affected feature is unreleased.)
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YZGn6jMwYeMveHf8RHKfU

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791636363&installation_model_id=426870&pr_number=14787&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14787&signature=054eb0f471803629a60053776c42b39220d421c277b1e7d05f80d051f17d59c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->