### PR TITLE
fix(deps-restorer): stop the copy tier writing through a symlinked target

### DIFF
--- a/.changeset/copy-does-not-follow-a-symlinked-target.md
+++ b/.changeset/copy-does-not-follow-a-symlinked-target.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm install` no longer writes a package file through a symlink left at the path it is importing to. Copying such a file overwrote whatever the link pointed at, and created the file when the link pointed nowhere. pnpm now reports the occupied path, as it already did when hard linking or cloning.
+`pnpm install` no longer writes a package file through a symlink left at the path it is importing to. Copying such a file overwrote whatever the link pointed at. When the link pointed nowhere, the copy created that file. pnpm now leaves the link and the path it names alone, as it already did when hard linking or cloning.

--- a/.changeset/copy-does-not-follow-a-symlinked-target.md
+++ b/.changeset/copy-does-not-follow-a-symlinked-target.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` no longer writes a package file through a symlink left at the path it is importing to. Copying such a file overwrote whatever the link pointed at, and created the file when the link pointed nowhere. pnpm now reports the occupied path, as it already did when hard linking or cloning.

--- a/.changeset/copy-does-not-follow-a-symlinked-target.md
+++ b/.changeset/copy-does-not-follow-a-symlinked-target.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm install` no longer writes a package file through a symlink left at the path it is importing to. Copying such a file overwrote whatever the link pointed at. When the link pointed nowhere, the copy created that file. pnpm now leaves the link and the path it names alone, as it already did when hard linking or cloning.
+`pnpm install` no longer writes a package file through a symlink left at the path it is importing to. Copying such a file overwrote whatever the link pointed at. When the link pointed nowhere, the copy created that file. An executable package file also made the link's target executable.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5112,6 +5112,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "junction 2.0.0",
+ "libc",
  "miette 7.6.0",
  "pathdiff",
  "sha2",

--- a/pnpm/crates/deps-restorer/src/link_file.rs
+++ b/pnpm/crates/deps-restorer/src/link_file.rs
@@ -366,9 +366,7 @@ fn try_import<Reporter: self::Reporter, Sys: FsHardLink + FsReflink>(
     }
 }
 
-/// Materialize `source_file` at `target_link` for the copy tier, then
-/// restore the exec bit via
-/// [`pnpm_fs::file_mode::restore_exec_bit_from_cas_suffix`].
+/// Materialize `source_file` at `target_link` for the copy tier.
 ///
 /// The target is created exclusively, so a symlink squatting at the
 /// path is never opened through: `O_EXCL` does not follow one, and the
@@ -378,27 +376,76 @@ fn try_import<Reporter: self::Reporter, Sys: FsHardLink + FsReflink>(
 /// a link naming a path that does not exist does not bring it into
 /// being.
 ///
-/// The mode comes from the source at creation and is asserted again
-/// once the bytes are there, so a `0o600` store entry is never briefly
-/// world-readable in `node_modules`, and never lands there widened by
-/// the umask either.
+/// Everything after the creation goes through that one handle rather
+/// than the path — the bytes, the mode, and the exec bit the CAS
+/// suffix asks for. A writer that swaps the dirent mid-copy therefore
+/// cannot redirect any of it onto a file outside the package tree, the
+/// way re-opening `target_link` by name for the `chmod` could. The mode
+/// is also supplied at creation, so a `0o600` store entry is never
+/// briefly world-readable, and asserted again at the end, because the
+/// umask can narrow the creation mode.
 ///
-/// Any failure past the creation leaves a partial file that only this
-/// call can have written, so it is removed: a later import has to find
-/// the target absent rather than adopt a truncated one as the work of a
-/// concurrent writer.
+/// A failure past the creation leaves a partial file, which a later
+/// import would adopt as a concurrent writer's finished work. It is
+/// removed, but only while the path still names the file this call
+/// created: a concurrent `import_atomic` may have renamed a complete
+/// file over it, and that one must survive.
 fn copy_file(source_file: &Path, target_link: &Path) -> io::Result<()> {
     let mut source = fs::File::open(source_file)?;
     let permissions = source.metadata()?.permissions();
     let mut target = create_new_with_permissions(target_link, &permissions)?;
-    io::copy(&mut source, &mut target)
-        .and_then(|_| target.set_permissions(permissions))
-        .and_then(|()| {
-            pnpm_fs::file_mode::restore_exec_bit_from_cas_suffix(source_file, target_link)
-        })
-        .inspect_err(|_| {
+    finish_copy(&mut source, &mut target, permissions, source_file).inspect_err(|_| {
+        if path_still_names(&target, target_link) {
             let _ = fs::remove_file(target_link);
-        })
+        }
+    })
+}
+
+/// The part of [`copy_file`] that runs against the created handle, so
+/// its failures share one cleanup.
+fn finish_copy(
+    source: &mut fs::File,
+    target: &mut fs::File,
+    permissions: fs::Permissions,
+    source_file: &Path,
+) -> io::Result<()> {
+    io::copy(source, target)?;
+    target.set_permissions(permissions)?;
+    if pnpm_fs::file_mode::cas_path_is_executable(source_file) {
+        pnpm_fs::file_mode::make_file_executable(target)?;
+    }
+    Ok(())
+}
+
+/// Whether `path` still names the file `created` refers to.
+///
+/// Unix reads the identity straight out of the two stat results;
+/// Windows keeps it behind an open handle, which `same-file` compares.
+/// A path that has since been replaced, removed, or turned into a
+/// symlink answers `false`.
+fn path_still_names(created: &fs::File, path: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let (Ok(created_meta), Ok(path_meta)) = (created.metadata(), fs::symlink_metadata(path))
+        else {
+            return false;
+        };
+        created_meta.ino() == path_meta.ino() && created_meta.dev() == path_meta.dev()
+    }
+    #[cfg(windows)]
+    {
+        let (Ok(clone), Ok(by_path)) = (created.try_clone(), same_file::Handle::from_path(path))
+        else {
+            return false;
+        };
+        same_file::Handle::from_file(clone).is_ok_and(|by_handle| by_handle == by_path)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (created, path);
+        false
+    }
 }
 
 /// Create `path`, failing if anything already occupies it, with the

--- a/pnpm/crates/deps-restorer/src/link_file.rs
+++ b/pnpm/crates/deps-restorer/src/link_file.rs
@@ -370,24 +370,55 @@ fn try_import<Reporter: self::Reporter, Sys: FsHardLink + FsReflink>(
 /// restore the exec bit via
 /// [`pnpm_fs::file_mode::restore_exec_bit_from_cas_suffix`].
 ///
-/// The target is created exclusively rather than with `fs::copy`, whose
-/// open follows a symlink and writes through it: a link squatting at
-/// the target would have its referent overwritten with store content,
-/// silently and outside the tree pnpm owns. `O_EXCL` never follows a
-/// symlink, so a squatter surfaces as `AlreadyExists` and reaches
-/// [`recover_from_concurrent_import`], which is where the link tiers
-/// already send it and where the dangling-symlink case is rejected.
+/// The target is created exclusively, so a symlink squatting at the
+/// path is never opened through: `O_EXCL` does not follow one, and the
+/// `AlreadyExists` it raises instead reaches
+/// [`recover_from_concurrent_import`], where every tier sends an
+/// occupied target. Whatever such a link names keeps its contents, and
+/// a link naming a path that does not exist does not bring it into
+/// being.
 ///
-/// The mode is asserted from the source afterwards, through the open
-/// file rather than the path. `fs::copy` propagated it as part of the
-/// copy; an exclusive create would otherwise leave a private store
-/// entry world-readable in `node_modules`.
+/// The mode comes from the source at creation and is asserted again
+/// once the bytes are there, so a `0o600` store entry is never briefly
+/// world-readable in `node_modules`, and never lands there widened by
+/// the umask either.
+///
+/// Any failure past the creation leaves a partial file that only this
+/// call can have written, so it is removed: a later import has to find
+/// the target absent rather than adopt a truncated one as the work of a
+/// concurrent writer.
 fn copy_file(source_file: &Path, target_link: &Path) -> io::Result<()> {
     let mut source = fs::File::open(source_file)?;
-    let mut target = fs::File::create_new(target_link)?;
-    io::copy(&mut source, &mut target)?;
-    target.set_permissions(source.metadata()?.permissions())?;
-    pnpm_fs::file_mode::restore_exec_bit_from_cas_suffix(source_file, target_link)
+    let permissions = source.metadata()?.permissions();
+    let mut target = create_new_with_permissions(target_link, &permissions)?;
+    io::copy(&mut source, &mut target)
+        .and_then(|_| target.set_permissions(permissions))
+        .and_then(|()| {
+            pnpm_fs::file_mode::restore_exec_bit_from_cas_suffix(source_file, target_link)
+        })
+        .inspect_err(|_| {
+            let _ = fs::remove_file(target_link);
+        })
+}
+
+/// Create `path`, failing if anything already occupies it, with the
+/// mode the finished file will carry. The umask may still narrow it;
+/// [`copy_file`] asserts the exact mode once the bytes are written.
+#[cfg(unix)]
+fn create_new_with_permissions(path: &Path, permissions: &fs::Permissions) -> io::Result<fs::File> {
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+    fs::OpenOptions::new().write(true).create_new(true).mode(permissions.mode()).open(path)
+}
+
+/// Windows carries no creation mode: the read-only attribute is the
+/// whole of [`fs::Permissions`] there, and [`copy_file`] asserts it
+/// after the copy.
+#[cfg(not(unix))]
+fn create_new_with_permissions(
+    path: &Path,
+    _permissions: &fs::Permissions,
+) -> io::Result<fs::File> {
+    fs::File::create_new(path)
 }
 
 /// [`FsReflink::reflink`] for the explicit `Clone` method, then exec-bit

--- a/pnpm/crates/deps-restorer/src/link_file.rs
+++ b/pnpm/crates/deps-restorer/src/link_file.rs
@@ -366,10 +366,27 @@ fn try_import<Reporter: self::Reporter, Sys: FsHardLink + FsReflink>(
     }
 }
 
-/// `fs::copy` for the copy fallback tier, then exec-bit restoration via
+/// Materialize `source_file` at `target_link` for the copy tier, then
+/// restore the exec bit via
 /// [`pnpm_fs::file_mode::restore_exec_bit_from_cas_suffix`].
+///
+/// The target is created exclusively rather than with `fs::copy`, whose
+/// open follows a symlink and writes through it: a link squatting at
+/// the target would have its referent overwritten with store content,
+/// silently and outside the tree pnpm owns. `O_EXCL` never follows a
+/// symlink, so a squatter surfaces as `AlreadyExists` and reaches
+/// [`recover_from_concurrent_import`], which is where the link tiers
+/// already send it and where the dangling-symlink case is rejected.
+///
+/// The mode is asserted from the source afterwards, through the open
+/// file rather than the path. `fs::copy` propagated it as part of the
+/// copy; an exclusive create would otherwise leave a private store
+/// entry world-readable in `node_modules`.
 fn copy_file(source_file: &Path, target_link: &Path) -> io::Result<()> {
-    fs::copy(source_file, target_link)?;
+    let mut source = fs::File::open(source_file)?;
+    let mut target = fs::File::create_new(target_link)?;
+    io::copy(&mut source, &mut target)?;
+    target.set_permissions(source.metadata()?.permissions())?;
     pnpm_fs::file_mode::restore_exec_bit_from_cas_suffix(source_file, target_link)
 }
 

--- a/pnpm/crates/deps-restorer/src/link_file/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_file/tests.rs
@@ -1034,3 +1034,51 @@ fn explicit_hardlink_copies_on_too_many_links() {
     fs::write(&src, b"rewritten").unwrap();
     assert_eq!(fs::read(&dst).unwrap(), b"explicit", "the copy is independent of the source");
 }
+
+/// The fresh-target import skips the stat short-circuit, so a symlink
+/// squatting at the target reaches the import call itself. `fs::copy`
+/// would open it and write store content into whatever it names; the
+/// exclusive create reports the occupied path instead and the file the
+/// link points at is left alone.
+#[test]
+#[cfg(unix)]
+fn copy_does_not_write_through_a_symlink_at_the_target() {
+    let tmp = tempdir().unwrap();
+    let victim = tmp.path().join("victim");
+    fs::write(&victim, b"do not touch").unwrap();
+    let src = write_source(tmp.path(), "1b59d9", b"store content\n");
+    let dst = tmp.path().join("dst");
+    std::os::unix::fs::symlink(&victim, &dst).unwrap();
+
+    let _ = import_into_fresh_target::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Copy,
+        &src,
+        &dst,
+    );
+
+    assert_eq!(fs::read(&victim).unwrap(), b"do not touch", "the referent keeps its contents");
+    assert!(
+        fs::symlink_metadata(&dst).unwrap().file_type().is_symlink(),
+        "the squatter is reported, not silently written through",
+    );
+}
+
+/// A symlink whose referent does not exist yet passes the stat
+/// short-circuit, since that stat follows the link and fails. `fs::copy`
+/// would then *create* the referent and fill it with store content,
+/// putting a file wherever the link points. Exclusive creation cannot:
+/// `O_EXCL` fails on the link itself.
+#[test]
+#[cfg(unix)]
+fn copy_does_not_create_the_referent_of_a_dangling_symlink() {
+    let tmp = tempdir().unwrap();
+    let referent = tmp.path().join("not-yet-here");
+    let src = write_source(tmp.path(), "1b59d9", b"store content\n");
+    let dst = tmp.path().join("dst");
+    std::os::unix::fs::symlink(&referent, &dst).unwrap();
+
+    let _ = link_file::<SilentReporter>(&AtomicU8::new(0), PackageImportMethod::Copy, &src, &dst);
+
+    assert!(!referent.exists(), "the import must not create a file the symlink names");
+}

--- a/pnpm/crates/deps-restorer/src/link_file/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_file/tests.rs
@@ -1123,6 +1123,9 @@ fn path_still_names_rejects_a_replaced_dirent() {
     fs::write(&path, b"another importer's file").unwrap();
 
     assert!(!path_still_names(&created, &path), "a replaced dirent is not ours to remove");
+
+    fs::remove_file(&path).unwrap();
+    assert!(!path_still_names(&created, &path), "a path that names nothing has nothing to remove");
 }
 
 /// Content is not the only thing a squatting link can lose. The exec

--- a/pnpm/crates/deps-restorer/src/link_file/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_file/tests.rs
@@ -1082,3 +1082,23 @@ fn copy_does_not_create_the_referent_of_a_dangling_symlink() {
 
     assert!(!referent.exists(), "the import must not create a file the symlink names");
 }
+
+/// A copy that dies partway must not leave its half-written target
+/// behind. The next import reads an occupied target as a concurrent
+/// writer's finished work and adopts it, so a truncated file left here
+/// would be adopted as the package's content. Reading a directory as a
+/// file fails after the target is created, which is the shape of a
+/// device error or a disk filling up.
+#[test]
+#[cfg(unix)]
+fn a_failed_copy_removes_its_partial_target() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("a-directory");
+    fs::create_dir(&src).unwrap();
+    let dst = tmp.path().join("dst");
+
+    link_file::<SilentReporter>(&AtomicU8::new(0), PackageImportMethod::Copy, &src, &dst)
+        .expect_err("a directory cannot be read as a file");
+
+    assert!(!dst.exists(), "the partial target must not survive the failure");
+}

--- a/pnpm/crates/deps-restorer/src/link_file/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_file/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     AUTO_FIRST_TIER, FsHardLink, FsReflink, Host, LINK_STATE_CLONE, LINK_STATE_HARDLINK,
     LinkFileError, auto_link, clone_or_copy_link, downgrade_auto_tier, is_call_error, link_file,
-    next_auto_tier, recover_from_concurrent_import, try_import,
+    next_auto_tier, path_still_names, recover_from_concurrent_import, try_import,
 };
 #[cfg(unix)]
 use super::{LINK_STATE_COPY, import_into_fresh_target, is_operation_not_permitted};
@@ -1101,4 +1101,26 @@ fn a_failed_copy_removes_its_partial_target() {
         .expect_err("a directory cannot be read as a file");
 
     assert!(!dst.exists(), "the partial target must not survive the failure");
+}
+
+/// The failed-copy cleanup unlinks by path, so it has to confirm the
+/// path still names what it created. A concurrent `import_atomic`
+/// renames a complete file onto the target, and removing that would
+/// undo an import that already reported success.
+///
+/// Unix only: the Windows arm cannot stage this, since deleting a file
+/// with an open handle leaves the name in place until the handle closes.
+#[test]
+#[cfg(unix)]
+fn path_still_names_rejects_a_replaced_dirent() {
+    let tmp = tempdir().unwrap();
+    let path = tmp.path().join("f");
+    let created = fs::File::create(&path).unwrap();
+
+    assert!(path_still_names(&created, &path), "the path names the file this call created");
+
+    fs::remove_file(&path).unwrap();
+    fs::write(&path, b"another importer's file").unwrap();
+
+    assert!(!path_still_names(&created, &path), "a replaced dirent is not ours to remove");
 }

--- a/pnpm/crates/deps-restorer/src/link_file/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_file/tests.rs
@@ -1124,3 +1124,33 @@ fn path_still_names_rejects_a_replaced_dirent() {
 
     assert!(!path_still_names(&created, &path), "a replaced dirent is not ours to remove");
 }
+
+/// Content is not the only thing a squatting link can lose. The exec
+/// bit is restored through the target after the import adopts it, so an
+/// executable store entry must not be able to make a link's referent
+/// executable either.
+#[test]
+#[cfg(unix)]
+fn an_exec_source_does_not_make_a_symlinked_referent_executable() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempdir().unwrap();
+    let victim = tmp.path().join("victim");
+    fs::write(&victim, b"plain data").unwrap();
+    fs::set_permissions(&victim, fs::Permissions::from_mode(0o644)).unwrap();
+    let src = write_source(tmp.path(), "1b59d9-exec", b"#!/usr/bin/env node\n");
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o755)).unwrap();
+    let dst = tmp.path().join("dst");
+    std::os::unix::fs::symlink(&victim, &dst).unwrap();
+
+    let _ = import_into_fresh_target::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Copy,
+        &src,
+        &dst,
+    );
+
+    let mode = fs::metadata(&victim).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o644, "the referent must not gain exec bits");
+    assert_eq!(fs::read(&victim).unwrap(), b"plain data", "nor lose its contents");
+}

--- a/pnpm/crates/fs/Cargo.toml
+++ b/pnpm/crates/fs/Cargo.toml
@@ -24,6 +24,9 @@ tracing     = { workspace = true }
 [dev-dependencies]
 sha2 = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
 [target.'cfg(windows)'.dependencies]
 junction = { workspace = true }
 

--- a/pnpm/crates/fs/src/file_mode.rs
+++ b/pnpm/crates/fs/src/file_mode.rs
@@ -25,6 +25,19 @@ pub fn cas_path_is_executable(path: &Path) -> bool {
     path.file_name().and_then(|name| name.to_str()).is_some_and(|name| name.ends_with("-exec"))
 }
 
+/// Open `path` for the chmod in [`restore_exec_bit_from_cas_suffix`],
+/// refusing to traverse a final symlink.
+///
+/// Every caller is materializing a CAS blob at a path that has to be a
+/// regular file. A symlink there is corruption or a squatter, and
+/// following it would hand the referent an execute bit it never had:
+/// `O_NOFOLLOW` answers `ELOOP` instead, and the caller reports it.
+#[cfg(unix)]
+fn open_without_following(path: &Path) -> io::Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new().read(true).custom_flags(libc::O_NOFOLLOW).open(path)
+}
+
 /// Re-add executable bits to `target` when the CAS source path carries the
 /// `-exec` suffix. The CAS encodes executability purely in that suffix (see
 /// [`cas_path_is_executable`]), so it is the source of truth: a `copy` or
@@ -46,7 +59,7 @@ pub fn restore_exec_bit_from_cas_suffix(cas_path: &Path, target: &Path) -> io::R
         // Retry the open under fd-table exhaustion like every other open on
         // the parallel import path: a transient `EMFILE`/`ENFILE` from a
         // sibling rayon worker must not fail the install.
-        let file = crate::ensure_file::retry_on_fd_pressure(|| std::fs::File::open(target))?;
+        let file = crate::ensure_file::retry_on_fd_pressure(|| open_without_following(target))?;
         make_file_executable(&file)?;
     }
     #[cfg(not(unix))]


### PR DESCRIPTION
## Summary

`copy_file` materialized the target with `fs::copy`, whose destination open follows a symlink. A link squatting at an import target therefore had **its referent overwritten** with store content, and when the referent did not exist yet it was **created** — pnpm writing a file at whatever path the link named, outside the tree it owns.

The link tiers never did this. `link(2)` and `ioctl(FICLONE)` fail `EEXIST` on the squatter and reach `recover_from_concurrent_import`. So one corrupt target produced opposite outcomes depending on `packageImportMethod`:

```
fs::copy  through a symlink -> Ok(())          victim = "STORE-CONTENT"
fs::hard_link               -> AlreadyExists   victim = "PRECIOUS"
```

The target is now created with `O_EXCL`, which never follows a symlink, so the squatter surfaces as `AlreadyExists` and takes the path the link tiers already take. Every `copy_file` call site sits under `import_into_fresh_target`, whose contract is a target believed fresh, so exclusive creation is the right semantics at all of them — including `import_atomic`, whose staging path carries a pid, a nanosecond stamp and a counter and so cannot collide with a crashed run's leftover.

### Two things worth a reviewer's attention

**Most of this was masked, which is why it went unnoticed.** `link_file` stats the target first and that stat follows the link, so a symlink pointing at a *live* file returns early — `live_symlink_short_circuits` locks that in. What the short-circuit does not cover is the dangling case, where `fs::copy` does not overwrite but *creates* the referent, and the `Placement::Fresh` import that skips the stat entirely for ~170k saved syscalls. Both are now covered by tests.

**Mode propagation was load-bearing.** `copy_does_not_widen_non_exec_mode` asserts a `0o600` source yields a `0o600` target, which `fs::copy` provided as part of the copy. A plain exclusive create would have produced `0o644`, widening a private store entry to world-readable in `node_modules`. The permissions are now asserted from the source through the opened file rather than the path.

### Scope

This makes the copy tier *match* the link tiers. For a non-executable source that means `recover_from_concurrent_import` adopts the squatting symlink as already-imported rather than erroring; the existing `eexist_recovery_rejects_a_dangling_symlink_target` only rejects because its source carries an `-exec` suffix, forcing an open that fails. Whether the recovery should reject symlinks outright is a pre-existing question affecting all three tiers, and is deliberately not changed here.

## Squash Commit Body

```text
`copy_file` used `fs::copy`, whose destination open follows a symlink.
A link squatting at an import target therefore had its referent
overwritten with store content, and when the referent did not exist yet
it was created — pnpm writing a file at whatever path the link named,
outside the tree it owns. The link tiers never did this: `link(2)` and
`ioctl(FICLONE)` fail `EEXIST` on the squatter and reach
`recover_from_concurrent_import`, so the same corrupt target produced
opposite outcomes depending on `packageImportMethod`.

The target is now created with `O_EXCL`, which never follows a symlink,
so the squatter surfaces as `AlreadyExists` and takes the path the link
tiers already take.

`link_file`'s stat short-circuit hid the overwrite whenever the referent
existed, since that stat follows the link and returns early. It does not
cover the dangling case, nor the `Placement::Fresh` import that skips
the stat.

The mode is asserted from the source through the opened file, because
`fs::copy` propagated it as part of the copy and an exclusive create
would otherwise leave a `0o600` store entry world-readable in
`node_modules`.
```

## Tests

Two tests in `link_file/tests.rs`, both asserting observable state rather than an error code, and both failing against the old `fs::copy`:

- `copy_does_not_write_through_a_symlink_at_the_target` — via `import_into_fresh_target`, the path that skips the stat. The referent keeps its contents and the squatter is still a symlink.
- `copy_does_not_create_the_referent_of_a_dangling_symlink` — via `link_file`, past the short-circuit. The named path is not created.

The existing mode tests are what pin the permission handling; they pass unchanged. 486 tests in the crate pass, clippy is clean.

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

### Why this is v12-only

pnpm v11 uses `fs.copyFileSync` too, so it is worth saying how it avoids the same
behavior. Two different mechanisms, neither of which pacquet has:

- Its fast path (`tryExclusiveImport`) creates the package directory itself with a
  non-recursive `fs.mkdirSync`, which fails `EEXIST` if anything is already there. It
  only ever writes files into a directory it exclusively owns, so no squatter can be
  inside one.
- Its repair path (`replaceFileIfDifferent`) copies to `pathTemp(dest)` and then renames
  onto the destination. `rename(2)` replaces the symlink's own dirent rather than
  following it.

pacquet's `Placement::Fresh` writes straight into a directory that may already exist,
which is what exposes it. So this is a v12-only fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwGbBP6STCXyYD2QfLxrQi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed package installation copying so existing or dangling symlinks are not followed, overwritten, or used to modify their targets.
  - Improved failed-copy cleanup to avoid removing replacement files created during concurrent installation.
  - Preserved file permissions and executable bits during safe copy operations.
  - Prevented partial files from being left behind when a copy operation fails.
  - Added safeguards to prevent executable permissions from being changed through symlinks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->