### PR TITLE
fix(sbom): normalize an npm shorthand repository field to a valid vcs URL

### DIFF
--- a/.changeset/sbom-repository-shorthand-url.md
+++ b/.changeset/sbom-repository-shorthand-url.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm sbom` now normalizes an npm shorthand `repository` field (e.g. `vercel/ms`) to a full GitHub URL, and omits the `vcs` external reference entirely when the field can't be turned into a valid URL, instead of writing an invalid reference into the generated SBOM [pnpm/pnpm#14773](https://github.com/pnpm/pnpm/issues/14773).

--- a/.changeset/sbom-repository-shorthand-url.md
+++ b/.changeset/sbom-repository-shorthand-url.md
@@ -1,4 +1,7 @@
 ---
+"@pnpm/deps.compliance.commands": patch
+"@pnpm/deps.compliance.sbom": patch
+"pnpm": patch
 "pacquet": patch
 ---
 

--- a/pnpm/crates/cli/src/cli_args/sbom.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom.rs
@@ -193,17 +193,30 @@ fn confined_importer_dir(lockfile_dir: &Path, importer_id: &str) -> Option<PathB
 fn extract_repository(manifest: &serde_json::Value) -> Option<String> {
     let repo = manifest.get("repository")?;
     let value = if let Some(s) = repo.as_str() {
-        s.to_string()
+        s.trim().to_string()
     } else {
-        repo.get("url")?.as_str()?.to_string()
+        repo.get("url")?.as_str()?.trim().to_string()
     };
     if value.starts_with("http://") || value.starts_with("https://") {
         return Some(strip_url_credentials(&value));
     }
-    if !value.contains(':') && value.matches('/').count() == 1 {
-        return Some(format!("https://github.com/{value}"));
-    }
-    None
+    is_npm_shorthand_repository(&value).then(|| format!("https://github.com/{value}"))
+}
+
+/// npm resolves a bare `owner/repo` to GitHub. Anything carrying a scheme, a
+/// host, extra path segments, or characters that would need escaping is not the
+/// shorthand, and prefixing it would only produce another invalid URL.
+fn is_npm_shorthand_repository(value: &str) -> bool {
+    let Some((owner, repo)) = value.split_once('/') else {
+        return false;
+    };
+    let is_segment = |segment: &str| {
+        !segment.is_empty()
+            && segment
+                .chars()
+                .all(|char| char.is_ascii_alphanumeric() || matches!(char, '_' | '.' | '-'))
+    };
+    is_segment(owner) && is_segment(repo)
 }
 
 fn strip_url_credentials(url: &str) -> String {

--- a/pnpm/crates/cli/src/cli_args/sbom.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom.rs
@@ -192,10 +192,18 @@ fn confined_importer_dir(lockfile_dir: &Path, importer_id: &str) -> Option<PathB
 
 fn extract_repository(manifest: &serde_json::Value) -> Option<String> {
     let repo = manifest.get("repository")?;
-    if let Some(s) = repo.as_str() {
-        return Some(s.to_string());
+    let value = if let Some(s) = repo.as_str() {
+        s.to_string()
+    } else {
+        repo.get("url")?.as_str()?.to_string()
+    };
+    if value.starts_with("http://") || value.starts_with("https://") {
+        return Some(strip_url_credentials(&value));
     }
-    repo.get("url").and_then(|u| u.as_str()).map(ToString::to_string)
+    if !value.contains(':') && value.matches('/').count() == 1 {
+        return Some(format!("https://github.com/{value}"));
+    }
+    None
 }
 
 fn strip_url_credentials(url: &str) -> String {

--- a/pnpm/crates/cli/src/cli_args/sbom/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom/tests.rs
@@ -227,6 +227,24 @@ fn extract_repository_object() {
 }
 
 #[test]
+fn extract_repository_normalizes_npm_shorthand() {
+    let manifest = serde_json::json!({ "repository": "vercel/ms" });
+    assert_eq!(extract_repository(&manifest), Some("https://github.com/vercel/ms".to_string()));
+}
+
+#[test]
+fn extract_repository_strips_credentials_from_full_url() {
+    let manifest = serde_json::json!({ "repository": "https://user:pass@github.com/foo/bar" });
+    assert_eq!(extract_repository(&manifest), Some("https://github.com/foo/bar".to_string()));
+}
+
+#[test]
+fn extract_repository_rejects_unparsable_value() {
+    let manifest = serde_json::json!({ "repository": "not a valid repository" });
+    assert_eq!(extract_repository(&manifest), None);
+}
+
+#[test]
 fn normalize_link_path_simple() {
     assert_eq!(normalize_link_path(".", "packages/foo"), Some("packages/foo".to_string()));
 }

--- a/pnpm/crates/cli/src/cli_args/sbom/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom/tests.rs
@@ -240,8 +240,19 @@ fn extract_repository_strips_credentials_from_full_url() {
 
 #[test]
 fn extract_repository_rejects_unparsable_value() {
-    let manifest = serde_json::json!({ "repository": "not a valid repository" });
-    assert_eq!(extract_repository(&manifest), None);
+    for value in [
+        "not a valid repository",
+        // One slash, but a segment that needs escaping: prefixing it would
+        // only produce another invalid URL.
+        "not valid/repo here",
+        // Extra path segments are not the shorthand.
+        "owner/repo/extra",
+        "git@github.com:foo/bar.git",
+        "git+ssh://git@github.com/foo/bar.git",
+    ] {
+        let manifest = serde_json::json!({ "repository": value });
+        assert_eq!(extract_repository(&manifest), None, "{value} must not become a vcs url");
+    }
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/suite/sbom.rs
+++ b/pnpm/crates/cli/tests/suite/sbom.rs
@@ -173,7 +173,7 @@ fn sbom_omits_unparsable_dependency_repository() {
         .is_some_and(|ext_refs| ext_refs.iter().any(|ext_ref| ext_ref["type"] == "vcs"));
     assert!(
         !has_vcs_ref,
-        "an unparsable repository field must not produce a vcs external reference"
+        "an unparsable repository field must not produce a vcs external reference",
     );
 }
 

--- a/pnpm/crates/cli/tests/suite/sbom.rs
+++ b/pnpm/crates/cli/tests/suite/sbom.rs
@@ -145,6 +145,38 @@ fn sbom_omits_a_blank_dependency_author() {
     );
 }
 
+/// An npm shorthand `repository` field (`owner/repo`) is normalized to a
+/// valid GitHub URL rather than reaching the BOM verbatim.
+#[test]
+fn sbom_normalizes_npm_shorthand_dependency_repository() {
+    let tmp = copy_fixture("simple-sbom");
+    set_dependency_repository(tmp.path(), "vercel/ms");
+
+    let cyclonedx = run_sbom_json_from_store(tmp.path(), "cyclonedx");
+    let component = cyclonedx_component(&cyclonedx, "is-positive");
+    let ext_refs = component["externalReferences"].as_array().expect("externalReferences");
+    let vcs_ref = ext_refs.iter().find(|ext_ref| ext_ref["type"] == "vcs").expect("vcs ref");
+    assert_eq!(vcs_ref["url"], "https://github.com/vercel/ms");
+}
+
+/// A `repository` field that cannot be turned into a valid URL is omitted
+/// from the BOM rather than emitted broken.
+#[test]
+fn sbom_omits_unparsable_dependency_repository() {
+    let tmp = copy_fixture("simple-sbom");
+    set_dependency_repository(tmp.path(), "not a valid repository");
+
+    let cyclonedx = run_sbom_json_from_store(tmp.path(), "cyclonedx");
+    let component = cyclonedx_component(&cyclonedx, "is-positive");
+    let has_vcs_ref = component["externalReferences"]
+        .as_array()
+        .is_some_and(|ext_refs| ext_refs.iter().any(|ext_ref| ext_ref["type"] == "vcs"));
+    assert!(
+        !has_vcs_ref,
+        "an unparsable repository field must not produce a vcs external reference"
+    );
+}
+
 #[test]
 fn sbom_missing_format_fails() {
     let tmp = copy_fixture("simple-sbom");
@@ -1461,6 +1493,26 @@ fn set_dependency_author(workspace: &Path, author_name: &str) {
             "version": "3.1.0",
             "description": "sbom author fixture",
             "author": { "name": author_name },
+        })
+        .to_string(),
+    )
+    .expect("write the package manifest");
+}
+
+/// Plants the store copy of the fixture's only dependency, with the given
+/// `repository` field. A run that is not `--lockfile-only` reads dependency
+/// metadata from there, so this is the seam for giving a dependency a
+/// repository.
+fn set_dependency_repository(workspace: &Path, repository: &str) {
+    let package_dir =
+        workspace.join("node_modules/.pnpm/is-positive@3.1.0/node_modules/is-positive");
+    fs::create_dir_all(&package_dir).expect("create the package directory");
+    fs::write(
+        package_dir.join("package.json"),
+        serde_json::json!({
+            "name": "is-positive",
+            "version": "3.1.0",
+            "repository": repository,
         })
         .to_string(),
     )

--- a/pnpm11/deps/compliance/commands/src/sbom/sbom.ts
+++ b/pnpm11/deps/compliance/commands/src/sbom/sbom.ts
@@ -12,6 +12,7 @@ import {
   authorNameFromField,
   bugsUrlFromField,
   collectSbomComponents,
+  repositoryUrlFromField,
   resolveWorkspaceDeps,
   type SbomComponentType,
   type SbomFormat,
@@ -475,8 +476,8 @@ async function generateSbomForProject (
   const rootAuthor = authorNameFromField(
     manifest.author ?? (singleProject ? rootManifest.author : undefined)
   )
-  const rootRepository = extractRepository(manifest)
-    ?? (singleProject ? extractRepository(rootManifest) : undefined)
+  const rootRepository = repositoryUrlFromField(manifest.repository)
+    ?? (singleProject ? repositoryUrlFromField(rootManifest.repository) : undefined)
   const rootDescription = manifest.description
     ?? (singleProject ? rootManifest.description : undefined)
   const rootBugsUrl = bugsUrlFromField(manifest.bugs)
@@ -597,11 +598,6 @@ async function resolveRootLicense (manifest: Parameters<typeof resolveLicenseFro
   return undefined
 }
 
-function extractRepository (manifest: { repository?: string | { url?: string } }): string | undefined {
-  if (typeof manifest.repository === 'string') return manifest.repository
-  return manifest.repository?.url
-}
-
 const WORKSPACE_MANIFEST_READ_CONCURRENCY = 8
 
 async function buildWorkspacePackagesMap (
@@ -629,7 +625,7 @@ async function buildWorkspacePackagesMap (
         license: typeof manifest.license === 'string' ? manifest.license : undefined,
         description: manifest.description,
         author: authorNameFromField(manifest.author),
-        repository: extractRepository(manifest),
+        repository: repositoryUrlFromField(manifest.repository),
       }]
     }))
   )

--- a/pnpm11/deps/compliance/commands/test/sbom/index.ts
+++ b/pnpm11/deps/compliance/commands/test/sbom/index.ts
@@ -113,6 +113,28 @@ test('pnpm sbom omits a blank root author', async () => {
   expect(spdxPackage(namedSpdx, 'simple-sbom-test').supplier).toBe('Person: Jane Doe')
 })
 
+test('pnpm sbom normalizes an npm shorthand root repository and omits an unparsable one', async () => {
+  const workspaceDir = tempDir()
+  f.copy('simple-sbom', workspaceDir)
+
+  const sbomOpts = {
+    ...DEFAULT_OPTS,
+    dir: workspaceDir,
+    lockfileDir: workspaceDir,
+    pnpmHomeDir: '',
+    lockfileOnly: true,
+    sbomFormat: 'cyclonedx' as const,
+  }
+
+  setManifestRepository(path.join(workspaceDir, 'package.json'), 'vercel/ms')
+  const shorthand = JSON.parse((await sbom.handler(sbomOpts)).output)
+  expect(vcsUrl(shorthand.metadata.component)).toBe('https://github.com/vercel/ms')
+
+  setManifestRepository(path.join(workspaceDir, 'package.json'), 'not a valid repository')
+  const unparsable = JSON.parse((await sbom.handler(sbomOpts)).output)
+  expect(vcsUrl(unparsable.metadata.component)).toBeUndefined()
+})
+
 // A selected project inherits the workspace root's author only when it declares
 // no author of its own. Declaring a blank one must not pull in the root's name.
 test('pnpm sbom --filter keeps a blank project author from inheriting the workspace author', async () => {
@@ -187,6 +209,16 @@ function setManifestAuthor (manifestPath: string, author: string): void {
   const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
   manifest.author = author
   fs.writeFileSync(manifestPath, JSON.stringify(manifest))
+}
+
+function setManifestRepository (manifestPath: string, repository: string): void {
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+  manifest.repository = repository
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest))
+}
+
+function vcsUrl (component: { externalReferences?: Array<{ type: string, url: string }> }): string | undefined {
+  return component.externalReferences?.find((ref) => ref.type === 'vcs')?.url
 }
 
 function spdxPackage (document: { packages: Array<{ name: string, supplier?: string }> }, name: string): { supplier?: string } {

--- a/pnpm11/deps/compliance/sbom/src/getPkgMetadata.ts
+++ b/pnpm11/deps/compliance/sbom/src/getPkgMetadata.ts
@@ -64,7 +64,7 @@ async function extractMetadata (manifest: PackageManifest, files: Map<string, st
     description: manifest.description,
     author: authorNameFromField(manifest.author),
     homepage: manifest.homepage,
-    repository: parseRepositoryField(manifest.repository),
+    repository: repositoryUrlFromField(manifest.repository),
     bugsUrl: bugsUrlFromField(manifest.bugs),
   }
 }
@@ -95,14 +95,42 @@ export function authorNameFromField (field: unknown): string | undefined {
   return name
 }
 
-function parseRepositoryField (field: unknown): string | undefined {
-  if (!field) return undefined
-  if (typeof field === 'string') return field
-  if (typeof field === 'object' && 'url' in field) {
-    return (field as { url: string }).url
+// `repository` may be a URL string, npm's `owner/repo` shorthand, or
+// `{ type, url }`. The CycloneDX vcs reference expects a URL, so normalize the
+// shorthand to its GitHub URL and keep everything else only when it parses as a
+// well-formed http(s) URL — an unparsable value like `owner/repo/extra` would
+// otherwise land in `externalReferences[].url` (whose format is an
+// `iri-reference`) and fail schema validation. Exported so the command's
+// root-package and workspace-package handling uses the same rule.
+export function repositoryUrlFromField (field: unknown): string | undefined {
+  let candidate: string | undefined
+  if (typeof field === 'string') {
+    candidate = field.trim()
+  } else if (field && typeof field === 'object' && 'url' in field) {
+    const value = (field as { url?: unknown }).url
+    if (typeof value === 'string') candidate = value.trim()
   }
-  return undefined
+  if (!candidate) return undefined
+  if (NPM_SHORTHAND_REPOSITORY.test(candidate)) {
+    return `https://github.com/${candidate}`
+  }
+  let parsed: URL
+  try {
+    parsed = new URL(candidate)
+  } catch {
+    return undefined
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return undefined
+  // Same reasoning as `bugsUrlFromField`: an SBOM is a shareable artifact, so
+  // credentials embedded in a repository URL must not travel with it.
+  parsed.username = ''
+  parsed.password = ''
+  return parsed.href
 }
+
+// npm resolves a bare `owner/repo` to GitHub. Anything with a scheme, a host,
+// or extra path segments is not the shorthand and goes through `new URL`.
+const NPM_SHORTHAND_REPOSITORY = /^[\w.-]+\/[\w.-]+$/
 
 // `bugs` may be a URL string, a bare email, or `{ url, email }`. The CycloneDX
 // issue-tracker reference expects a URL, so parse the candidate and keep it only

--- a/pnpm11/deps/compliance/sbom/src/index.ts
+++ b/pnpm11/deps/compliance/sbom/src/index.ts
@@ -1,5 +1,5 @@
 export { collectSbomComponents, type CollectSbomComponentsOptions, gitDownloadUrl, resolveWorkspaceDeps, type WorkspacePackageInfo } from './collectComponents.js'
-export { authorNameFromField, bugsUrlFromField } from './getPkgMetadata.js'
+export { authorNameFromField, bugsUrlFromField, repositoryUrlFromField } from './getPkgMetadata.js'
 export { integrityToHashes } from './integrity.js'
 export { buildPurl, encodePurlName } from './purl.js'
 export { type CycloneDxOptions, serializeCycloneDx } from './serializeCycloneDx.js'

--- a/pnpm11/deps/compliance/sbom/test/getPkgMetadata.test.ts
+++ b/pnpm11/deps/compliance/sbom/test/getPkgMetadata.test.ts
@@ -7,7 +7,7 @@ import type { PackageFilesIndex } from '@pnpm/store.cafs'
 import { gitHostedStoreIndexKey, StoreIndex, storeIndexKey } from '@pnpm/store.index'
 import type { DepPath } from '@pnpm/types'
 
-import { authorNameFromField, bugsUrlFromField, getPkgMetadata } from '../lib/getPkgMetadata.js'
+import { authorNameFromField, bugsUrlFromField, getPkgMetadata, repositoryUrlFromField } from '../lib/getPkgMetadata.js'
 
 const DEFAULT_REGISTRY_OPTS = {
   registriesByScope: {
@@ -166,6 +166,39 @@ describe('bugsUrlFromField', () => {
     expect(bugsUrlFromField('mailto:bugs@example.com')).toBeUndefined()
     expect(bugsUrlFromField({ email: 'bugs@example.com' })).toBeUndefined()
     expect(bugsUrlFromField(undefined)).toBeUndefined()
+  })
+})
+
+describe('repositoryUrlFromField', () => {
+  it('normalizes npm\'s owner/repo shorthand to its GitHub URL', () => {
+    expect(repositoryUrlFromField('vercel/ms')).toBe('https://github.com/vercel/ms')
+    expect(repositoryUrlFromField('  vercel/ms  ')).toBe('https://github.com/vercel/ms')
+    expect(repositoryUrlFromField({ url: 'vercel/ms' })).toBe('https://github.com/vercel/ms')
+  })
+
+  it('keeps well-formed http(s) URLs in both manifest shapes', () => {
+    expect(repositoryUrlFromField('https://github.com/foo/bar.git')).toBe('https://github.com/foo/bar.git')
+    expect(repositoryUrlFromField({ type: 'git', url: 'https://github.com/foo/bar' })).toBe('https://github.com/foo/bar')
+    expect(repositoryUrlFromField('http://example.com/foo/bar')).toBe('http://example.com/foo/bar')
+  })
+
+  it('strips embedded credentials so the SBOM does not leak them', () => {
+    expect(repositoryUrlFromField('https://user:token@github.com/foo/bar')).toBe('https://github.com/foo/bar')
+    expect(repositoryUrlFromField({ url: 'https://u:p@github.com/foo/bar' })).toBe('https://github.com/foo/bar')
+  })
+
+  it('drops values that cannot become a valid iri-reference', () => {
+    expect(repositoryUrlFromField('not a valid repository')).toBeUndefined()
+    // One slash, but a segment that needs escaping: prefixing it would only
+    // produce another invalid URL.
+    expect(repositoryUrlFromField('not valid/repo here')).toBeUndefined()
+    // Extra path segments are not the shorthand.
+    expect(repositoryUrlFromField('owner/repo/extra')).toBeUndefined()
+    expect(repositoryUrlFromField('git@github.com:foo/bar.git')).toBeUndefined()
+    expect(repositoryUrlFromField('git+ssh://git@github.com/foo/bar.git')).toBeUndefined()
+    expect(repositoryUrlFromField('')).toBeUndefined()
+    expect(repositoryUrlFromField(undefined)).toBeUndefined()
+    expect(repositoryUrlFromField({ type: 'git' })).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary

`pnpm sbom` read a manifest's `repository` field verbatim into `externalReferences[].url`. When a package declares it with npm's `owner/repo` shorthand (`ms@2.1.3` ships `"repository": "vercel/ms"`), the generated BOM carried `{ "type": "vcs", "url": "vercel/ms" }`. That is not a valid RFC 3986/3987 IRI-reference, so CycloneDX schema validation fails and Dependency-Track rejects the upload.

Both SBOM implementations in this repo had the bug, and both are fixed the same way: normalize the bare `owner/repo` shorthand to `https://github.com/owner/repo`, keep any other value only when it is a well-formed http(s) URL, and omit the `vcs` reference entirely otherwise. Each stack now applies to `repository` the validate-or-omit rule its own `bugs` extractor already applied.

- Rust v12 CLI: `extract_repository()` in `pnpm/crates/cli/src/cli_args/sbom.rs`, which feeds the root project, workspace packages, and dependency components alike.
- TypeScript v11 CLI: `parseRepositoryField()` in `pnpm11/deps/compliance/sbom/src/getPkgMetadata.ts` covered dependencies, and `extractRepository()` in `pnpm11/deps/compliance/commands/src/sbom/sbom.ts` was a second copy of the same passthrough for the root and workspace components. Both now call one exported `repositoryUrlFromField()`, the same consolidation `authorNameFromField()` got in #14708.

A value that has one slash but needs escaping (`not valid/repo here`) is rejected rather than prefixed, since prefixing would only produce another invalid URL. Credentials embedded in a repository URL are stripped, matching the `bugs` extractor, because an SBOM is a shareable artifact.

Closes pnpm/pnpm#14773

## Squash Commit Body

```text
`pnpm sbom` wrote a manifest's repository field into
externalReferences[].url verbatim, so npm's owner/repo shorthand (ms@2.1.3
declares "repository": "vercel/ms") reached the BOM as
{ "type": "vcs", "url": "vercel/ms" }. That is not a valid RFC 3986/3987
IRI-reference, so CycloneDX schema validation fails and Dependency-Track
rejects the document.

Normalize the bare owner/repo shorthand to https://github.com/owner/repo,
keep any other value only when it is a well-formed http(s) URL, and omit
the vcs reference entirely otherwise. This applies to repository the
validate-or-omit rule each stack's own bugs extractor already applied, so
a value that cannot become a URL no longer reaches the BOM.

Fixed in both implementations. In the Rust v12 CLI, extract_repository()
already fed the root project, workspace packages, and dependency
components. In the TypeScript v11 CLI the rule lived in two places,
parseRepositoryField() for dependencies and extractRepository() in the
commands package for the root and workspace components; both now call one
exported repositoryUrlFromField(), the consolidation authorNameFromField()
got in #14708.

A shorthand segment that would need escaping is rejected rather than
prefixed, since prefixing it would produce another invalid URL, and
credentials embedded in a repository URL are stripped as the bugs
extractor already does.

Closes pnpm/pnpm#14773
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

Written by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDwLRvqaRqUwSCHSrBCq3Y

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791636602&installation_model_id=426870&pr_number=14789&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14789&signature=59fdfcb0f89eb9782d61ea0b23425bb49e4b183643ac1317b77dd6c6c898a4f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->