### PR TITLE
docs(deps-restorer): correct where the hoisted resolution comparison applies

### DIFF
--- a/pnpm/crates/cli/tests/suite/hoisted_node_linker.rs
+++ b/pnpm/crates/cli/tests/suite/hoisted_node_linker.rs
@@ -1489,6 +1489,39 @@ fn a_repeat_frozen_install_reimports_a_hoisted_package_whose_resolution_changed(
     drop((root, mock_instance));
 }
 
+/// The resolution comparison is not frozen-path-only: `pnpm add` builds
+/// a fresh lockfile and is handed the current one too, so a package
+/// whose recorded resolution no longer matches is imported again there
+/// as well. Pins the claim, which a stale comment on
+/// `HoistedLinkerInputs::current_lockfile` used to contradict.
+#[test]
+fn adding_a_dependency_reimports_a_hoisted_package_whose_resolution_changed() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, serde_json::json!({ "ms": "1.0.0", "is-positive": "1.0.0" }));
+    write_workspace_yaml(&workspace, "nodeLinker: hoisted\noptimisticRepeatInstall: false\n");
+    pacquet.with_args(["install"]).assert().success();
+
+    let inode = |relative: &str| fs::metadata(workspace.join(relative)).unwrap().ino();
+    let is_positive_before = inode("node_modules/is-positive");
+    let ms_before = inode("node_modules/ms");
+
+    retouch_recorded_integrity(&workspace, "is-positive@1.0.0");
+
+    pacquet_at(&workspace).with_args(["add", "@pnpm.e2e/foo@100.0.0"]).assert().success();
+
+    assert_ne!(
+        is_positive_before,
+        inode("node_modules/is-positive"),
+        "the package whose resolution changed was imported again on the fresh path",
+    );
+    assert_eq!(ms_before, inode("node_modules/ms"), "its unchanged sibling was left in place");
+
+    drop((root, mock_instance));
+}
+
 /// A package reached through a link is not present, even when the link
 /// resolves to a `package.json` carrying the recorded version. The
 /// hoisted linker writes real directories of regular files and

--- a/pnpm/crates/deps-restorer/src/hoisted_dep_graph.rs
+++ b/pnpm/crates/deps-restorer/src/hoisted_dep_graph.rs
@@ -827,9 +827,12 @@ fn package_present_at(modules: &Path, dir: &Path, version: &str) -> bool {
 /// A dep path carries the package's name and version, so the same key
 /// can survive a change of tarball URL, integrity or revision, and the
 /// manifest version on disk still matches. The contents are meant to
-/// change, so the directory has to be imported again. `false` when
-/// there is no previous graph to compare against, which is the
-/// fresh-lockfile path: the recorded location and version stay the only
+/// change, so the directory has to be imported again.
+///
+/// Both install paths reach this: each is handed the current lockfile.
+/// `false` when there is no previous graph to compare against, which is
+/// an install with no current lockfile or one whose `packages:` map is
+/// empty. The recorded location and the manifest version stay the only
 /// evidence there, as they are for pnpm's `skipFetch`.
 fn resolution_changed_at(
     prev_graph: Option<&DependenciesGraph>,

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile/hoisted.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile/hoisted.rs
@@ -49,9 +49,10 @@ pub struct HoistedLinkerInputs<'a> {
     /// `importers:` from. `&built_lockfile` on the fresh path,
     /// the loaded wanted lockfile on the frozen path.
     pub lockfile: &'a Lockfile,
-    /// Previous install's `<virtual_store_dir>/lock.yaml`, used by the
-    /// walker to diff orphans. `None` on the fresh path (no analogue
-    /// yet).
+    /// Previous install's `<virtual_store_dir>/lock.yaml`. The walker
+    /// diffs orphans against it and compares the resolution it records
+    /// for a directory against the wanted one. Both install paths pass
+    /// it; `None` when the file is absent, which is a first install.
     pub current_lockfile: Option<&'a Lockfile>,
     /// `hoistedLocations` from the previous install's `.modules.yaml`,
     /// so the walker can mark packages that are already on disk. `None`


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#14772, which added the hoisted linker's presence check. Two comments in that PR claimed the resolution comparison cannot run on the fresh-lockfile path, "which is handed no current lockfile". That is wrong, and I wrote it: I took it from the doc on `HoistedLinkerInputs::current_lockfile`, which had said `None` on the fresh path (no analogue yet) since before that PR, instead of tracing the value.

`install/run.rs` loads the current lockfile and `install/materialize.rs` threads it into both install paths, so `pnpm add` compares the recorded resolution against the wanted one exactly as a frozen install does. Measured against the merged binary before writing this:

```
PROBE is-positive changed=true ms changed=false
```

The package whose recorded resolution changed was imported again on the fresh path; its unchanged sibling was left in place.

No behavior change, so no changeset. The comments and one new test only.

- `resolution_changed_at` now says it returns `false` when there is no previous graph to compare against, which is an install with no current lockfile or one whose `packages:` map is empty, rather than naming a whole install path.
- `HoistedLinkerInputs::current_lockfile` now says both paths pass it and what the walker uses it for, which is orphan diffing *and* the resolution comparison.
- `adding_a_dependency_reimports_a_hoisted_package_whose_resolution_changed` pins the behavior so the claim cannot drift again. It retouches the integrity recorded in `node_modules/.pnpm/lock.yaml`, runs `pnpm add`, and asserts that package was imported again while an unchanged sibling was not. Watched failing with the comparison removed.

## Squash Commit Body

```text
Two comments claimed the fresh-lockfile path is handed no current
lockfile, so the presence check's resolution comparison could not run
there. It does run there. `install/run.rs` loads the current lockfile and
`materialize.rs` threads it into both install paths, so `pnpm add`
compares the recorded resolution against the wanted one exactly as a
frozen install does.

`resolution_changed_at` returns `false` when there is no previous graph
to compare against, which is an install with no current lockfile or one
whose `packages:` map is empty, not a whole install path.

A test pins the behavior so the claim cannot drift again: it retouches
the integrity recorded in `node_modules/.pnpm/lock.yaml`, runs
`pnpm add`, and asserts that package was imported again while an
unchanged sibling was left alone. It fails without the comparison.

Related to pnpm/pnpm#14772.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added or updated tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cNCc8LjujhGgdN85d1RAq

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791639716&installation_model_id=426870&pr_number=14793&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14793&signature=1c3cf136eacb0cb2a66edcd1ef3cbe598dd135790e91309e4f8fb7ff6bd26da4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage ensuring that adding a dependency re-imports hoisted packages when their resolution has changed.
  * Verified that unchanged sibling packages remain in place during the update.

* **Documentation**
  * Clarified resolution comparison behavior across fresh and existing lockfile installation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->