### PR TITLE
docs(skills): keep the Yarn example off the start of a line

### DIFF
--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -150,11 +150,11 @@ recognises, then the new capability, then the code.
 ## How one entry should read
 
 **Do not ship the raw composed list.** Yarn's release pages are the conventional-commit
-log with the PR appended - "fix(nm): prefer direct dependency binaries by @user in
-#1234". Every entry is accurate and the page tells a user nothing: it is indexed by
-the change's author, not by the reader's problem. pnpm's uncurated output has the same
-shape, one entry per pull request in filename order. That is the thing being fixed
-here.
+log with the author and PR appended: `fix(nm): prefer direct dependency binaries by
+@user in #1234`. Every entry is accurate and the page tells a user nothing: it is
+indexed by the change's author, not by the reader's problem. pnpm's uncurated output
+has the same shape, one entry per pull request in filename order. That is the thing
+being fixed here.
 
 **The first sentence is the title.** esbuild gives every entry a bold heading; uv
 makes each bullet short enough to be one. pnpm's format has no title slot, so the
@@ -165,9 +165,9 @@ issue where, under certain conditions, ..." does not.
 **Default to one sentence.** uv's bullets run 80 to 120 characters and hold exactly
 one idea; Gitea's run 60 to 90. SQLite states a whole behavior change in one clause
 and no adjectives: "Fix the count-of-view optimization so that it does not give an
-incorrect answer for a DISTINCT query." Add a second sentence when the reader needs the old behavior to recognise
-the bug, and a second paragraph only when they must act: a migration, an opt-out, an
-exception to what the first paragraph promised.
+incorrect answer for a DISTINCT query." Add a second sentence when the reader needs
+the old behavior to recognise the bug, and a second paragraph only when they must
+act: a migration, an opt-out, an exception to what the first paragraph promised.
 
 **Show the literal change when output changes.** esbuild pairs almost every entry
 with before and after. Where a change rewrites a manifest range, a lockfile field, or


### PR DESCRIPTION
## Summary

Follow-up to the review of pnpm/pnpm#14802, which merged before this thread was addressed.

The `release-notes` skill quotes a Yarn changelog entry as the example of what not to
ship. The hard wrap left its issue reference opening a line, which markdownlint reads as
an ATX heading missing its space (MD018). Wrapping the whole example in backticks fixes
that and stops the bare mention inside it reading as one.

Two paragraphs whose wrapping had drifted past the width the rest of the file uses are
reflowed at the same time. No guidance changes.

## Squash Commit Body

```text
The hard wrap left the issue reference opening its line, which markdownlint
reads as an ATX heading missing its space (MD018). Wrapping the whole example
in backticks fixes that and stops the bare mention inside it reading as one.

Reflow the two paragraphs whose wrapping drifted while the file was being
edited, so the whole skill stays inside the width the rest of it uses.
```

## Checklist

- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
  Not applicable: this touches only an agent skill file, no published package.
- [x] Updated the documentation if needed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGJYxrAARz5kpZnESxm3xd

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791650718&installation_model_id=426870&pr_number=14805&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14805&signature=0eaaddc9c509373001268955e4f875f0d976314edbdbeae8e9f5f6a6550e9562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified guidance for composing release note entries, including how to reference authors and pull requests.
  - Improved the formatting of examples and reflowed explanatory text for easier reading.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->