### PR TITLE
fix(ci): switch to the release branch before installing

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -56,6 +56,24 @@ jobs:
         # single-use remote URL in the "Commit and push" step.
         persist-credentials: false
 
+    # Base the release on the tip of the target branch, fetched explicitly so the
+    # run is correct even when dispatched from another ref. A force-push to
+    # release-pr/<target> reuses an already-open release PR for the same target
+    # rather than opening a second.
+    #
+    # This runs before the install: the install writes into the tracked
+    # `.cargo/config.toml`, and `git checkout -B` refuses to switch when that
+    # file is modified and the target branch carries different content. It also
+    # means the install below sees the manifests of the branch being released.
+    - name: Prepare release branch
+      env:
+        TARGET: ${{ github.event.inputs.target }}
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git fetch origin "$TARGET"
+        git checkout -B "release-pr/$TARGET" FETCH_HEAD
+
     - name: Initialize Rust before dependency installation
       uses: $/.github/actions/rustup
       with:
@@ -65,19 +83,6 @@ jobs:
       uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
       with:
         runtime: node@26.3.0
-
-    # Base the release on the tip of the target branch, fetched explicitly so the
-    # run is correct even when dispatched from another ref. A force-push to
-    # release-pr/<target> reuses an already-open release PR for the same target
-    # rather than opening a second.
-    - name: Prepare release branch
-      env:
-        TARGET: ${{ github.event.inputs.target }}
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        git fetch origin "$TARGET"
-        git checkout -B "release-pr/$TARGET" FETCH_HEAD
 
     # Refresh the npm registry signing keys embedded in
     # @pnpm/deps.security.signatures from what npm advertises. pnpm verifies


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#14689, which enabled `cargo.enabled` for this repository. That PR merged before this fix was ready, so the problem is on `main`.

`pnpm install` now writes a Cargo source replacement block into the tracked `.cargo/config.toml`. The release PR workflow installed before switching to the branch it releases, so it reached `git checkout -B "release-pr/$TARGET" FETCH_HEAD` with that file modified. Git refuses to switch when a modified tracked file carries different content on the target:

```
error: Your local changes to the following files would be overwritten by checkout: .cargo/config.toml
Please commit your changes or stash them before you switch branches.
Aborting
```

A dispatch targeting `main` survives, because the committed file matches there. One targeting a branch whose `.cargo/config.toml` differs ends before any version bump. The step that discards the block runs much later, immediately before the commit, so it cannot prevent the checkout from failing.

This moves `Prepare release branch` ahead of the Rust initialization and the install. The tree is clean at the checkout, and the block is written afterwards on the branch being released, where the existing discard step still removes it before the commit.

Switching first also means the install sees the manifests of the branch being released rather than those of the dispatch ref, which is what the rest of the job operates on.

Found by Qodo's review on pnpm/pnpm#14689.

## Squash Commit Body

```text
`cargo.enabled` makes `pnpm install` write a Cargo source replacement into
the tracked `.cargo/config.toml`. The release PR workflow installed before
switching to the branch it releases, so it reached `git checkout -B` with
that file modified. Git refuses to switch when a modified tracked file
carries different content on the target, ending the run before any version
bump.

A dispatch targeting `main` survives it, because the file matches there.
One targeting a maintenance branch whose `.cargo/config.toml` differs does
not. The step that discards the block runs much later, before the commit,
so it cannot help.

Switch first, then install. The install now also sees the manifests of the
branch being released rather than those of the dispatch ref.
```

## Checklist

- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version. Not applicable: this is a CI
  workflow fix, in neither CLI.
- [x] Added a changeset if this PR changes any published package. Not
  applicable: no published package changes.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDxJNVEeyUBb4pcepEpGcj

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791659997&installation_model_id=426870&pr_number=14812&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14812&signature=a9e5e5edd025403515854838e18ce0421e4b050bd12dfc9bb9d05d7369d57eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release preparation workflow ordering to ensure the correct branch manifests are used during environment setup.
  * Clarified workflow guidance for handling tracked configuration changes during release preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->