### PR TITLE
style: stop aligning TOML entries and comments

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -2,5 +2,6 @@ include = ["Cargo.toml", "pnpm/crates/*/*.toml", "pnpm/tasks/*/*.toml", "pnpr/cr
 
 [formatting]
 align_entries = false
+align_comments = false
 column_width = 120
 allowed_blank_lines = 1

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,6 +1,6 @@
 include = ["Cargo.toml", "pnpm/crates/*/*.toml", "pnpm/tasks/*/*.toml", "pnpr/crates/*/*.toml"]
 
 [formatting]
-align_entries = true
+align_entries = false
 column_width = 120
 allowed_blank_lines = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,50 +268,50 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(dylint_lib, values("perfec
 pedantic = { level = "warn", priority = -1 }
 nursery = { level = "warn", priority = -1 }
 
-doc_link_with_quotes = "allow"                      # false positive: matches markdown link titles
-unreadable_literal = "allow"                        # false positive: octal file modes
+doc_link_with_quotes = "allow" # false positive: matches markdown link titles
+unreadable_literal = "allow" # false positive: octal file modes
 case_sensitive_file_extension_comparisons = "allow" # extension checks are intentionally case-sensitive
-implicit_hasher = "allow"                           # only matters across a public API
-unnecessary_debug_formatting = "allow"              # keeps the quoted `Path` output
-option_option = "allow"                             # distinguishes missing from null
-cast_possible_truncation = "allow"                  # deliberate numeric narrowing
+implicit_hasher = "allow" # only matters across a public API
+unnecessary_debug_formatting = "allow" # keeps the quoted `Path` output
+option_option = "allow" # distinguishes missing from null
+cast_possible_truncation = "allow" # deliberate numeric narrowing
 cast_sign_loss = "allow"
 cast_possible_wrap = "allow"
 cast_precision_loss = "allow"
-missing_errors_doc = "allow"                        # error enums are self-documenting (#[display] + #[diagnostic(code)]); a # Errors section would just restate them
-missing_panics_doc = "allow"                        # deferred: refactor away / document / #[expect] each panic before enabling
-too_many_lines = "allow"                            # pacquet mirrors pnpm's function decomposition
-struct_excessive_bools = "allow"                    # option structs mirror pnpm's
-fn_params_excessive_bools = "allow"                 # mirrors pnpm's option parameters
-match_same_arms = "allow"                           # arms kept explicit to mirror pnpm's switch cases
+missing_errors_doc = "allow" # error enums are self-documenting (#[display] + #[diagnostic(code)]); a # Errors section would just restate them
+missing_panics_doc = "allow" # deferred: refactor away / document / #[expect] each panic before enabling
+too_many_lines = "allow" # pacquet mirrors pnpm's function decomposition
+struct_excessive_bools = "allow" # option structs mirror pnpm's
+fn_params_excessive_bools = "allow" # mirrors pnpm's option parameters
+match_same_arms = "allow" # arms kept explicit to mirror pnpm's switch cases
 unnecessary_wraps = "allow"
-unused_async = "allow"                              # deferred: audit each async signature (trait/seam-required?) before enabling
-similar_names = "allow"                             # names ported verbatim from pnpm
+unused_async = "allow" # deferred: audit each async signature (trait/seam-required?) before enabling
+similar_names = "allow" # names ported verbatim from pnpm
 items_after_statements = "allow"
 needless_continue = "allow"
-many_single_char_names = "allow"                    # perfectionist's single_letter_* lints already cover this with finer per-position control
+many_single_char_names = "allow" # perfectionist's single_letter_* lints already cover this with finer per-position control
 
 # nursery-group opt-outs (the group is experimental; these lints are either
 # false positives on this code or fight conventions the project keeps on purpose)
-use_self = "allow"                            # spelling out the concrete type name over Self is left to author discretion
-too_long_first_doc_paragraph = "allow"        # doc comments deliberately open with a detailed pnpm-parity summary, not a one-line lede
-missing_const_for_fn = "allow"                # const-ness is a forward semver commitment and this nursery lint is noisy / churns as const-eval grows
-option_if_let_else = "allow"                  # the suggested map_or_else closures read worse than the if-let they replace
-significant_drop_tightening = "allow"         # the flagged guards are held deliberately (atomic check-then-act); early-dropping is FP-prone and behavioral
-redundant_pub_crate = "allow"                 # pub(crate) is kept to document intended visibility even where technically redundant
-derive_partial_eq_without_eq = "allow"        # deriving Eq is a forward semver commitment that all fields stay Eq
-branches_sharing_code = "allow"               # false-positive-prone: clippy itself flags its own suggestion as needing adjustment
-useless_let_if_seq = "allow"                  # rewrites large init blocks into an awkward if-as-expression
-single_option_map = "allow"                   # flags test helpers that exist precisely to dedupe a `.map` over an Option
-iter_with_drain = "allow"                     # false positive: drain(..) reuses the batch Vec's allocation across loop iterations; into_iter() would consume it
+use_self = "allow" # spelling out the concrete type name over Self is left to author discretion
+too_long_first_doc_paragraph = "allow" # doc comments deliberately open with a detailed pnpm-parity summary, not a one-line lede
+missing_const_for_fn = "allow" # const-ness is a forward semver commitment and this nursery lint is noisy / churns as const-eval grows
+option_if_let_else = "allow" # the suggested map_or_else closures read worse than the if-let they replace
+significant_drop_tightening = "allow" # the flagged guards are held deliberately (atomic check-then-act); early-dropping is FP-prone and behavioral
+redundant_pub_crate = "allow" # pub(crate) is kept to document intended visibility even where technically redundant
+derive_partial_eq_without_eq = "allow" # deriving Eq is a forward semver commitment that all fields stay Eq
+branches_sharing_code = "allow" # false-positive-prone: clippy itself flags its own suggestion as needing adjustment
+useless_let_if_seq = "allow" # rewrites large init blocks into an awkward if-as-expression
+single_option_map = "allow" # flags test helpers that exist precisely to dedupe a `.map` over an Option
+iter_with_drain = "allow" # false positive: drain(..) reuses the batch Vec's allocation across loop iterations; into_iter() would consume it
 literal_string_with_formatting_args = "allow" # false positive: `${VAR:-default}` strings are .npmrc / env-replace fixtures, not Rust format args
-collection_is_never_read = "allow"            # false positive: the flagged Vec owns sockets to keep them alive, it is never meant to be read
+collection_is_never_read = "allow" # false positive: the flagged Vec owns sockets to keep them alive, it is never meant to be read
 
 # restriction lints opted into individually — not part of any default group or
 # the nursery group, so these lines are what enable them (kept on purpose).
 clone_on_ref_ptr = "warn"
 if_then_some_else_none = "warn"
-mod_module_files = "warn"           # forbids mod.rs, enforcing the flat module.rs layout (see CODE_STYLE_GUIDE.md)
+mod_module_files = "warn" # forbids mod.rs, enforcing the flat module.rs layout (see CODE_STYLE_GUIDE.md)
 undocumented_unsafe_blocks = "warn"
 unnecessary_safety_comment = "warn"
 todo = "warn"
@@ -335,7 +335,7 @@ lto = "fat"
 codegen-units = 1
 strip = "symbols"
 debug = false
-panic = "abort"   # Let it crash and force ourselves to write safe Rust.
+panic = "abort" # Let it crash and force ourselves to write safe Rust.
 
 # Use the `--profile release-debug` flag to show symbols in release mode.
 # e.g. `cargo build --profile release-debug`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,126 +1,126 @@
 [workspace]
 resolver = "2"
-members  = ["pnpm/crates/*", "pnpm/tasks/*", "pnpr/crates/*"]
+members = ["pnpm/crates/*", "pnpm/tasks/*", "pnpr/crates/*"]
 
 [workspace.package]
-authors     = ["Yagiz Nizipli <yagiz@nizipli.com"]
+authors = ["Yagiz Nizipli <yagiz@nizipli.com"]
 description = "Pacquet"
-edition     = "2024"
-homepage    = "https://github.com/pnpm/pacquet"
-keywords    = ["nodejs", "package", "manager", "pnpm", "npm"]
-license     = "MIT"
-repository  = "https://github.com/pnpm/pacquet"
+edition = "2024"
+homepage = "https://github.com/pnpm/pacquet"
+keywords = ["nodejs", "package", "manager", "pnpm", "npm"]
+license = "MIT"
+repository = "https://github.com/pnpm/pacquet"
 
 [workspace.dependencies]
 # Crates
-pnpm-github-actions                    = { path = "pnpm/crates/github-actions" }
-pnpm-matcher                           = { path = "pnpm/crates/matcher" }
-pnpm-pnpr-client                       = { path = "pnpm/crates/pnpr-client" }
-pnpm-shared-artifact-protocol          = { path = "pnpm/crates/shared-artifact-protocol" }
-pnpm-auth-commands                     = { path = "pnpm/crates/auth-commands" }
-pnpm-cargo-resolver                    = { path = "pnpm/crates/cargo-resolver" }
-pnpm-catalogs-config                   = { path = "pnpm/crates/catalogs-config" }
-pnpm-catalogs-protocol-parser          = { path = "pnpm/crates/catalogs-protocol-parser" }
-pnpm-catalogs-resolver                 = { path = "pnpm/crates/catalogs-resolver" }
-pnpm-catalogs-types                    = { path = "pnpm/crates/catalogs-types" }
-pnpm-cli                               = { path = "pnpm/crates/cli" }
-pnpm-cmd-shim                          = { path = "pnpm/crates/cmd-shim" }
-pnpm-crypto-hash                       = { path = "pnpm/crates/crypto-hash" }
-pnpm-crypto-shasums-file               = { path = "pnpm/crates/crypto-shasums-file" }
-pnpm-engine-pm-yarn-resolver           = { path = "pnpm/crates/engine-pm-yarn-resolver" }
-pnpm-engine-runtime-bun-resolver       = { path = "pnpm/crates/engine-runtime-bun-resolver" }
-pnpm-engine-runtime-deno-resolver      = { path = "pnpm/crates/engine-runtime-deno-resolver" }
-pnpm-engine-runtime-node-resolver      = { path = "pnpm/crates/engine-runtime-node-resolver" }
-pnpm-env-installer                     = { path = "pnpm/crates/env-installer" }
-pnpm-env-replace                       = { path = "pnpm/crates/env-replace" }
-pnpm-fs                                = { path = "pnpm/crates/fs" }
-pnpm-fs-packlist                       = { path = "pnpm/crates/fs-packlist" }
-pnpm-git-utils                         = { path = "pnpm/crates/git-utils" }
-pnpm-registry                          = { path = "pnpm/crates/registry" }
-pnpm-tarball                           = { path = "pnpm/crates/tarball" }
-pnpm-testing-utils                     = { path = "pnpm/crates/testing-utils" }
-pnpm-text-sanitize                     = { path = "pnpm/crates/text-sanitize" }
-pnpm-pack                              = { path = "pnpm/crates/pack" }
-pnpm-publish                           = { path = "pnpm/crates/publish" }
-pnpm-python-resolver                   = { path = "pnpm/crates/python-resolver" }
-pnpm-package-name                      = { path = "pnpm/crates/package-name" }
-pnpm-package-manifest                  = { path = "pnpm/crates/package-manifest" }
-pnpm-package-manager                   = { path = "pnpm/crates/package-manager" }
-pnpm-package-is-installable            = { path = "pnpm/crates/package-is-installable" }
-pnpm-lockfile                          = { path = "pnpm/crates/lockfile" }
-pnpm-lockfile-import                   = { path = "pnpm/crates/lockfile-import" }
-pnpm-lockfile-preferred-versions       = { path = "pnpm/crates/lockfile-preferred-versions" }
-pnpm-lockfile-verification             = { path = "pnpm/crates/lockfile-verification" }
-pnpm-modules-yaml                      = { path = "pnpm/crates/modules-yaml" }
-pnpm-network                           = { path = "pnpm/crates/network" }
-pnpm-napi                              = { path = "pnpm/crates/napi" }
-pnpm-network-web-auth                  = { path = "pnpm/crates/network-web-auth" }
-pnpm-network-web-auth-testing          = { path = "pnpm/crates/network-web-auth-testing" }
-pnpm-config                            = { path = "pnpm/crates/config" }
-pnpm-config-dir                        = { path = "pnpm/crates/config-dir" }
-pnpm-config-parse-overrides            = { path = "pnpm/crates/config-parse-overrides" }
-pnpm-default-reporter                  = { path = "pnpm/crates/default-reporter" }
-pnpm-executor                          = { path = "pnpm/crates/executor" }
-pnpm-exportable-manifest               = { path = "pnpm/crates/exportable-manifest" }
-pnpm-directory-fetcher                 = { path = "pnpm/crates/directory-fetcher" }
-pnpm-git-fetcher                       = { path = "pnpm/crates/git-fetcher" }
-pnpm-global                            = { path = "pnpm/crates/global" }
-pnpm-deps-inspection                   = { path = "pnpm/crates/deps-inspection" }
-pnpm-deps-inspection-peers             = { path = "pnpm/crates/deps-inspection-peers" }
-pnpm-deps-path                         = { path = "pnpm/crates/deps-path" }
-pnpm-deps-restorer                     = { path = "pnpm/crates/deps-restorer" }
-pnpm-detect-libc                       = { path = "pnpm/crates/detect-libc" }
-pnpm-diagnostics                       = { path = "pnpm/crates/diagnostics" }
-pnpm-graph-hasher                      = { path = "pnpm/crates/graph-hasher" }
-pnpm-hooks                             = { path = "pnpm/crates/hooks" }
-pnpm-injected-deps-syncer              = { path = "pnpm/crates/injected-deps-syncer" }
-pnpm-install-coordinator               = { path = "pnpm/crates/install-coordinator" }
-pnpm-store-dir                         = { path = "pnpm/crates/store-dir" }
-pnpm-reporter                          = { path = "pnpm/crates/reporter" }
-pnpm-patching                          = { path = "pnpm/crates/patching" }
-pnpm-real-hoist                        = { path = "pnpm/crates/real-hoist" }
-pnpm-resolving-default-resolver        = { path = "pnpm/crates/resolving-default-resolver" }
-pnpm-resolving-deps-resolver           = { path = "pnpm/crates/resolving-deps-resolver" }
-pnpm-resolving-git-resolver            = { path = "pnpm/crates/resolving-git-resolver" }
-pnpm-resolving-jsr-specifier-parser    = { path = "pnpm/crates/resolving-jsr-specifier-parser" }
-pnpm-resolving-local-resolver          = { path = "pnpm/crates/resolving-local-resolver" }
-pnpm-resolving-npm-resolver            = { path = "pnpm/crates/resolving-npm-resolver" }
+pnpm-github-actions = { path = "pnpm/crates/github-actions" }
+pnpm-matcher = { path = "pnpm/crates/matcher" }
+pnpm-pnpr-client = { path = "pnpm/crates/pnpr-client" }
+pnpm-shared-artifact-protocol = { path = "pnpm/crates/shared-artifact-protocol" }
+pnpm-auth-commands = { path = "pnpm/crates/auth-commands" }
+pnpm-cargo-resolver = { path = "pnpm/crates/cargo-resolver" }
+pnpm-catalogs-config = { path = "pnpm/crates/catalogs-config" }
+pnpm-catalogs-protocol-parser = { path = "pnpm/crates/catalogs-protocol-parser" }
+pnpm-catalogs-resolver = { path = "pnpm/crates/catalogs-resolver" }
+pnpm-catalogs-types = { path = "pnpm/crates/catalogs-types" }
+pnpm-cli = { path = "pnpm/crates/cli" }
+pnpm-cmd-shim = { path = "pnpm/crates/cmd-shim" }
+pnpm-crypto-hash = { path = "pnpm/crates/crypto-hash" }
+pnpm-crypto-shasums-file = { path = "pnpm/crates/crypto-shasums-file" }
+pnpm-engine-pm-yarn-resolver = { path = "pnpm/crates/engine-pm-yarn-resolver" }
+pnpm-engine-runtime-bun-resolver = { path = "pnpm/crates/engine-runtime-bun-resolver" }
+pnpm-engine-runtime-deno-resolver = { path = "pnpm/crates/engine-runtime-deno-resolver" }
+pnpm-engine-runtime-node-resolver = { path = "pnpm/crates/engine-runtime-node-resolver" }
+pnpm-env-installer = { path = "pnpm/crates/env-installer" }
+pnpm-env-replace = { path = "pnpm/crates/env-replace" }
+pnpm-fs = { path = "pnpm/crates/fs" }
+pnpm-fs-packlist = { path = "pnpm/crates/fs-packlist" }
+pnpm-git-utils = { path = "pnpm/crates/git-utils" }
+pnpm-registry = { path = "pnpm/crates/registry" }
+pnpm-tarball = { path = "pnpm/crates/tarball" }
+pnpm-testing-utils = { path = "pnpm/crates/testing-utils" }
+pnpm-text-sanitize = { path = "pnpm/crates/text-sanitize" }
+pnpm-pack = { path = "pnpm/crates/pack" }
+pnpm-publish = { path = "pnpm/crates/publish" }
+pnpm-python-resolver = { path = "pnpm/crates/python-resolver" }
+pnpm-package-name = { path = "pnpm/crates/package-name" }
+pnpm-package-manifest = { path = "pnpm/crates/package-manifest" }
+pnpm-package-manager = { path = "pnpm/crates/package-manager" }
+pnpm-package-is-installable = { path = "pnpm/crates/package-is-installable" }
+pnpm-lockfile = { path = "pnpm/crates/lockfile" }
+pnpm-lockfile-import = { path = "pnpm/crates/lockfile-import" }
+pnpm-lockfile-preferred-versions = { path = "pnpm/crates/lockfile-preferred-versions" }
+pnpm-lockfile-verification = { path = "pnpm/crates/lockfile-verification" }
+pnpm-modules-yaml = { path = "pnpm/crates/modules-yaml" }
+pnpm-network = { path = "pnpm/crates/network" }
+pnpm-napi = { path = "pnpm/crates/napi" }
+pnpm-network-web-auth = { path = "pnpm/crates/network-web-auth" }
+pnpm-network-web-auth-testing = { path = "pnpm/crates/network-web-auth-testing" }
+pnpm-config = { path = "pnpm/crates/config" }
+pnpm-config-dir = { path = "pnpm/crates/config-dir" }
+pnpm-config-parse-overrides = { path = "pnpm/crates/config-parse-overrides" }
+pnpm-default-reporter = { path = "pnpm/crates/default-reporter" }
+pnpm-executor = { path = "pnpm/crates/executor" }
+pnpm-exportable-manifest = { path = "pnpm/crates/exportable-manifest" }
+pnpm-directory-fetcher = { path = "pnpm/crates/directory-fetcher" }
+pnpm-git-fetcher = { path = "pnpm/crates/git-fetcher" }
+pnpm-global = { path = "pnpm/crates/global" }
+pnpm-deps-inspection = { path = "pnpm/crates/deps-inspection" }
+pnpm-deps-inspection-peers = { path = "pnpm/crates/deps-inspection-peers" }
+pnpm-deps-path = { path = "pnpm/crates/deps-path" }
+pnpm-deps-restorer = { path = "pnpm/crates/deps-restorer" }
+pnpm-detect-libc = { path = "pnpm/crates/detect-libc" }
+pnpm-diagnostics = { path = "pnpm/crates/diagnostics" }
+pnpm-graph-hasher = { path = "pnpm/crates/graph-hasher" }
+pnpm-hooks = { path = "pnpm/crates/hooks" }
+pnpm-injected-deps-syncer = { path = "pnpm/crates/injected-deps-syncer" }
+pnpm-install-coordinator = { path = "pnpm/crates/install-coordinator" }
+pnpm-store-dir = { path = "pnpm/crates/store-dir" }
+pnpm-reporter = { path = "pnpm/crates/reporter" }
+pnpm-patching = { path = "pnpm/crates/patching" }
+pnpm-real-hoist = { path = "pnpm/crates/real-hoist" }
+pnpm-resolving-default-resolver = { path = "pnpm/crates/resolving-default-resolver" }
+pnpm-resolving-deps-resolver = { path = "pnpm/crates/resolving-deps-resolver" }
+pnpm-resolving-git-resolver = { path = "pnpm/crates/resolving-git-resolver" }
+pnpm-resolving-jsr-specifier-parser = { path = "pnpm/crates/resolving-jsr-specifier-parser" }
+pnpm-resolving-local-resolver = { path = "pnpm/crates/resolving-local-resolver" }
+pnpm-resolving-npm-resolver = { path = "pnpm/crates/resolving-npm-resolver" }
 pnpm-resolving-parse-wanted-dependency = { path = "pnpm/crates/resolving-parse-wanted-dependency" }
-pnpm-resolving-resolver-base           = { path = "pnpm/crates/resolving-resolver-base" }
-pnpm-resolving-tarball-resolver        = { path = "pnpm/crates/resolving-tarball-resolver" }
-pnpm-semver-include-prerelease         = { path = "pnpm/crates/semver-include-prerelease" }
-pnpm-versioning                        = { path = "pnpm/crates/versioning" }
-pnpm-workspace                         = { path = "pnpm/crates/workspace" }
-pnpm-workspace-manifest-writer         = { path = "pnpm/crates/workspace-manifest-writer" }
-pnpm-workspace-projects-filter         = { path = "pnpm/crates/workspace-projects-filter" }
-pnpm-workspace-projects-graph          = { path = "pnpm/crates/workspace-projects-graph" }
-pnpm-workspace-range-resolver          = { path = "pnpm/crates/workspace-range-resolver" }
-pnpm-workspace-spec                    = { path = "pnpm/crates/workspace-spec" }
-pnpm-workspace-state                   = { path = "pnpm/crates/workspace-state" }
-pnpm-workspace-task-scheduler          = { path = "pnpm/crates/workspace-task-scheduler" }
+pnpm-resolving-resolver-base = { path = "pnpm/crates/resolving-resolver-base" }
+pnpm-resolving-tarball-resolver = { path = "pnpm/crates/resolving-tarball-resolver" }
+pnpm-semver-include-prerelease = { path = "pnpm/crates/semver-include-prerelease" }
+pnpm-versioning = { path = "pnpm/crates/versioning" }
+pnpm-workspace = { path = "pnpm/crates/workspace" }
+pnpm-workspace-manifest-writer = { path = "pnpm/crates/workspace-manifest-writer" }
+pnpm-workspace-projects-filter = { path = "pnpm/crates/workspace-projects-filter" }
+pnpm-workspace-projects-graph = { path = "pnpm/crates/workspace-projects-graph" }
+pnpm-workspace-range-resolver = { path = "pnpm/crates/workspace-range-resolver" }
+pnpm-workspace-spec = { path = "pnpm/crates/workspace-spec" }
+pnpm-workspace-state = { path = "pnpm/crates/workspace-state" }
+pnpm-workspace-task-scheduler = { path = "pnpm/crates/workspace-task-scheduler" }
 
 # Tasks
 pnpm-registry-mock = { path = "pnpm/tasks/registry-mock" }
 
 # Registry (sibling project — pnpm-compatible registry server)
-pnpr                  = { path = "pnpr/crates/pnpr" }
-pnpr-auth             = { path = "pnpr/crates/auth" }
-pnpr-cargo            = { path = "pnpr/crates/cargo" }
-pnpr-config           = { path = "pnpr/crates/config" }
-pnpr-error            = { path = "pnpr/crates/error" }
-pnpr-oci              = { path = "pnpr/crates/oci" }
-pnpr-osv              = { path = "pnpr/crates/osv" }
-pnpr-package-name     = { path = "pnpr/crates/package-name" }
-pnpr-policy           = { path = "pnpr/crates/policy" }
-pnpr-pypi             = { path = "pnpr/crates/pypi" }
-pnpr-registry         = { path = "pnpr/crates/registry" }
-pnpr-storage          = { path = "pnpr/crates/storage" }
-pnpr-route            = { path = "pnpr/crates/route" }
-pnpr-pipeline-runs    = { path = "pnpr/crates/pipeline-runs" }
-pnpr-search           = { path = "pnpr/crates/search" }
+pnpr = { path = "pnpr/crates/pnpr" }
+pnpr-auth = { path = "pnpr/crates/auth" }
+pnpr-cargo = { path = "pnpr/crates/cargo" }
+pnpr-config = { path = "pnpr/crates/config" }
+pnpr-error = { path = "pnpr/crates/error" }
+pnpr-oci = { path = "pnpr/crates/oci" }
+pnpr-osv = { path = "pnpr/crates/osv" }
+pnpr-package-name = { path = "pnpr/crates/package-name" }
+pnpr-policy = { path = "pnpr/crates/policy" }
+pnpr-pypi = { path = "pnpr/crates/pypi" }
+pnpr-registry = { path = "pnpr/crates/registry" }
+pnpr-storage = { path = "pnpr/crates/storage" }
+pnpr-route = { path = "pnpr/crates/route" }
+pnpr-pipeline-runs = { path = "pnpr/crates/pipeline-runs" }
+pnpr-search = { path = "pnpr/crates/search" }
 pnpr-shared-artifacts = { path = "pnpr/crates/shared-artifacts" }
-pnpr-upstream         = { path = "pnpr/crates/upstream" }
-pnpr-fixtures         = { path = "pnpr/crates/pnpr-fixtures" }
+pnpr-upstream = { path = "pnpr/crates/upstream" }
+pnpr-fixtures = { path = "pnpr/crates/pnpr-fixtures" }
 
 # Dependencies
 openidconnect = { version = "4.0.1", default-features = false }
@@ -205,41 +205,41 @@ rustls = { version = "0.23", default-features = false, features = ["std"] }
 serde-saphyr = { version = "0.0.29" }
 sqlx = { version = "0.8.6", default-features = false, features = ["runtime-tokio-rustls"] }
 # 0.11 removes the LowerHex impl on Output; revisit after upstream/consumers catch up
-sha2               = { version = "0.10.9" }
-sigstore-sign      = { version = "0.11.0" }
-smart-default      = { version = "0.7.1" }
-split-first-char   = { version = "2.0.1" }
-ssri               = { version = "9.2.0" }
-strum              = { version = "0.28.0", features = ["derive"] }
-sysinfo            = { version = "0.39.2" }
-tabled             = { version = "0.21", features = ["ansi"] }
-tar                = { version = "0.4.46" }
-text-block-macros  = { version = "0.2.0" }
-tower              = { version = "0.5.3" }
-tower-http         = { version = "0.7.0", features = ["compression-gzip", "cors", "trace"] }
-tracing            = { version = "0.1.44" }
+sha2 = { version = "0.10.9" }
+sigstore-sign = { version = "0.11.0" }
+smart-default = { version = "0.7.1" }
+split-first-char = { version = "2.0.1" }
+ssri = { version = "9.2.0" }
+strum = { version = "0.28.0", features = ["derive"] }
+sysinfo = { version = "0.39.2" }
+tabled = { version = "0.21", features = ["ansi"] }
+tar = { version = "0.4.46" }
+text-block-macros = { version = "0.2.0" }
+tower = { version = "0.5.3" }
+tower-http = { version = "0.7.0", features = ["compression-gzip", "cors", "trace"] }
+tracing = { version = "0.1.44" }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
-tokio              = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs", "io-util", "net", "signal", "sync"] }
-toml               = { version = "1.1.5" }
-url                = { version = "2.5.8" }
-walkdir            = { version = "2.5.0" }
-webpki-root-certs  = { version = "1.0.7" }
-windows-sys        = { version = "0.61", features = ["Win32_Foundation", "Win32_System_JobObjects", "Win32_System_Threading"] }
-yaml_serde         = { version = "0.10.4" }
-yamlpatch          = { version = "1.25.2" }
-yamlpath           = { version = "1.25.2" }
-wax                = { version = "0.7.0" }
-which              = { version = "8.0.2" }
-zip                = { version = "8", default-features = false, features = ["deflate"] }
-zune-inflate       = { version = "0.2.54" }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs", "io-util", "net", "signal", "sync"] }
+toml = { version = "1.1.5" }
+url = { version = "2.5.8" }
+walkdir = { version = "2.5.0" }
+webpki-root-certs = { version = "1.0.7" }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_JobObjects", "Win32_System_Threading"] }
+yaml_serde = { version = "0.10.4" }
+yamlpatch = { version = "1.25.2" }
+yamlpath = { version = "1.25.2" }
+wax = { version = "0.7.0" }
+which = { version = "8.0.2" }
+zip = { version = "8", default-features = false, features = ["deflate"] }
+zune-inflate = { version = "0.2.54" }
 
 # Dev dependencies
-assert_cmd        = { version = "2.2.2" }
-criterion         = { version = "0.8.2", features = ["async_tokio"] }
+assert_cmd = { version = "2.2.2" }
+criterion = { version = "0.8.2", features = ["async_tokio"] }
 pretty_assertions = { version = "1.4.1" }
-project-root      = { version = "0.2.2" }
-tempfile          = { version = "3.27.0" }
-mockito           = { version = "1.7.2" }
+project-root = { version = "0.2.2" }
+tempfile = { version = "3.27.0" }
+mockito = { version = "1.7.2" }
 
 # node-semver 2.2.0 parses a partial version after `<=` as an exact patch
 # bound, so `<=16` becomes `<=16.0.0-0` and rejects every 16.x. The fork
@@ -266,83 +266,83 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(dylint_lib, values("perfec
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }
-nursery  = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
 
-doc_link_with_quotes                      = "allow" # false positive: matches markdown link titles
-unreadable_literal                        = "allow" # false positive: octal file modes
+doc_link_with_quotes = "allow"                      # false positive: matches markdown link titles
+unreadable_literal = "allow"                        # false positive: octal file modes
 case_sensitive_file_extension_comparisons = "allow" # extension checks are intentionally case-sensitive
-implicit_hasher                           = "allow" # only matters across a public API
-unnecessary_debug_formatting              = "allow" # keeps the quoted `Path` output
-option_option                             = "allow" # distinguishes missing from null
-cast_possible_truncation                  = "allow" # deliberate numeric narrowing
-cast_sign_loss                            = "allow"
-cast_possible_wrap                        = "allow"
-cast_precision_loss                       = "allow"
-missing_errors_doc                        = "allow" # error enums are self-documenting (#[display] + #[diagnostic(code)]); a # Errors section would just restate them
-missing_panics_doc                        = "allow" # deferred: refactor away / document / #[expect] each panic before enabling
-too_many_lines                            = "allow" # pacquet mirrors pnpm's function decomposition
-struct_excessive_bools                    = "allow" # option structs mirror pnpm's
-fn_params_excessive_bools                 = "allow" # mirrors pnpm's option parameters
-match_same_arms                           = "allow" # arms kept explicit to mirror pnpm's switch cases
-unnecessary_wraps                         = "allow"
-unused_async                              = "allow" # deferred: audit each async signature (trait/seam-required?) before enabling
-similar_names                             = "allow" # names ported verbatim from pnpm
-items_after_statements                    = "allow"
-needless_continue                         = "allow"
-many_single_char_names                    = "allow" # perfectionist's single_letter_* lints already cover this with finer per-position control
+implicit_hasher = "allow"                           # only matters across a public API
+unnecessary_debug_formatting = "allow"              # keeps the quoted `Path` output
+option_option = "allow"                             # distinguishes missing from null
+cast_possible_truncation = "allow"                  # deliberate numeric narrowing
+cast_sign_loss = "allow"
+cast_possible_wrap = "allow"
+cast_precision_loss = "allow"
+missing_errors_doc = "allow"                        # error enums are self-documenting (#[display] + #[diagnostic(code)]); a # Errors section would just restate them
+missing_panics_doc = "allow"                        # deferred: refactor away / document / #[expect] each panic before enabling
+too_many_lines = "allow"                            # pacquet mirrors pnpm's function decomposition
+struct_excessive_bools = "allow"                    # option structs mirror pnpm's
+fn_params_excessive_bools = "allow"                 # mirrors pnpm's option parameters
+match_same_arms = "allow"                           # arms kept explicit to mirror pnpm's switch cases
+unnecessary_wraps = "allow"
+unused_async = "allow"                              # deferred: audit each async signature (trait/seam-required?) before enabling
+similar_names = "allow"                             # names ported verbatim from pnpm
+items_after_statements = "allow"
+needless_continue = "allow"
+many_single_char_names = "allow"                    # perfectionist's single_letter_* lints already cover this with finer per-position control
 
 # nursery-group opt-outs (the group is experimental; these lints are either
 # false positives on this code or fight conventions the project keeps on purpose)
-use_self                            = "allow" # spelling out the concrete type name over Self is left to author discretion
-too_long_first_doc_paragraph        = "allow" # doc comments deliberately open with a detailed pnpm-parity summary, not a one-line lede
-missing_const_for_fn                = "allow" # const-ness is a forward semver commitment and this nursery lint is noisy / churns as const-eval grows
-option_if_let_else                  = "allow" # the suggested map_or_else closures read worse than the if-let they replace
-significant_drop_tightening         = "allow" # the flagged guards are held deliberately (atomic check-then-act); early-dropping is FP-prone and behavioral
-redundant_pub_crate                 = "allow" # pub(crate) is kept to document intended visibility even where technically redundant
-derive_partial_eq_without_eq        = "allow" # deriving Eq is a forward semver commitment that all fields stay Eq
-branches_sharing_code               = "allow" # false-positive-prone: clippy itself flags its own suggestion as needing adjustment
-useless_let_if_seq                  = "allow" # rewrites large init blocks into an awkward if-as-expression
-single_option_map                   = "allow" # flags test helpers that exist precisely to dedupe a `.map` over an Option
-iter_with_drain                     = "allow" # false positive: drain(..) reuses the batch Vec's allocation across loop iterations; into_iter() would consume it
+use_self = "allow"                            # spelling out the concrete type name over Self is left to author discretion
+too_long_first_doc_paragraph = "allow"        # doc comments deliberately open with a detailed pnpm-parity summary, not a one-line lede
+missing_const_for_fn = "allow"                # const-ness is a forward semver commitment and this nursery lint is noisy / churns as const-eval grows
+option_if_let_else = "allow"                  # the suggested map_or_else closures read worse than the if-let they replace
+significant_drop_tightening = "allow"         # the flagged guards are held deliberately (atomic check-then-act); early-dropping is FP-prone and behavioral
+redundant_pub_crate = "allow"                 # pub(crate) is kept to document intended visibility even where technically redundant
+derive_partial_eq_without_eq = "allow"        # deriving Eq is a forward semver commitment that all fields stay Eq
+branches_sharing_code = "allow"               # false-positive-prone: clippy itself flags its own suggestion as needing adjustment
+useless_let_if_seq = "allow"                  # rewrites large init blocks into an awkward if-as-expression
+single_option_map = "allow"                   # flags test helpers that exist precisely to dedupe a `.map` over an Option
+iter_with_drain = "allow"                     # false positive: drain(..) reuses the batch Vec's allocation across loop iterations; into_iter() would consume it
 literal_string_with_formatting_args = "allow" # false positive: `${VAR:-default}` strings are .npmrc / env-replace fixtures, not Rust format args
-collection_is_never_read            = "allow" # false positive: the flagged Vec owns sockets to keep them alive, it is never meant to be read
+collection_is_never_read = "allow"            # false positive: the flagged Vec owns sockets to keep them alive, it is never meant to be read
 
 # restriction lints opted into individually — not part of any default group or
 # the nursery group, so these lines are what enable them (kept on purpose).
-clone_on_ref_ptr           = "warn"
-if_then_some_else_none     = "warn"
-mod_module_files           = "warn" # forbids mod.rs, enforcing the flat module.rs layout (see CODE_STYLE_GUIDE.md)
+clone_on_ref_ptr = "warn"
+if_then_some_else_none = "warn"
+mod_module_files = "warn"           # forbids mod.rs, enforcing the flat module.rs layout (see CODE_STYLE_GUIDE.md)
 undocumented_unsafe_blocks = "warn"
 unnecessary_safety_comment = "warn"
-todo                       = "warn"
-unimplemented              = "warn"
-exit                       = "warn"
-infinite_loop              = "warn"
-mem_forget                 = "warn"
-unused_result_ok           = "warn"
-pathbuf_init_then_push     = "warn"
-string_add                 = "warn"
-verbose_file_reads         = "warn"
+todo = "warn"
+unimplemented = "warn"
+exit = "warn"
+infinite_loop = "warn"
+mem_forget = "warn"
+unused_result_ok = "warn"
+pathbuf_init_then_push = "warn"
+string_add = "warn"
+verbose_file_reads = "warn"
 
 # cargo-group lints opted into individually (the cargo group is otherwise off).
-negative_feature_names  = "warn"
+negative_feature_names = "warn"
 redundant_feature_names = "warn"
-wildcard_dependencies   = "warn"
+wildcard_dependencies = "warn"
 
 [profile.release]
-opt-level     = 3
-lto           = "fat"
+opt-level = 3
+lto = "fat"
 codegen-units = 1
-strip         = "symbols"
-debug         = false
-panic         = "abort"   # Let it crash and force ourselves to write safe Rust.
+strip = "symbols"
+debug = false
+panic = "abort"   # Let it crash and force ourselves to write safe Rust.
 
 # Use the `--profile release-debug` flag to show symbols in release mode.
 # e.g. `cargo build --profile release-debug`
 [profile.release-debug]
 inherits = "release"
-strip    = false
-debug    = true
+strip = false
+debug = true
 
 # Profile for the Node.js NAPI addon (`pacquet-node-api`, a cdylib loaded
 # into a host `node` process). The `release` profile above uses
@@ -352,4 +352,4 @@ debug    = true
 # `panic = "unwind"` instead.
 [profile.napi-release]
 inherits = "release"
-panic    = "unwind"
+panic = "unwind"

--- a/pnpm/crates/auth-commands/Cargo.toml
+++ b/pnpm/crates/auth-commands/Cargo.toml
@@ -1,41 +1,41 @@
 [package]
-name                  = "pnpm-auth-commands"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-auth-commands"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-config                    = { workspace = true }
-pnpm-fs                        = { workspace = true }
-pnpm-network                   = { workspace = true }
-pnpm-network-web-auth          = { workspace = true }
-pnpm-reporter                  = { workspace = true }
+pnpm-config = { workspace = true }
+pnpm-fs = { workspace = true }
+pnpm-network = { workspace = true }
+pnpm-network-web-auth = { workspace = true }
+pnpm-reporter = { workspace = true }
 pnpm-workspace-manifest-writer = { workspace = true }
 
-derive_more  = { workspace = true }
-dialoguer    = { workspace = true, features = ["password"] }
-miette       = { workspace = true }
-reqwest      = { workspace = true }
+derive_more = { workspace = true }
+dialoguer = { workspace = true, features = ["password"] }
+miette = { workspace = true }
+reqwest = { workspace = true }
 serde-saphyr = { workspace = true }
-serde_json   = { workspace = true }
-tokio        = { workspace = true, features = ["rt"] }
-url          = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["rt"] }
+url = { workspace = true }
 
 [dev-dependencies]
 pnpm-network-web-auth-testing = { workspace = true }
 
-mockito            = { workspace = true }
-pipe-trait         = { workspace = true }
-pretty_assertions  = { workspace = true }
-tempfile           = { workspace = true }
-tokio              = { workspace = true }
-tracing            = { workspace = true }
+mockito = { workspace = true }
+pipe-trait = { workspace = true }
+pretty_assertions = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [lints]

--- a/pnpm/crates/cargo-resolver/Cargo.toml
+++ b/pnpm/crates/cargo-resolver/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name                 = "pnpm-cargo-resolver"
-version              = "0.0.1"
-publish              = false
-authors.workspace    = true
-description          = "Cargo-compatible dependency resolution for pnpm"
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
+name = "pnpm-cargo-resolver"
+version = "0.0.1"
+publish = false
+authors.workspace = true
+description = "Cargo-compatible dependency resolution for pnpm"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [dependencies]
-cargo-lock.workspace         = true
+cargo-lock.workspace = true
 cargo-util-schemas.workspace = true
-miette.workspace             = true
-pubgrub.workspace            = true
-semver.workspace             = true
-serde.workspace              = true
-serde_json.workspace         = true
+miette.workspace = true
+pubgrub.workspace = true
+semver.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 [lints]
 workspace = true

--- a/pnpm/crates/catalogs-config/Cargo.toml
+++ b/pnpm/crates/catalogs-config/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-name                  = "pnpm-catalogs-config"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-catalogs-config"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 pnpm-catalogs-types = { workspace = true }
-pnpm-workspace      = { workspace = true }
+pnpm-workspace = { workspace = true }
 
 derive_more = { workspace = true }
-miette      = { workspace = true }
+miette = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/catalogs-protocol-parser/Cargo.toml
+++ b/pnpm/crates/catalogs-protocol-parser/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name                  = "pnpm-catalogs-protocol-parser"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-catalogs-protocol-parser"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 pnpm-catalogs-types = { workspace = true }

--- a/pnpm/crates/catalogs-resolver/Cargo.toml
+++ b/pnpm/crates/catalogs-resolver/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-name                  = "pnpm-catalogs-resolver"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-catalogs-resolver"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 pnpm-catalogs-protocol-parser = { workspace = true }
-pnpm-catalogs-types           = { workspace = true }
+pnpm-catalogs-types = { workspace = true }
 
 derive_more = { workspace = true }
-miette      = { workspace = true }
+miette = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/catalogs-types/Cargo.toml
+++ b/pnpm/crates/catalogs-types/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name                  = "pnpm-catalogs-types"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-catalogs-types"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 

--- a/pnpm/crates/cli/Cargo.toml
+++ b/pnpm/crates/cli/Cargo.toml
@@ -1,132 +1,132 @@
 [package]
-name                  = "pnpm-cli"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-cli"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [[bin]]
 name = "pnpm"
 path = "src/bin/main.rs"
 
 [dependencies]
-pnpm-package-name                      = { workspace = true }
-cargo-util-schemas                     = { workspace = true }
-pnpm-auth-commands                     = { workspace = true }
-pnpm-cargo-resolver                    = { workspace = true }
-pnpm-catalogs-config                   = { workspace = true }
-pnpm-catalogs-protocol-parser          = { workspace = true }
-pnpm-catalogs-resolver                 = { workspace = true }
-pnpm-catalogs-types                    = { workspace = true }
-pnpm-cmd-shim                          = { workspace = true }
-pnpm-crypto-hash                       = { workspace = true }
-pnpm-detect-libc                       = { workspace = true }
-pnpm-engine-pm-yarn-resolver           = { workspace = true }
-pnpm-engine-runtime-node-resolver      = { workspace = true }
-pnpm-pnpr-client                       = { workspace = true }
-pnpm-env-installer                     = { workspace = true }
-pnpm-executor                          = { workspace = true }
-pnpm-fs                                = { workspace = true }
-pnpm-git-fetcher                       = { workspace = true }
-pnpm-github-actions                    = { workspace = true }
-pnpm-global                            = { workspace = true }
-pnpm-graph-hasher                      = { workspace = true }
-pnpm-hooks                             = { workspace = true }
-pnpm-injected-deps-syncer              = { workspace = true }
-pnpm-install-coordinator               = { workspace = true }
-pnpm-lockfile                          = { workspace = true }
-pnpm-lockfile-import                   = { workspace = true }
-pnpm-lockfile-preferred-versions       = { workspace = true }
-pnpm-lockfile-verification             = { workspace = true }
-pnpm-matcher                           = { workspace = true }
-pnpm-modules-yaml                      = { workspace = true }
-pnpm-network                           = { workspace = true }
-pnpm-network-web-auth                  = { workspace = true }
-pnpm-config                            = { workspace = true }
-pnpm-config-parse-overrides            = { workspace = true }
-pnpm-default-reporter                  = { workspace = true }
-pnpm-deps-inspection                   = { workspace = true }
-pnpm-deps-inspection-peers             = { workspace = true }
-pnpm-deps-path                         = { workspace = true }
-pnpm-deps-restorer                     = { workspace = true }
-pnpm-pack                              = { workspace = true }
-pnpm-publish                           = { workspace = true }
-pnpm-python-resolver                   = { workspace = true }
-pnpm-package-manifest                  = { workspace = true }
-pnpm-package-manager                   = { workspace = true }
-pnpm-patching                          = { workspace = true }
-pnpm-package-is-installable            = { workspace = true }
-pnpm-registry                          = { workspace = true }
-pnpm-reporter                          = { workspace = true }
-pnpm-resolving-default-resolver        = { workspace = true }
-pnpm-resolving-git-resolver            = { workspace = true }
-pnpm-resolving-npm-resolver            = { workspace = true }
+pnpm-package-name = { workspace = true }
+cargo-util-schemas = { workspace = true }
+pnpm-auth-commands = { workspace = true }
+pnpm-cargo-resolver = { workspace = true }
+pnpm-catalogs-config = { workspace = true }
+pnpm-catalogs-protocol-parser = { workspace = true }
+pnpm-catalogs-resolver = { workspace = true }
+pnpm-catalogs-types = { workspace = true }
+pnpm-cmd-shim = { workspace = true }
+pnpm-crypto-hash = { workspace = true }
+pnpm-detect-libc = { workspace = true }
+pnpm-engine-pm-yarn-resolver = { workspace = true }
+pnpm-engine-runtime-node-resolver = { workspace = true }
+pnpm-pnpr-client = { workspace = true }
+pnpm-env-installer = { workspace = true }
+pnpm-executor = { workspace = true }
+pnpm-fs = { workspace = true }
+pnpm-git-fetcher = { workspace = true }
+pnpm-github-actions = { workspace = true }
+pnpm-global = { workspace = true }
+pnpm-graph-hasher = { workspace = true }
+pnpm-hooks = { workspace = true }
+pnpm-injected-deps-syncer = { workspace = true }
+pnpm-install-coordinator = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-lockfile-import = { workspace = true }
+pnpm-lockfile-preferred-versions = { workspace = true }
+pnpm-lockfile-verification = { workspace = true }
+pnpm-matcher = { workspace = true }
+pnpm-modules-yaml = { workspace = true }
+pnpm-network = { workspace = true }
+pnpm-network-web-auth = { workspace = true }
+pnpm-config = { workspace = true }
+pnpm-config-parse-overrides = { workspace = true }
+pnpm-default-reporter = { workspace = true }
+pnpm-deps-inspection = { workspace = true }
+pnpm-deps-inspection-peers = { workspace = true }
+pnpm-deps-path = { workspace = true }
+pnpm-deps-restorer = { workspace = true }
+pnpm-pack = { workspace = true }
+pnpm-publish = { workspace = true }
+pnpm-python-resolver = { workspace = true }
+pnpm-package-manifest = { workspace = true }
+pnpm-package-manager = { workspace = true }
+pnpm-patching = { workspace = true }
+pnpm-package-is-installable = { workspace = true }
+pnpm-registry = { workspace = true }
+pnpm-reporter = { workspace = true }
+pnpm-resolving-default-resolver = { workspace = true }
+pnpm-resolving-git-resolver = { workspace = true }
+pnpm-resolving-npm-resolver = { workspace = true }
 pnpm-resolving-parse-wanted-dependency = { workspace = true }
-pnpm-resolving-resolver-base           = { workspace = true }
-pnpm-semver-include-prerelease         = { workspace = true }
-pnpm-store-dir                         = { workspace = true }
-pnpm-tarball                           = { workspace = true }
-pnpm-text-sanitize                     = { workspace = true }
-pnpm-diagnostics                       = { workspace = true }
-pnpm-directory-fetcher                 = { workspace = true }
-pnpm-versioning                        = { workspace = true }
-pnpm-workspace                         = { workspace = true }
-pnpm-workspace-manifest-writer         = { workspace = true }
-pnpm-workspace-projects-graph          = { workspace = true }
-pnpm-workspace-projects-filter         = { workspace = true }
-pnpm-workspace-state                   = { workspace = true }
-pnpm-workspace-task-scheduler          = { workspace = true }
+pnpm-resolving-resolver-base = { workspace = true }
+pnpm-semver-include-prerelease = { workspace = true }
+pnpm-store-dir = { workspace = true }
+pnpm-tarball = { workspace = true }
+pnpm-text-sanitize = { workspace = true }
+pnpm-diagnostics = { workspace = true }
+pnpm-directory-fetcher = { workspace = true }
+pnpm-versioning = { workspace = true }
+pnpm-workspace = { workspace = true }
+pnpm-workspace-manifest-writer = { workspace = true }
+pnpm-workspace-projects-graph = { workspace = true }
+pnpm-workspace-projects-filter = { workspace = true }
+pnpm-workspace-state = { workspace = true }
+pnpm-workspace-task-scheduler = { workspace = true }
 
-cargo-lock           = { workspace = true }
-chrono               = { workspace = true }
-clap                 = { workspace = true }
-console              = { workspace = true }
-derive_more          = { workspace = true }
-dialoguer            = { workspace = true }
-dunce                = { workspace = true }
-flate2               = { workspace = true }
-futures-util         = { workspace = true }
-getrandom            = { workspace = true }
-home                 = { workspace = true }
-indexmap             = { workspace = true }
-is_ci                = { workspace = true }
-node-semver          = { workspace = true }
-miette               = { workspace = true }
+cargo-lock = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true }
+console = { workspace = true }
+derive_more = { workspace = true }
+dialoguer = { workspace = true }
+dunce = { workspace = true }
+flate2 = { workspace = true }
+futures-util = { workspace = true }
+getrandom = { workspace = true }
+home = { workspace = true }
+indexmap = { workspace = true }
+is_ci = { workspace = true }
+node-semver = { workspace = true }
+miette = { workspace = true }
 owo-colors.workspace = true
-p256                 = { workspace = true }
-pathdiff             = { workspace = true }
-pipe-trait           = { workspace = true }
-pep440_rs            = { workspace = true }
-pep508_rs            = { workspace = true }
-pubgrub              = { workspace = true }
-rayon                = { workspace = true }
-rustc-hash           = { workspace = true }
-reflink-copy         = { workspace = true }
-regex                = { workspace = true }
-reqwest              = { workspace = true }
-rmp-serde            = { workspace = true }
-same-file            = { workspace = true }
-serde                = { workspace = true }
-serde_json           = { workspace = true }
-semver               = { workspace = true }
-shell-words          = { workspace = true }
-ssri                 = { workspace = true }
-strum                = { workspace = true }
-tabled               = { workspace = true }
-tar                  = { workspace = true }
-tempfile             = { workspace = true }
-toml                 = { workspace = true }
-tokio                = { workspace = true, features = ["process"] }
-tracing              = { workspace = true }
-url                  = { workspace = true }
-which                = { workspace = true }
-base64               = { workspace = true }
-wax                  = { workspace = true }
+p256 = { workspace = true }
+pathdiff = { workspace = true }
+pipe-trait = { workspace = true }
+pep440_rs = { workspace = true }
+pep508_rs = { workspace = true }
+pubgrub = { workspace = true }
+rayon = { workspace = true }
+rustc-hash = { workspace = true }
+reflink-copy = { workspace = true }
+regex = { workspace = true }
+reqwest = { workspace = true }
+rmp-serde = { workspace = true }
+same-file = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+semver = { workspace = true }
+shell-words = { workspace = true }
+ssri = { workspace = true }
+strum = { workspace = true }
+tabled = { workspace = true }
+tar = { workspace = true }
+tempfile = { workspace = true }
+toml = { workspace = true }
+tokio = { workspace = true, features = ["process"] }
+tracing = { workspace = true }
+url = { workspace = true }
+which = { workspace = true }
+base64 = { workspace = true }
+wax = { workspace = true }
 
 # Windows has no process groups, so a Job Object ties the lifetime of spawned
 # children (lifecycle scripts and their descendants) to pacquet's. See
@@ -143,21 +143,21 @@ libc = { workspace = true }
 
 [dev-dependencies]
 pnpm-network-web-auth-testing = { workspace = true }
-pnpm-testing-utils            = { workspace = true }
-pnpr                          = { workspace = true }
+pnpm-testing-utils = { workspace = true }
+pnpr = { workspace = true }
 
-assert_cmd        = { workspace = true }
-command-extra     = { workspace = true }
-dialoguer         = { workspace = true }
-insta             = { workspace = true }
-mockito           = { workspace = true }
+assert_cmd = { workspace = true }
+command-extra = { workspace = true }
+dialoguer = { workspace = true }
+insta = { workspace = true }
+mockito = { workspace = true }
 pretty_assertions = { workspace = true }
-serde-saphyr      = { workspace = true }
-sha2              = { workspace = true }
-ssri              = { workspace = true }
+serde-saphyr = { workspace = true }
+sha2 = { workspace = true }
+ssri = { workspace = true }
 text-block-macros = { workspace = true }
-walkdir           = { workspace = true }
-zip               = { workspace = true }
+walkdir = { workspace = true }
+zip = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/cmd-shim/Cargo.toml
+++ b/pnpm/crates/cmd-shim/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
-name                 = "pnpm-cmd-shim"
-description          = "Bin field parsing and command-shim generation for pacquet, mirroring pnpm's @pnpm/bins.resolver, @pnpm/bins.linker, and @zkochan/cmd-shim"
-version              = "0.0.1"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
+name = "pnpm-cmd-shim"
+description = "Bin field parsing and command-shim generation for pacquet, mirroring pnpm's @pnpm/bins.resolver, @pnpm/bins.linker, and @zkochan/cmd-shim"
+version = "0.0.1"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [dependencies]
-pnpm-fs               = { workspace = true }
+pnpm-fs = { workspace = true }
 pnpm-package-manifest = { workspace = true }
 
 derive_more = { workspace = true }
-dunce       = { workspace = true }
-miette      = { workspace = true }
+dunce = { workspace = true }
+miette = { workspace = true }
 node-semver = { workspace = true }
-pipe-trait  = { workspace = true }
-rayon       = { workspace = true }
-same-file   = { workspace = true }
-serde_json  = { workspace = true }
-tracing     = { workspace = true }
-walkdir     = { workspace = true }
+pipe-trait = { workspace = true }
+rayon = { workspace = true }
+same-file = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+walkdir = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/pnpm/crates/config-dir/Cargo.toml
+++ b/pnpm/crates/config-dir/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name                  = "pnpm-config-dir"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-config-dir"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 

--- a/pnpm/crates/config-parse-overrides/Cargo.toml
+++ b/pnpm/crates/config-parse-overrides/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-name                  = "pnpm-config-parse-overrides"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-config-parse-overrides"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-derive_more                            = { workspace = true }
-miette                                 = { workspace = true }
-node-semver                            = { workspace = true }
-pnpm-catalogs-resolver                 = { workspace = true }
-pnpm-catalogs-types                    = { workspace = true }
+derive_more = { workspace = true }
+miette = { workspace = true }
+node-semver = { workspace = true }
+pnpm-catalogs-resolver = { workspace = true }
+pnpm-catalogs-types = { workspace = true }
 pnpm-resolving-parse-wanted-dependency = { workspace = true }
 
 [lints]

--- a/pnpm/crates/config/Cargo.toml
+++ b/pnpm/crates/config/Cargo.toml
@@ -1,47 +1,47 @@
 [package]
-name                  = "pnpm-config"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-config"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-matcher                = { workspace = true }
-pnpm-catalogs-types         = { workspace = true }
-pnpm-config-dir             = { workspace = true }
-pnpm-detect-libc            = { workspace = true }
-pnpm-env-replace            = { workspace = true }
-pnpm-fs                     = { workspace = true }
-pnpm-git-utils              = { workspace = true }
-pnpm-lockfile               = { workspace = true }
-pnpm-network                = { workspace = true }
+pnpm-matcher = { workspace = true }
+pnpm-catalogs-types = { workspace = true }
+pnpm-config-dir = { workspace = true }
+pnpm-detect-libc = { workspace = true }
+pnpm-env-replace = { workspace = true }
+pnpm-fs = { workspace = true }
+pnpm-git-utils = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-network = { workspace = true }
 pnpm-package-is-installable = { workspace = true }
-pnpm-package-manifest       = { workspace = true }
-pnpm-patching               = { workspace = true }
-pnpm-store-dir              = { workspace = true }
-pnpm-versioning             = { workspace = true }
-pnpm-workspace-state        = { workspace = true }
+pnpm-package-manifest = { workspace = true }
+pnpm-patching = { workspace = true }
+pnpm-store-dir = { workspace = true }
+pnpm-versioning = { workspace = true }
+pnpm-workspace-state = { workspace = true }
 
-base64        = { workspace = true }
-derive_more   = { workspace = true }
-dunce         = { workspace = true }
-home          = { workspace = true }
-indexmap      = { workspace = true }
-is_ci         = { workspace = true }
-miette        = { workspace = true }
-node-semver   = { workspace = true }
-pipe-trait    = { workspace = true }
-serde         = { workspace = true }
-serde-saphyr  = { workspace = true }
-serde_json    = { workspace = true }
+base64 = { workspace = true }
+derive_more = { workspace = true }
+dunce = { workspace = true }
+home = { workspace = true }
+indexmap = { workspace = true }
+is_ci = { workspace = true }
+miette = { workspace = true }
+node-semver = { workspace = true }
+pipe-trait = { workspace = true }
+serde = { workspace = true }
+serde-saphyr = { workspace = true }
+serde_json = { workspace = true }
 smart-default = { workspace = true }
-tracing       = { workspace = true }
-url           = { workspace = true }
+tracing = { workspace = true }
+url = { workspace = true }
 
 [target.'cfg(all(unix, not(target_os = "cygwin")))'.dependencies]
 libc = { workspace = true }
@@ -49,8 +49,8 @@ libc = { workspace = true }
 [dev-dependencies]
 pnpm-testing-utils = { workspace = true }
 
-pretty_assertions  = { workspace = true }
-tempfile           = { workspace = true }
+pretty_assertions = { workspace = true }
+tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [lints]

--- a/pnpm/crates/crypto-hash/Cargo.toml
+++ b/pnpm/crates/crypto-hash/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
-name                 = "pnpm-crypto-hash"
-description          = "Hash helpers shared across pacquet crates"
-version              = "0.0.1"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
+name = "pnpm-crypto-hash"
+description = "Hash helpers shared across pacquet crates"
+version = "0.0.1"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [dependencies]
 base64 = { workspace = true }
-sha2   = { workspace = true }
-ssri   = { workspace = true }
+sha2 = { workspace = true }
+ssri = { workspace = true }
 
 # Match pnpm-store-dir's MSVC-aware feature gate so this crate
 # inherits the `asm` backend on every target where it compiles.

--- a/pnpm/crates/crypto-shasums-file/Cargo.toml
+++ b/pnpm/crates/crypto-shasums-file/Cargo.toml
@@ -1,32 +1,32 @@
 [package]
-name                  = "pnpm-crypto-shasums-file"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-crypto-shasums-file"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 pnpm-network = { workspace = true }
 
-base64      = { workspace = true }
+base64 = { workspace = true }
 derive_more = { workspace = true }
-miette      = { workspace = true }
-pgp         = { workspace = true }
-reqwest     = { workspace = true }
+miette = { workspace = true }
+pgp = { workspace = true }
+reqwest = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 
 [dev-dependencies]
-mockito           = { workspace = true }
+mockito = { workspace = true }
 pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
-tokio             = { workspace = true, features = ["macros", "rt"] }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/default-reporter/Cargo.toml
+++ b/pnpm/crates/default-reporter/Cargo.toml
@@ -1,28 +1,28 @@
 [package]
-name                  = "pnpm-default-reporter"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-default-reporter"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-matcher  = { workspace = true }
-pnpm-config   = { workspace = true }
+pnpm-matcher = { workspace = true }
+pnpm-config = { workspace = true }
 pnpm-reporter = { workspace = true }
 
-chrono      = { workspace = true }
-console     = { workspace = true }
+chrono = { workspace = true }
+console = { workspace = true }
 node-semver = { workspace = true }
-owo-colors  = { workspace = true }
-serde_json  = { workspace = true }
+owo-colors = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
-insta             = { workspace = true }
+insta = { workspace = true }
 pretty_assertions = { workspace = true }
 
 [lints]

--- a/pnpm/crates/deps-inspection-peers/Cargo.toml
+++ b/pnpm/crates/deps-inspection-peers/Cargo.toml
@@ -1,32 +1,32 @@
 [package]
-name                  = "pnpm-deps-inspection-peers"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-deps-inspection-peers"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-matcher                           = { workspace = true }
-pnpm-catalogs-resolver                 = { workspace = true }
-pnpm-catalogs-types                    = { workspace = true }
-pnpm-config                            = { workspace = true }
-pnpm-lockfile                          = { workspace = true }
-pnpm-package-manifest                  = { workspace = true }
+pnpm-matcher = { workspace = true }
+pnpm-catalogs-resolver = { workspace = true }
+pnpm-catalogs-types = { workspace = true }
+pnpm-config = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-package-manifest = { workspace = true }
 pnpm-resolving-parse-wanted-dependency = { workspace = true }
-pnpm-resolving-resolver-base           = { workspace = true }
-pnpm-text-sanitize                     = { workspace = true }
-pnpm-workspace                         = { workspace = true }
+pnpm-resolving-resolver-base = { workspace = true }
+pnpm-text-sanitize = { workspace = true }
+pnpm-workspace = { workspace = true }
 
-dunce       = { workspace = true }
+dunce = { workspace = true }
 node-semver = { workspace = true }
-owo-colors  = { workspace = true }
-serde       = { workspace = true }
-serde_json  = { workspace = true }
+owo-colors = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/pnpm/crates/deps-inspection/Cargo.toml
+++ b/pnpm/crates/deps-inspection/Cargo.toml
@@ -1,41 +1,41 @@
 [package]
-name                  = "pnpm-deps-inspection"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-deps-inspection"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-matcher          = { workspace = true }
-pnpm-config           = { workspace = true }
-pnpm-crypto-hash      = { workspace = true }
-pnpm-deps-restorer    = { workspace = true }
-pnpm-fs               = { workspace = true }
-pnpm-lockfile         = { workspace = true }
-pnpm-modules-yaml     = { workspace = true }
+pnpm-matcher = { workspace = true }
+pnpm-config = { workspace = true }
+pnpm-crypto-hash = { workspace = true }
+pnpm-deps-restorer = { workspace = true }
+pnpm-fs = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-modules-yaml = { workspace = true }
 pnpm-package-manifest = { workspace = true }
-pnpm-store-dir        = { workspace = true }
-pnpm-text-sanitize    = { workspace = true }
-pnpm-workspace        = { workspace = true }
+pnpm-store-dir = { workspace = true }
+pnpm-text-sanitize = { workspace = true }
+pnpm-workspace = { workspace = true }
 
-dunce       = { workspace = true }
-miette      = { workspace = true }
+dunce = { workspace = true }
+miette = { workspace = true }
 node-semver = { workspace = true }
-owo-colors  = { workspace = true }
-pathdiff    = { workspace = true }
-serde       = { workspace = true }
-serde_json  = { workspace = true }
+owo-colors = { workspace = true }
+pathdiff = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 pnpm-testing-utils = { workspace = true }
 
 pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/deps-path/Cargo.toml
+++ b/pnpm/crates/deps-path/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name                  = "pnpm-deps-path"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-deps-path"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-derive_more      = { workspace = true }
-node-semver      = { workspace = true }
+derive_more = { workspace = true }
+node-semver = { workspace = true }
 pnpm-crypto-hash = { workspace = true }
 
 [lints]

--- a/pnpm/crates/deps-restorer/Cargo.toml
+++ b/pnpm/crates/deps-restorer/Cargo.toml
@@ -1,87 +1,87 @@
 [package]
-name                  = "pnpm-deps-restorer"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-deps-restorer"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-package-name             = { workspace = true }
-pnpm-matcher                  = { workspace = true }
-rustc-hash                    = { workspace = true }
-pnpm-cmd-shim                 = { workspace = true }
-pnpm-config                   = { workspace = true }
-pnpm-deps-path                = { workspace = true }
-pnpm-detect-libc              = { workspace = true }
-pnpm-directory-fetcher        = { workspace = true }
-pnpm-executor                 = { workspace = true }
-pnpm-fs                       = { workspace = true }
-pnpm-git-fetcher              = { workspace = true }
-pnpm-graph-hasher             = { workspace = true }
-pnpm-hooks                    = { workspace = true }
-pnpm-lockfile                 = { workspace = true }
-pnpm-lockfile-verification    = { workspace = true }
-pnpm-modules-yaml             = { workspace = true }
-pnpm-network                  = { workspace = true }
-pnpm-package-is-installable   = { workspace = true }
-pnpm-package-manifest         = { workspace = true }
-pnpm-patching                 = { workspace = true }
-pnpm-pnpr-client              = { workspace = true }
+pnpm-package-name = { workspace = true }
+pnpm-matcher = { workspace = true }
+rustc-hash = { workspace = true }
+pnpm-cmd-shim = { workspace = true }
+pnpm-config = { workspace = true }
+pnpm-deps-path = { workspace = true }
+pnpm-detect-libc = { workspace = true }
+pnpm-directory-fetcher = { workspace = true }
+pnpm-executor = { workspace = true }
+pnpm-fs = { workspace = true }
+pnpm-git-fetcher = { workspace = true }
+pnpm-graph-hasher = { workspace = true }
+pnpm-hooks = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-lockfile-verification = { workspace = true }
+pnpm-modules-yaml = { workspace = true }
+pnpm-network = { workspace = true }
+pnpm-package-is-installable = { workspace = true }
+pnpm-package-manifest = { workspace = true }
+pnpm-patching = { workspace = true }
+pnpm-pnpr-client = { workspace = true }
 pnpm-shared-artifact-protocol = { workspace = true }
-pnpm-real-hoist               = { workspace = true }
-pnpm-reporter                 = { workspace = true }
-pnpm-resolving-npm-resolver   = { workspace = true }
-pnpm-resolving-resolver-base  = { workspace = true }
-pnpm-store-dir                = { workspace = true }
-pnpm-tarball                  = { workspace = true }
-pnpm-workspace                = { workspace = true }
+pnpm-real-hoist = { workspace = true }
+pnpm-reporter = { workspace = true }
+pnpm-resolving-npm-resolver = { workspace = true }
+pnpm-resolving-resolver-base = { workspace = true }
+pnpm-store-dir = { workspace = true }
+pnpm-tarball = { workspace = true }
+pnpm-workspace = { workspace = true }
 pnpm-workspace-task-scheduler = { workspace = true }
 
-derive_more  = { workspace = true }
-base64       = { workspace = true }
+derive_more = { workspace = true }
+base64 = { workspace = true }
 futures-util = { workspace = true }
-indexmap     = { workspace = true }
-miette       = { workspace = true }
-node-semver  = { workspace = true }
-pathdiff     = { workspace = true }
-pipe-trait   = { workspace = true }
-rayon        = { workspace = true }
+indexmap = { workspace = true }
+miette = { workspace = true }
+node-semver = { workspace = true }
+pathdiff = { workspace = true }
+pipe-trait = { workspace = true }
+rayon = { workspace = true }
 reflink-copy = { workspace = true }
-serde        = { workspace = true }
-serde_json   = { workspace = true }
-sha2         = { workspace = true }
-ssri         = { workspace = true }
-tempfile     = { workspace = true }
-tokio        = { workspace = true }
-tracing      = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+ssri = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 pnpm-testing-utils = { workspace = true }
 
-async-trait       = { workspace = true }
-dunce             = { workspace = true }
-flate2            = { workspace = true }
-insta             = { workspace = true }
-mockito           = { workspace = true }
-p256              = { workspace = true }
+async-trait = { workspace = true }
+dunce = { workspace = true }
+flate2 = { workspace = true }
+insta = { workspace = true }
+mockito = { workspace = true }
+p256 = { workspace = true }
 pretty_assertions = { workspace = true }
-serde-saphyr      = { workspace = true }
-sha2              = { workspace = true }
-tar               = { workspace = true }
+serde-saphyr = { workspace = true }
+sha2 = { workspace = true }
+tar = { workspace = true }
 text-block-macros = { workspace = true }
-walkdir           = { workspace = true }
+walkdir = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-same-file   = { workspace = true }
-sysinfo     = { workspace = true }
+same-file = { workspace = true }
+sysinfo = { workspace = true }
 windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
 
 [lints]

--- a/pnpm/crates/detect-libc/Cargo.toml
+++ b/pnpm/crates/detect-libc/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name                  = "pnpm-detect-libc"
-version               = "0.0.1"
-license               = "Apache-2.0"
-publish               = false
-authors.workspace     = true
+name = "pnpm-detect-libc"
+version = "0.0.1"
+license = "Apache-2.0"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+repository.workspace = true
 
 [dependencies]
 

--- a/pnpm/crates/diagnostics/Cargo.toml
+++ b/pnpm/crates/diagnostics/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name                  = "pnpm-diagnostics"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-diagnostics"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-miette             = { workspace = true }
-tracing            = { workspace = true }
+miette = { workspace = true }
+tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["json"] }
 
 [lints]

--- a/pnpm/crates/directory-fetcher/Cargo.toml
+++ b/pnpm/crates/directory-fetcher/Cargo.toml
@@ -1,33 +1,33 @@
 [package]
-name                  = "pnpm-directory-fetcher"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-directory-fetcher"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-diagnostics      = { workspace = true }
-pnpm-git-fetcher      = { workspace = true }
+pnpm-diagnostics = { workspace = true }
+pnpm-git-fetcher = { workspace = true }
 pnpm-package-manifest = { workspace = true }
-pnpm-store-dir        = { workspace = true }
+pnpm-store-dir = { workspace = true }
 
 derive_more = { workspace = true }
-miette      = { workspace = true }
-serde_json  = { workspace = true }
-tracing     = { workspace = true }
+miette = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-pnpm-fs            = { workspace = true }
+pnpm-fs = { workspace = true }
 pnpm-testing-utils = { workspace = true }
 
-junction          = { workspace = true }
+junction = { workspace = true }
 pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/engine-pm-yarn-resolver/Cargo.toml
+++ b/pnpm/crates/engine-pm-yarn-resolver/Cargo.toml
@@ -1,33 +1,33 @@
 [package]
-name                  = "pnpm-engine-pm-yarn-resolver"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-engine-pm-yarn-resolver"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-crypto-shasums-file     = { workspace = true }
-pnpm-lockfile                = { workspace = true }
-pnpm-network                 = { workspace = true }
+pnpm-crypto-shasums-file = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-network = { workspace = true }
 pnpm-resolving-resolver-base = { workspace = true }
 
 derive_more = { workspace = true }
-miette      = { workspace = true }
+miette = { workspace = true }
 node-semver = { workspace = true }
-reqwest     = { workspace = true }
-serde       = { workspace = true }
-serde_json  = { workspace = true }
-ssri        = { workspace = true }
-tokio       = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+ssri = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-tokio             = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/engine-runtime-bun-resolver/Cargo.toml
+++ b/pnpm/crates/engine-runtime-bun-resolver/Cargo.toml
@@ -1,33 +1,33 @@
 [package]
-name                  = "pnpm-engine-runtime-bun-resolver"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-engine-runtime-bun-resolver"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-crypto-shasums-file     = { workspace = true }
-pnpm-lockfile                = { workspace = true }
-pnpm-network                 = { workspace = true }
-pnpm-resolving-npm-resolver  = { workspace = true }
+pnpm-crypto-shasums-file = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-network = { workspace = true }
+pnpm-resolving-npm-resolver = { workspace = true }
 pnpm-resolving-resolver-base = { workspace = true }
 
 derive_more = { workspace = true }
-miette      = { workspace = true }
-reqwest     = { workspace = true }
-serde       = { workspace = true }
-serde_json  = { workspace = true }
-ssri        = { workspace = true }
-tokio       = { workspace = true }
+miette = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+ssri = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-tokio             = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/engine-runtime-deno-resolver/Cargo.toml
+++ b/pnpm/crates/engine-runtime-deno-resolver/Cargo.toml
@@ -1,33 +1,33 @@
 [package]
-name                  = "pnpm-engine-runtime-deno-resolver"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-engine-runtime-deno-resolver"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-lockfile                = { workspace = true }
-pnpm-network                 = { workspace = true }
-pnpm-resolving-npm-resolver  = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-network = { workspace = true }
+pnpm-resolving-npm-resolver = { workspace = true }
 pnpm-resolving-resolver-base = { workspace = true }
 
-base64      = { workspace = true }
+base64 = { workspace = true }
 derive_more = { workspace = true }
-miette      = { workspace = true }
-reqwest     = { workspace = true }
-serde       = { workspace = true }
-serde_json  = { workspace = true }
-ssri        = { workspace = true }
-tokio       = { workspace = true }
+miette = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+ssri = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-tokio             = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/engine-runtime-node-resolver/Cargo.toml
+++ b/pnpm/crates/engine-runtime-node-resolver/Cargo.toml
@@ -1,35 +1,35 @@
 [package]
-name                  = "pnpm-engine-runtime-node-resolver"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-engine-runtime-node-resolver"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-crypto-shasums-file     = { workspace = true }
-pnpm-lockfile                = { workspace = true }
-pnpm-network                 = { workspace = true }
+pnpm-crypto-shasums-file = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-network = { workspace = true }
 pnpm-resolving-resolver-base = { workspace = true }
 
 derive_more = { workspace = true }
-miette      = { workspace = true }
+miette = { workspace = true }
 node-semver = { workspace = true }
-reqwest     = { workspace = true }
-serde       = { workspace = true }
-serde_json  = { workspace = true }
-ssri        = { workspace = true }
-tokio       = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+ssri = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
-mockito           = { workspace = true }
+mockito = { workspace = true }
 pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
-tokio             = { workspace = true, features = ["macros", "rt"] }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/env-installer/Cargo.toml
+++ b/pnpm/crates/env-installer/Cargo.toml
@@ -1,47 +1,47 @@
 [package]
-name                  = "pnpm-env-installer"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-env-installer"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-package-name            = { workspace = true }
-pnpm-config                  = { workspace = true }
-pnpm-diagnostics             = { workspace = true }
-pnpm-fs                      = { workspace = true }
-pnpm-graph-hasher            = { workspace = true }
-pnpm-lockfile                = { workspace = true }
-pnpm-network                 = { workspace = true }
-pnpm-package-is-installable  = { workspace = true }
-pnpm-package-manager         = { workspace = true }
-pnpm-reporter                = { workspace = true }
+pnpm-package-name = { workspace = true }
+pnpm-config = { workspace = true }
+pnpm-diagnostics = { workspace = true }
+pnpm-fs = { workspace = true }
+pnpm-graph-hasher = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-network = { workspace = true }
+pnpm-package-is-installable = { workspace = true }
+pnpm-package-manager = { workspace = true }
+pnpm-reporter = { workspace = true }
 pnpm-resolving-resolver-base = { workspace = true }
-pnpm-store-dir               = { workspace = true }
-pnpm-tarball                 = { workspace = true }
-pnpm-workspace-state         = { workspace = true }
+pnpm-store-dir = { workspace = true }
+pnpm-tarball = { workspace = true }
+pnpm-workspace-state = { workspace = true }
 
-derive_more  = { workspace = true }
+derive_more = { workspace = true }
 futures-util = { workspace = true }
-miette       = { workspace = true }
-node-semver  = { workspace = true }
-serde_json   = { workspace = true }
-ssri         = { workspace = true }
-tokio        = { workspace = true, features = ["sync"] }
-tracing      = { workspace = true }
+miette = { workspace = true }
+node-semver = { workspace = true }
+serde_json = { workspace = true }
+ssri = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+tracing = { workspace = true }
 
 [dev-dependencies]
-pnpm-registry               = { workspace = true }
+pnpm-registry = { workspace = true }
 pnpm-resolving-npm-resolver = { workspace = true }
-pnpm-testing-utils          = { workspace = true }
-pretty_assertions           = { workspace = true }
-tempfile                    = { workspace = true }
-tokio                       = { workspace = true, features = ["macros", "rt-multi-thread"] }
+pnpm-testing-utils = { workspace = true }
+pretty_assertions = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/env-replace/Cargo.toml
+++ b/pnpm/crates/env-replace/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name                  = "pnpm-env-replace"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-env-replace"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/pnpm/crates/executor/Cargo.toml
+++ b/pnpm/crates/executor/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
-name                  = "pnpm-executor"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-executor"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 pnpm-package-manifest = { workspace = true }
-pnpm-reporter         = { workspace = true }
+pnpm-reporter = { workspace = true }
 
 deno_task_shell = { workspace = true }
-derive_more     = { workspace = true }
-miette          = { workspace = true }
-serde_json      = { workspace = true }
-tokio           = { workspace = true, features = ["process"] }
-tracing         = { workspace = true }
+derive_more = { workspace = true }
+miette = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["process"] }
+tracing = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
@@ -29,7 +29,7 @@ windows-sys = { workspace = true, features = ["Win32_System_Console", "Win32_Sys
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/exportable-manifest/Cargo.toml
+++ b/pnpm/crates/exportable-manifest/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
-name                  = "pnpm-exportable-manifest"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-exportable-manifest"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-catalogs-resolver              = { workspace = true }
-pnpm-catalogs-types                 = { workspace = true }
-pnpm-package-manifest               = { workspace = true }
+pnpm-catalogs-resolver = { workspace = true }
+pnpm-catalogs-types = { workspace = true }
+pnpm-package-manifest = { workspace = true }
 pnpm-resolving-jsr-specifier-parser = { workspace = true }
-pnpm-workspace-spec                 = { workspace = true }
+pnpm-workspace-spec = { workspace = true }
 
 derive_more = { workspace = true }
-miette      = { workspace = true }
-serde_json  = { workspace = true }
+miette = { workspace = true }
+serde_json = { workspace = true }
 
 # `O_NOFOLLOW` for the symlink-safe README read (see `read_readme_file`).
 [target.'cfg(unix)'.dependencies]

--- a/pnpm/crates/fs-packlist/Cargo.toml
+++ b/pnpm/crates/fs-packlist/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name                  = "pnpm-fs-packlist"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-fs-packlist"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-diagnostics      = { workspace = true }
+pnpm-diagnostics = { workspace = true }
 pnpm-package-manifest = { workspace = true }
 
 derive_more = { workspace = true }
-ignore      = { workspace = true }
-serde_json  = { workspace = true }
-tracing     = { workspace = true }
+ignore = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/pnpm/crates/fs/Cargo.toml
+++ b/pnpm/crates/fs/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name                 = "pnpm-fs"
-description          = "Filesystem utility functions used by pacquet"
-version              = "0.0.1"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
+name = "pnpm-fs"
+description = "Filesystem utility functions used by pacquet"
+version = "0.0.1"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [features]
@@ -15,11 +15,11 @@ test = []
 
 [dependencies]
 derive_more = { workspace = true }
-dunce       = { workspace = true }
-miette      = { workspace = true }
-pathdiff    = { workspace = true }
-tempfile    = { workspace = true }
-tracing     = { workspace = true }
+dunce = { workspace = true }
+miette = { workspace = true }
+pathdiff = { workspace = true }
+tempfile = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 sha2 = { workspace = true }

--- a/pnpm/crates/git-fetcher/Cargo.toml
+++ b/pnpm/crates/git-fetcher/Cargo.toml
@@ -1,35 +1,35 @@
 [package]
-name                  = "pnpm-git-fetcher"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-git-fetcher"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-cmd-shim         = { workspace = true }
-pnpm-diagnostics      = { workspace = true }
-pnpm-executor         = { workspace = true }
-pnpm-fs               = { workspace = true }
-pnpm-fs-packlist      = { workspace = true }
-pnpm-network          = { workspace = true }
+pnpm-cmd-shim = { workspace = true }
+pnpm-diagnostics = { workspace = true }
+pnpm-executor = { workspace = true }
+pnpm-fs = { workspace = true }
+pnpm-fs-packlist = { workspace = true }
+pnpm-network = { workspace = true }
 pnpm-package-manifest = { workspace = true }
-pnpm-reporter         = { workspace = true }
-pnpm-store-dir        = { workspace = true }
+pnpm-reporter = { workspace = true }
+pnpm-store-dir = { workspace = true }
 
 derive_more = { workspace = true }
-miette      = { workspace = true }
+miette = { workspace = true }
 node-semver = { workspace = true }
-pipe-trait  = { workspace = true }
-serde_json  = { workspace = true }
-tempfile    = { workspace = true }
-tokio       = { workspace = true }
-tracing     = { workspace = true }
-which       = { workspace = true }
+pipe-trait = { workspace = true }
+serde_json = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+which = { workspace = true }
 
 [dev-dependencies]
 pnpm-testing-utils = { workspace = true }

--- a/pnpm/crates/git-utils/Cargo.toml
+++ b/pnpm/crates/git-utils/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name                 = "pnpm-git-utils"
-description          = "Read-only git queries shared by the commands that branch on repository state"
-version              = "0.0.1"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
+name = "pnpm-git-utils"
+description = "Read-only git queries shared by the commands that branch on repository state"
+version = "0.0.1"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [dependencies]

--- a/pnpm/crates/github-actions/Cargo.toml
+++ b/pnpm/crates/github-actions/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
-name                 = "pnpm-github-actions"
-version              = "0.0.1"
-publish              = false
-authors.workspace    = true
-description          = "Inspect and update GitHub Actions dependencies in workflow files"
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
+name = "pnpm-github-actions"
+version = "0.0.1"
+publish = false
+authors.workspace = true
+description = "Inspect and update GitHub Actions dependencies in workflow files"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [dependencies]
-pnpm-fs                     = { workspace = true }
-pnpm-matcher                = { workspace = true }
-pnpm-network                = { workspace = true }
-pnpm-reporter               = { workspace = true }
+pnpm-fs = { workspace = true }
+pnpm-matcher = { workspace = true }
+pnpm-network = { workspace = true }
+pnpm-reporter = { workspace = true }
 pnpm-resolving-git-resolver = { workspace = true }
 
 futures-util = { workspace = true }
-miette       = { workspace = true }
-node-semver  = { workspace = true }
-tokio        = { workspace = true }
-url          = { workspace = true }
-yaml_serde   = { workspace = true }
-yamlpath     = { workspace = true }
+miette = { workspace = true }
+node-semver = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }
+yaml_serde = { workspace = true }
+yamlpath = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/pnpm/crates/global/Cargo.toml
+++ b/pnpm/crates/global/Cargo.toml
@@ -1,27 +1,27 @@
 [package]
-name                 = "pnpm-global"
-description          = "Global package install support (ports @pnpm/global.packages and @pnpm/global.commands)"
-version              = "0.0.1"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
+name = "pnpm-global"
+description = "Global package install support (ports @pnpm/global.packages and @pnpm/global.commands)"
+version = "0.0.1"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [dependencies]
-pnpm-package-name     = { workspace = true }
-pnpm-matcher          = { workspace = true }
-pnpm-cmd-shim         = { workspace = true }
-pnpm-crypto-hash      = { workspace = true }
-pnpm-fs               = { workspace = true }
+pnpm-package-name = { workspace = true }
+pnpm-matcher = { workspace = true }
+pnpm-cmd-shim = { workspace = true }
+pnpm-crypto-hash = { workspace = true }
+pnpm-fs = { workspace = true }
 pnpm-package-manifest = { workspace = true }
 
 derive_more = { workspace = true }
-miette      = { workspace = true }
-owo-colors  = { workspace = true }
-serde_json  = { workspace = true }
+miette = { workspace = true }
+owo-colors = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/pnpm/crates/graph-hasher/Cargo.toml
+++ b/pnpm/crates/graph-hasher/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-name                  = "pnpm-graph-hasher"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-graph-hasher"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-base64           = { workspace = true }
-indexmap         = { workspace = true }
+base64 = { workspace = true }
+indexmap = { workspace = true }
 pnpm-detect-libc = { workspace = true }
-serde_json       = { workspace = true }
-sha2             = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/pnpm/crates/hooks/Cargo.toml
+++ b/pnpm/crates/hooks/Cargo.toml
@@ -1,28 +1,28 @@
 [package]
-name                  = "pnpm-hooks"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-hooks"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-crypto-hash             = { workspace = true }
-serde                        = { workspace = true }
-serde_json                   = { workspace = true }
-async-trait                  = { workspace = true }
-tokio                        = { workspace = true, features = ["rt", "process", "time", "io-util", "sync"] }
-derive_more                  = { workspace = true }
+pnpm-crypto-hash = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true, features = ["rt", "process", "time", "io-util", "sync"] }
+derive_more = { workspace = true }
 pnpm-resolving-resolver-base = { workspace = true }
-pnpm-lockfile                = { workspace = true }
+pnpm-lockfile = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-tokio    = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/injected-deps-syncer/Cargo.toml
+++ b/pnpm/crates/injected-deps-syncer/Cargo.toml
@@ -1,27 +1,27 @@
 [package]
-name                  = "pnpm-injected-deps-syncer"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-injected-deps-syncer"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-cmd-shim          = { workspace = true }
+pnpm-cmd-shim = { workspace = true }
 pnpm-directory-fetcher = { workspace = true }
-pnpm-fs                = { workspace = true }
-pnpm-modules-yaml      = { workspace = true }
-pnpm-package-manifest  = { workspace = true }
-pnpm-workspace         = { workspace = true }
+pnpm-fs = { workspace = true }
+pnpm-modules-yaml = { workspace = true }
+pnpm-package-manifest = { workspace = true }
+pnpm-workspace = { workspace = true }
 
 derive_more = { workspace = true }
-miette      = { workspace = true }
-serde_json  = { workspace = true }
-tracing     = { workspace = true }
+miette = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
@@ -30,7 +30,7 @@ windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
 pnpm-testing-utils = { workspace = true }
 
 pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/install-coordinator/Cargo.toml
+++ b/pnpm/crates/install-coordinator/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-name                  = "pnpm-install-coordinator"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-install-coordinator"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 pnpm-crypto-hash = { workspace = true }
-pnpm-fs          = { workspace = true }
-futures-util     = { workspace = true }
-miette           = { workspace = true }
-tokio            = { workspace = true }
+pnpm-fs = { workspace = true }
+futures-util = { workspace = true }
+miette = { workspace = true }
+tokio = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
@@ -25,7 +25,7 @@ windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-tokio    = { workspace = true, features = ["time"] }
+tokio = { workspace = true, features = ["time"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/lockfile-import/Cargo.toml
+++ b/pnpm/crates/lockfile-import/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
-name                  = "pnpm-lockfile-import"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-lockfile-import"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 pnpm-resolving-resolver-base = { workspace = true }
 
 derive_more = { workspace = true }
-miette      = { workspace = true }
-serde_json  = { workspace = true }
-yaml_serde  = { workspace = true }
+miette = { workspace = true }
+serde_json = { workspace = true }
+yaml_serde = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/lockfile-preferred-versions/Cargo.toml
+++ b/pnpm/crates/lockfile-preferred-versions/Cargo.toml
@@ -1,27 +1,27 @@
 [package]
-name                  = "pnpm-lockfile-preferred-versions"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-lockfile-preferred-versions"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-lockfile                = { workspace = true }
-pnpm-package-manifest        = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-package-manifest = { workspace = true }
 pnpm-resolving-resolver-base = { workspace = true }
 
 node-semver = { workspace = true }
-rayon       = { workspace = true }
+rayon = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-serde_json        = { workspace = true }
-tempfile          = { workspace = true }
+serde_json = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/lockfile-verification/Cargo.toml
+++ b/pnpm/crates/lockfile-verification/Cargo.toml
@@ -1,38 +1,38 @@
 [package]
-name                  = "pnpm-lockfile-verification"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-lockfile-verification"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-package-name            = { workspace = true }
-pnpm-diagnostics             = { workspace = true }
-pnpm-lockfile                = { workspace = true }
-pnpm-reporter                = { workspace = true }
+pnpm-package-name = { workspace = true }
+pnpm-diagnostics = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-reporter = { workspace = true }
 pnpm-resolving-resolver-base = { workspace = true }
 
-chrono       = { workspace = true }
-derive_more  = { workspace = true }
+chrono = { workspace = true }
+derive_more = { workspace = true }
 futures-util = { workspace = true }
-miette       = { workspace = true }
-serde        = { workspace = true }
-serde_json   = { workspace = true }
-sha2         = { workspace = true }
-tokio        = { workspace = true, features = ["sync"] }
+miette = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
-insta             = { workspace = true }
+insta = { workspace = true }
 pretty_assertions = { workspace = true }
-serde-saphyr      = { workspace = true }
-ssri              = { workspace = true }
-tempfile          = { workspace = true }
-tokio             = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+serde-saphyr = { workspace = true }
+ssri = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/lockfile/Cargo.toml
+++ b/pnpm/crates/lockfile/Cargo.toml
@@ -1,40 +1,40 @@
 [package]
-name                  = "pnpm-lockfile"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-lockfile"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-catalogs-types                    = { workspace = true }
-pnpm-crypto-hash                       = { workspace = true }
-pnpm-deps-path                         = { workspace = true }
-pnpm-diagnostics                       = { workspace = true }
-pnpm-fs                                = { workspace = true }
-pnpm-package-manifest                  = { workspace = true }
+pnpm-catalogs-types = { workspace = true }
+pnpm-crypto-hash = { workspace = true }
+pnpm-deps-path = { workspace = true }
+pnpm-diagnostics = { workspace = true }
+pnpm-fs = { workspace = true }
+pnpm-package-manifest = { workspace = true }
 pnpm-resolving-parse-wanted-dependency = { workspace = true }
 
-derive_more      = { workspace = true }
-indexmap         = { workspace = true }
-miette           = { workspace = true }
-node-semver      = { workspace = true }
-pipe-trait       = { workspace = true }
-rayon            = { workspace = true }
-serde            = { workspace = true }
-serde-saphyr     = { workspace = true }
-serde_json       = { workspace = true }
-ssri             = { workspace = true }
+derive_more = { workspace = true }
+indexmap = { workspace = true }
+miette = { workspace = true }
+node-semver = { workspace = true }
+pipe-trait = { workspace = true }
+rayon = { workspace = true }
+serde = { workspace = true }
+serde-saphyr = { workspace = true }
+serde_json = { workspace = true }
+ssri = { workspace = true }
 split-first-char = { workspace = true }
-url              = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
+tempfile = { workspace = true }
 text-block-macros = { workspace = true }
 
 [lints]

--- a/pnpm/crates/matcher/Cargo.toml
+++ b/pnpm/crates/matcher/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name                 = "pnpm-matcher"
-version              = "0.0.1"
-publish              = false
-authors.workspace    = true
-description          = "Ordered wildcard matching with include and exclude patterns"
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
+name = "pnpm-matcher"
+version = "0.0.1"
+publish = false
+authors.workspace = true
+description = "Ordered wildcard matching with include and exclude patterns"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [lints]

--- a/pnpm/crates/modules-yaml/Cargo.toml
+++ b/pnpm/crates/modules-yaml/Cargo.toml
@@ -1,34 +1,34 @@
 [package]
-name                  = "pnpm-modules-yaml"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-modules-yaml"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 pnpm-diagnostics = { workspace = true }
-pnpm-fs          = { workspace = true }
+pnpm-fs = { workspace = true }
 
-derive_more  = { workspace = true }
-httpdate     = { workspace = true }
-indexmap     = { workspace = true }
-pathdiff     = { workspace = true }
-pipe-trait   = { workspace = true }
-serde        = { workspace = true }
+derive_more = { workspace = true }
+httpdate = { workspace = true }
+indexmap = { workspace = true }
+pathdiff = { workspace = true }
+pipe-trait = { workspace = true }
+serde = { workspace = true }
 serde-saphyr = { workspace = true }
-serde_json   = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 pnpm-testing-utils = { workspace = true }
 
-chrono            = { workspace = true }
+chrono = { workspace = true }
 pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
+tempfile = { workspace = true }
 text-block-macros = { workspace = true }
 
 [lints]

--- a/pnpm/crates/napi/Cargo.toml
+++ b/pnpm/crates/napi/Cargo.toml
@@ -1,69 +1,69 @@
 [package]
-name                  = "pnpm-napi"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-napi"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-pnpm-matcher                           = { workspace = true }
-pnpm-config                            = { workspace = true }
-pnpm-default-reporter                  = { workspace = true }
-pnpm-deps-inspection                   = { workspace = true }
-pnpm-diagnostics                       = { workspace = true }
-pnpm-catalogs-types                    = { workspace = true }
-pnpm-engine-pm-yarn-resolver           = { workspace = true }
-pnpm-engine-runtime-bun-resolver       = { workspace = true }
-pnpm-engine-runtime-deno-resolver      = { workspace = true }
-pnpm-engine-runtime-node-resolver      = { workspace = true }
-pnpm-hooks                             = { workspace = true }
-pnpm-lockfile                          = { workspace = true }
-pnpm-modules-yaml                      = { workspace = true }
-pnpm-network                           = { workspace = true }
-pnpm-pack                              = { workspace = true }
-pnpm-package-manager                   = { workspace = true }
-pnpm-resolving-deps-resolver           = { workspace = true }
-node-semver                            = { workspace = true }
-pnpm-package-manifest                  = { workspace = true }
-pnpm-reporter                          = { workspace = true }
-pnpm-resolving-default-resolver        = { workspace = true }
-pnpm-resolving-git-resolver            = { workspace = true }
-pnpm-resolving-local-resolver          = { workspace = true }
-pnpm-resolving-npm-resolver            = { workspace = true }
+pnpm-matcher = { workspace = true }
+pnpm-config = { workspace = true }
+pnpm-default-reporter = { workspace = true }
+pnpm-deps-inspection = { workspace = true }
+pnpm-diagnostics = { workspace = true }
+pnpm-catalogs-types = { workspace = true }
+pnpm-engine-pm-yarn-resolver = { workspace = true }
+pnpm-engine-runtime-bun-resolver = { workspace = true }
+pnpm-engine-runtime-deno-resolver = { workspace = true }
+pnpm-engine-runtime-node-resolver = { workspace = true }
+pnpm-hooks = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-modules-yaml = { workspace = true }
+pnpm-network = { workspace = true }
+pnpm-pack = { workspace = true }
+pnpm-package-manager = { workspace = true }
+pnpm-resolving-deps-resolver = { workspace = true }
+node-semver = { workspace = true }
+pnpm-package-manifest = { workspace = true }
+pnpm-reporter = { workspace = true }
+pnpm-resolving-default-resolver = { workspace = true }
+pnpm-resolving-git-resolver = { workspace = true }
+pnpm-resolving-local-resolver = { workspace = true }
+pnpm-resolving-npm-resolver = { workspace = true }
 pnpm-resolving-parse-wanted-dependency = { workspace = true }
-pnpm-resolving-resolver-base           = { workspace = true }
-pnpm-resolving-tarball-resolver        = { workspace = true }
-pnpm-store-dir                         = { workspace = true }
-pnpm-tarball                           = { workspace = true }
-pnpm-workspace                         = { workspace = true }
+pnpm-resolving-resolver-base = { workspace = true }
+pnpm-resolving-tarball-resolver = { workspace = true }
+pnpm-store-dir = { workspace = true }
+pnpm-tarball = { workspace = true }
+pnpm-workspace = { workspace = true }
 
 async-trait = { workspace = true }
-dashmap     = { workspace = true }
-indexmap    = { workspace = true }
-libc        = { workspace = true }
-miette      = { workspace = true }
-napi        = { workspace = true }
+dashmap = { workspace = true }
+indexmap = { workspace = true }
+libc = { workspace = true }
+miette = { workspace = true }
+napi = { workspace = true }
 napi-derive = { workspace = true }
-serde       = { workspace = true }
-serde_json  = { workspace = true }
-tokio       = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }
 
 [dev-dependencies]
-mockito            = { workspace = true }
-pretty_assertions  = { workspace = true }
+mockito = { workspace = true }
+pretty_assertions = { workspace = true }
 pnpm-testing-utils = { workspace = true }
-tempfile           = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/network-web-auth-testing/Cargo.toml
+++ b/pnpm/crates/network-web-auth-testing/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name                 = "pnpm-network-web-auth-testing"
-description          = "Shared test fakes for the OTP / web-auth flow (pnpm-network-web-auth)"
-version              = "0.0.1"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
+name = "pnpm-network-web-auth-testing"
+description = "Shared test fakes for the OTP / web-auth flow (pnpm-network-web-auth)"
+version = "0.0.1"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [dependencies]
-pnpm-diagnostics      = { workspace = true }
+pnpm-diagnostics = { workspace = true }
 pnpm-network-web-auth = { workspace = true }
-pnpm-reporter         = { workspace = true }
+pnpm-reporter = { workspace = true }
 
 derive_more = { workspace = true }
-serde_json  = { workspace = true }
-tokio       = { workspace = true, features = ["sync"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/network-web-auth/Cargo.toml
+++ b/pnpm/crates/network-web-auth/Cargo.toml
@@ -1,36 +1,36 @@
 [package]
-name                 = "pnpm-network-web-auth"
-description          = "Web-based authentication flow with QR code display and token polling"
-version              = "0.0.1"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
+name = "pnpm-network-web-auth"
+description = "Web-based authentication flow with QR code display and token polling"
+version = "0.0.1"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [dependencies]
-crossterm        = { workspace = true }
-derive_more      = { workspace = true }
-dialoguer        = { workspace = true }
-open             = { workspace = true }
+crossterm = { workspace = true }
+derive_more = { workspace = true }
+dialoguer = { workspace = true }
+open = { workspace = true }
 pnpm-diagnostics = { workspace = true }
-pnpm-network     = { workspace = true }
-pnpm-reporter    = { workspace = true }
-qrcode           = { workspace = true }
-reqwest          = { workspace = true }
-serde            = { workspace = true }
-serde_json       = { workspace = true }
-tokio            = { workspace = true, features = ["macros", "rt", "sync", "time"] }
-url              = { workspace = true }
+pnpm-network = { workspace = true }
+pnpm-reporter = { workspace = true }
+qrcode = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
+url = { workspace = true }
 
 [dev-dependencies]
-mockito                       = { workspace = true }
+mockito = { workspace = true }
 pnpm-network-web-auth-testing = { workspace = true }
-pipe-trait                    = { workspace = true }
-pretty_assertions             = { workspace = true }
-tokio                         = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
+pipe-trait = { workspace = true }
+pretty_assertions = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/network/Cargo.toml
+++ b/pnpm/crates/network/Cargo.toml
@@ -1,32 +1,32 @@
 [package]
-name                 = "pnpm-network"
-description          = "Network utility functions used by pacquet"
-version              = "0.0.1"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
+name = "pnpm-network"
+description = "Network utility functions used by pacquet"
+version = "0.0.1"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [dependencies]
-bytes             = { workspace = true }
-derive_more       = { workspace = true }
-futures-util      = { workspace = true }
-miette            = { workspace = true }
-pipe-trait        = { workspace = true }
-reqwest           = { workspace = true }
-tokio             = { workspace = true, features = ["time"] }
-tracing           = { workspace = true }
+bytes = { workspace = true }
+derive_more = { workspace = true }
+futures-util = { workspace = true }
+miette = { workspace = true }
+pipe-trait = { workspace = true }
+reqwest = { workspace = true }
+tokio = { workspace = true, features = ["time"] }
+tracing = { workspace = true }
 webpki-root-certs = { workspace = true }
 
 [dev-dependencies]
-mockito            = { workspace = true }
+mockito = { workspace = true }
 pnpm-testing-utils = { workspace = true }
-pretty_assertions  = { workspace = true }
-rustls             = { workspace = true }
-tokio              = { workspace = true, features = ["macros", "rt-multi-thread"] }
+pretty_assertions = { workspace = true }
+rustls = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/pack/Cargo.toml
+++ b/pnpm/crates/pack/Cargo.toml
@@ -1,38 +1,38 @@
 [package]
-name                  = "pnpm-pack"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-pack"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-package-name        = { workspace = true }
-pnpm-catalogs-types      = { workspace = true }
-pnpm-cmd-shim            = { workspace = true }
-pnpm-config              = { workspace = true }
-pnpm-executor            = { workspace = true }
+pnpm-package-name = { workspace = true }
+pnpm-catalogs-types = { workspace = true }
+pnpm-cmd-shim = { workspace = true }
+pnpm-config = { workspace = true }
+pnpm-executor = { workspace = true }
 pnpm-exportable-manifest = { workspace = true }
-pnpm-fs                  = { workspace = true }
-pnpm-fs-packlist         = { workspace = true }
-pnpm-hooks               = { workspace = true }
-pnpm-package-manifest    = { workspace = true }
-pnpm-reporter            = { workspace = true }
+pnpm-fs = { workspace = true }
+pnpm-fs-packlist = { workspace = true }
+pnpm-hooks = { workspace = true }
+pnpm-package-manifest = { workspace = true }
+pnpm-reporter = { workspace = true }
 
 derive_more = { workspace = true }
-flate2      = { workspace = true }
-indexmap    = { workspace = true }
-miette      = { workspace = true }
-pathdiff    = { workspace = true }
-serde       = { workspace = true }
-serde_json  = { workspace = true }
-tar         = { workspace = true }
-tempfile    = { workspace = true }
-tokio       = { workspace = true }
+flate2 = { workspace = true }
+indexmap = { workspace = true }
+miette = { workspace = true }
+pathdiff = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tar = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/pnpm/crates/package-is-installable/Cargo.toml
+++ b/pnpm/crates/package-is-installable/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
-name                  = "pnpm-package-is-installable"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-package-is-installable"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 pnpm-semver-include-prerelease = { workspace = true }
 
 derive_more = { workspace = true }
-miette      = { workspace = true }
+miette = { workspace = true }
 node-semver = { workspace = true }
-serde       = { workspace = true }
+serde = { workspace = true }
 
 [dev-dependencies]
 pnpm-testing-utils = { workspace = true }
-pretty_assertions  = { workspace = true }
+pretty_assertions = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/package-manager/Cargo.toml
+++ b/pnpm/crates/package-manager/Cargo.toml
@@ -1,109 +1,109 @@
 [package]
-name                  = "pnpm-package-manager"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-package-manager"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-package-name                      = { workspace = true }
-pnpm-matcher                           = { workspace = true }
-rustc-hash                             = { workspace = true }
-pnpm-catalogs-config                   = { workspace = true }
-pnpm-catalogs-protocol-parser          = { workspace = true }
-pnpm-catalogs-resolver                 = { workspace = true }
-pnpm-catalogs-types                    = { workspace = true }
-pnpm-cmd-shim                          = { workspace = true }
-pnpm-crypto-hash                       = { workspace = true }
-pnpm-deps-path                         = { workspace = true }
-pnpm-deps-restorer                     = { workspace = true }
-pnpm-workspace-projects-graph          = { workspace = true }
-pnpm-directory-fetcher                 = { workspace = true }
-pnpm-engine-pm-yarn-resolver           = { workspace = true }
-pnpm-engine-runtime-bun-resolver       = { workspace = true }
-pnpm-engine-runtime-deno-resolver      = { workspace = true }
-pnpm-engine-runtime-node-resolver      = { workspace = true }
-pnpm-executor                          = { workspace = true }
-pnpm-fs                                = { workspace = true }
-pnpm-git-fetcher                       = { workspace = true }
-pnpm-lockfile                          = { workspace = true }
-pnpm-lockfile-preferred-versions       = { workspace = true }
-pnpm-lockfile-verification             = { workspace = true }
-pnpm-modules-yaml                      = { workspace = true }
-pnpm-network                           = { workspace = true }
-pnpm-config                            = { workspace = true }
-pnpm-config-parse-overrides            = { workspace = true }
-pnpm-deps-inspection-peers             = { workspace = true }
-pnpm-graph-hasher                      = { workspace = true }
-pnpm-hooks                             = { workspace = true }
-pnpm-package-manifest                  = { workspace = true }
-pnpm-package-is-installable            = { workspace = true }
-pnpm-patching                          = { workspace = true }
-pnpm-real-hoist                        = { workspace = true }
-pnpm-registry                          = { workspace = true }
-pnpm-reporter                          = { workspace = true }
-pnpm-resolving-default-resolver        = { workspace = true }
-pnpm-resolving-deps-resolver           = { workspace = true }
-pnpm-resolving-git-resolver            = { workspace = true }
-pnpm-resolving-jsr-specifier-parser    = { workspace = true }
-pnpm-resolving-local-resolver          = { workspace = true }
-pnpm-resolving-npm-resolver            = { workspace = true }
+pnpm-package-name = { workspace = true }
+pnpm-matcher = { workspace = true }
+rustc-hash = { workspace = true }
+pnpm-catalogs-config = { workspace = true }
+pnpm-catalogs-protocol-parser = { workspace = true }
+pnpm-catalogs-resolver = { workspace = true }
+pnpm-catalogs-types = { workspace = true }
+pnpm-cmd-shim = { workspace = true }
+pnpm-crypto-hash = { workspace = true }
+pnpm-deps-path = { workspace = true }
+pnpm-deps-restorer = { workspace = true }
+pnpm-workspace-projects-graph = { workspace = true }
+pnpm-directory-fetcher = { workspace = true }
+pnpm-engine-pm-yarn-resolver = { workspace = true }
+pnpm-engine-runtime-bun-resolver = { workspace = true }
+pnpm-engine-runtime-deno-resolver = { workspace = true }
+pnpm-engine-runtime-node-resolver = { workspace = true }
+pnpm-executor = { workspace = true }
+pnpm-fs = { workspace = true }
+pnpm-git-fetcher = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-lockfile-preferred-versions = { workspace = true }
+pnpm-lockfile-verification = { workspace = true }
+pnpm-modules-yaml = { workspace = true }
+pnpm-network = { workspace = true }
+pnpm-config = { workspace = true }
+pnpm-config-parse-overrides = { workspace = true }
+pnpm-deps-inspection-peers = { workspace = true }
+pnpm-graph-hasher = { workspace = true }
+pnpm-hooks = { workspace = true }
+pnpm-package-manifest = { workspace = true }
+pnpm-package-is-installable = { workspace = true }
+pnpm-patching = { workspace = true }
+pnpm-real-hoist = { workspace = true }
+pnpm-registry = { workspace = true }
+pnpm-reporter = { workspace = true }
+pnpm-resolving-default-resolver = { workspace = true }
+pnpm-resolving-deps-resolver = { workspace = true }
+pnpm-resolving-git-resolver = { workspace = true }
+pnpm-resolving-jsr-specifier-parser = { workspace = true }
+pnpm-resolving-local-resolver = { workspace = true }
+pnpm-resolving-npm-resolver = { workspace = true }
 pnpm-resolving-parse-wanted-dependency = { workspace = true }
-pnpm-resolving-resolver-base           = { workspace = true }
-pnpm-resolving-tarball-resolver        = { workspace = true }
-pnpm-store-dir                         = { workspace = true }
-pnpm-tarball                           = { workspace = true }
-pnpm-workspace                         = { workspace = true }
-pnpm-workspace-manifest-writer         = { workspace = true }
-pnpm-workspace-range-resolver          = { workspace = true }
-pnpm-workspace-spec                    = { workspace = true }
-pnpm-workspace-state                   = { workspace = true }
-pnpm-workspace-task-scheduler          = { workspace = true }
+pnpm-resolving-resolver-base = { workspace = true }
+pnpm-resolving-tarball-resolver = { workspace = true }
+pnpm-store-dir = { workspace = true }
+pnpm-tarball = { workspace = true }
+pnpm-workspace = { workspace = true }
+pnpm-workspace-manifest-writer = { workspace = true }
+pnpm-workspace-range-resolver = { workspace = true }
+pnpm-workspace-spec = { workspace = true }
+pnpm-workspace-state = { workspace = true }
+pnpm-workspace-task-scheduler = { workspace = true }
 
 async-recursion = { workspace = true }
-chrono          = { workspace = true }
-dashmap         = { workspace = true }
-derive_more     = { workspace = true }
-dialoguer       = { workspace = true }
-dunce           = { workspace = true }
-futures-util    = { workspace = true }
-httpdate        = { workspace = true }
-indexmap        = { workspace = true }
-is_ci           = { workspace = true }
-node-semver     = { workspace = true }
-pathdiff        = { workspace = true }
-pipe-trait      = { workspace = true }
-rayon           = { workspace = true }
-reflink-copy    = { workspace = true }
-serde           = { workspace = true }
-serde_json      = { workspace = true }
-ssri            = { workspace = true }
-tempfile        = { workspace = true }
-tokio           = { workspace = true }
-tracing         = { workspace = true }
-miette          = { workspace = true }
+chrono = { workspace = true }
+dashmap = { workspace = true }
+derive_more = { workspace = true }
+dialoguer = { workspace = true }
+dunce = { workspace = true }
+futures-util = { workspace = true }
+httpdate = { workspace = true }
+indexmap = { workspace = true }
+is_ci = { workspace = true }
+node-semver = { workspace = true }
+pathdiff = { workspace = true }
+pipe-trait = { workspace = true }
+rayon = { workspace = true }
+reflink-copy = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+ssri = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+miette = { workspace = true }
 
 [dev-dependencies]
 pnpm-testing-utils = { workspace = true }
 
-async-trait       = { workspace = true }
-flate2            = { workspace = true }
-insta             = { workspace = true }
-mockito           = { workspace = true }
-node-semver       = { workspace = true }
-pathdiff          = { workspace = true }
+async-trait = { workspace = true }
+flate2 = { workspace = true }
+insta = { workspace = true }
+mockito = { workspace = true }
+node-semver = { workspace = true }
+pathdiff = { workspace = true }
 pretty_assertions = { workspace = true }
-serde-saphyr      = { workspace = true }
-sha2              = { workspace = true }
-ssri              = { workspace = true }
-tar               = { workspace = true }
+serde-saphyr = { workspace = true }
+sha2 = { workspace = true }
+ssri = { workspace = true }
+tar = { workspace = true }
 text-block-macros = { workspace = true }
-walkdir           = { workspace = true }
+walkdir = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/package-manifest/Cargo.toml
+++ b/pnpm/crates/package-manifest/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
-name                  = "pnpm-package-manifest"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-package-manifest"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 derive_more = { workspace = true }
-miette      = { workspace = true }
+miette = { workspace = true }
 node-semver = { workspace = true }
-serde       = { workspace = true }
-serde_json  = { workspace = true }
-strum       = { workspace = true }
-tempfile    = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+strum = { workspace = true }
+tempfile = { workspace = true }
 
 [dev-dependencies]
-pipe-trait        = { workspace = true }
+pipe-trait = { workspace = true }
 pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
-insta             = { workspace = true }
+tempfile = { workspace = true }
+insta = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/package-name/Cargo.toml
+++ b/pnpm/crates/package-name/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name                  = "pnpm-package-name"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-package-name"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 

--- a/pnpm/crates/patching/Cargo.toml
+++ b/pnpm/crates/patching/Cargo.toml
@@ -1,30 +1,30 @@
 [package]
-name                  = "pnpm-patching"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-patching"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-git-fetcher      = { workspace = true }
+pnpm-git-fetcher = { workspace = true }
 pnpm-package-manifest = { workspace = true }
 
 derive_more = { workspace = true }
-diffy       = { workspace = true }
-indexmap    = { workspace = true }
-miette      = { workspace = true }
+diffy = { workspace = true }
+indexmap = { workspace = true }
+miette = { workspace = true }
 node-semver = { workspace = true }
-serde_json  = { workspace = true }
-sha2        = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
+tempfile = { workspace = true }
 text-block-macros = { workspace = true }
 
 [lints]

--- a/pnpm/crates/pnpr-client/Cargo.toml
+++ b/pnpm/crates/pnpr-client/Cargo.toml
@@ -1,44 +1,44 @@
 [package]
-name                 = "pnpm-pnpr-client"
-description          = "Client for pnpr's server-side resolver"
-version              = "0.0.1"
-edition.workspace    = true
-license.workspace    = true
-homepage.workspace   = true
+name = "pnpm-pnpr-client"
+description = "Client for pnpr's server-side resolver"
+version = "0.0.1"
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
 repository.workspace = true
 
 [lib]
 path = "src/lib.rs"
 
 [dependencies]
-pnpm-catalogs-types           = { workspace = true }
-pnpm-config                   = { workspace = true }
-pnpm-graph-hasher             = { workspace = true }
-pnpm-lockfile                 = { workspace = true }
-pnpm-python-resolver          = { workspace = true }
-pnpm-lockfile-verification    = { workspace = true }
-pnpm-network                  = { workspace = true }
+pnpm-catalogs-types = { workspace = true }
+pnpm-config = { workspace = true }
+pnpm-graph-hasher = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-python-resolver = { workspace = true }
+pnpm-lockfile-verification = { workspace = true }
+pnpm-network = { workspace = true }
 pnpm-shared-artifact-protocol = { workspace = true }
-derive_more                   = { workspace = true }
-futures-util                  = { workspace = true }
-indexmap                      = { workspace = true }
-reqwest                       = { workspace = true }
-serde                         = { workspace = true }
-serde_json                    = { workspace = true }
-tokio                         = { workspace = true }
-tracing                       = { workspace = true }
+derive_more = { workspace = true }
+futures-util = { workspace = true }
+indexmap = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 pnpm-testing-utils = { workspace = true }
-base64             = { workspace = true }
-mockito            = { workspace = true }
-p256               = { workspace = true }
-pnpr               = { workspace = true }
-reqwest            = { workspace = true }
-serde_json         = { workspace = true }
-sha2               = { workspace = true }
-tempfile           = { workspace = true }
-tokio              = { workspace = true }
+base64 = { workspace = true }
+mockito = { workspace = true }
+p256 = { workspace = true }
+pnpr = { workspace = true }
+reqwest = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/publish/Cargo.toml
+++ b/pnpm/crates/publish/Cargo.toml
@@ -1,52 +1,52 @@
 [package]
-name                 = "pnpm-publish"
-description          = "Publish a package to an npm registry (the `pnpm publish` command)"
-version              = "0.0.1"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
+name = "pnpm-publish"
+description = "Publish a package to an npm registry (the `pnpm publish` command)"
+version = "0.0.1"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [dependencies]
-pnpm-package-name     = { workspace = true }
-pnpm-diagnostics      = { workspace = true }
-pnpm-executor         = { workspace = true }
-pnpm-git-utils        = { workspace = true }
-pnpm-network          = { workspace = true }
+pnpm-package-name = { workspace = true }
+pnpm-diagnostics = { workspace = true }
+pnpm-executor = { workspace = true }
+pnpm-git-utils = { workspace = true }
+pnpm-network = { workspace = true }
 pnpm-network-web-auth = { workspace = true }
-pnpm-pack             = { workspace = true }
+pnpm-pack = { workspace = true }
 pnpm-package-manifest = { workspace = true }
-pnpm-reporter         = { workspace = true }
+pnpm-reporter = { workspace = true }
 
-base64        = { workspace = true }
-bytes         = { workspace = true }
-derive_more   = { workspace = true }
-dialoguer     = { workspace = true }
-flate2        = { workspace = true }
-miette        = { workspace = true }
-node-semver   = { workspace = true }
-pipe-trait    = { workspace = true }
-reqwest       = { workspace = true }
-serde         = { workspace = true }
-serde_json    = { workspace = true }
-sha2          = { workspace = true }
+base64 = { workspace = true }
+bytes = { workspace = true }
+derive_more = { workspace = true }
+dialoguer = { workspace = true }
+flate2 = { workspace = true }
+miette = { workspace = true }
+node-semver = { workspace = true }
+pipe-trait = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
 sigstore-sign = { workspace = true }
-ssri          = { workspace = true }
-tar           = { workspace = true }
-tokio         = { workspace = true, features = ["time"] }
-tracing       = { workspace = true }
-url           = { workspace = true }
+ssri = { workspace = true }
+tar = { workspace = true }
+tokio = { workspace = true, features = ["time"] }
+tracing = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 pnpm-network-web-auth-testing = { workspace = true }
 
-mockito           = { workspace = true }
+mockito = { workspace = true }
 pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
-tokio             = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/python-resolver/Cargo.toml
+++ b/pnpm/crates/python-resolver/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
-name                 = "pnpm-python-resolver"
-version              = "0.0.1"
-publish              = false
-authors.workspace    = true
-description          = "Python dependency resolution for pnpm"
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
+name = "pnpm-python-resolver"
+version = "0.0.1"
+publish = false
+authors.workspace = true
+description = "Python dependency resolution for pnpm"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [dependencies]
-miette     = { workspace = true }
-pep440_rs  = { workspace = true }
-pep508_rs  = { workspace = true }
-pubgrub    = { workspace = true }
-serde      = { workspace = true }
+miette = { workspace = true }
+pep440_rs = { workspace = true }
+pep508_rs = { workspace = true }
+pubgrub = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
-ssri       = { workspace = true }
-url        = { workspace = true }
+ssri = { workspace = true }
+url = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/real-hoist/Cargo.toml
+++ b/pnpm/crates/real-hoist/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-name                  = "pnpm-real-hoist"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-real-hoist"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 pnpm-lockfile = { workspace = true }
 
 derive_more = { workspace = true }
-indexmap    = { workspace = true }
-miette      = { workspace = true }
+indexmap = { workspace = true }
+miette = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/pnpm/crates/registry/Cargo.toml
+++ b/pnpm/crates/registry/Cargo.toml
@@ -1,35 +1,35 @@
 [package]
-name                  = "pnpm-registry"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-registry"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-diagnostics      = { workspace = true }
-pnpm-network          = { workspace = true }
+pnpm-diagnostics = { workspace = true }
+pnpm-network = { workspace = true }
 pnpm-package-manifest = { workspace = true }
 
 derive_more = { workspace = true }
-reqwest     = { workspace = true }
+reqwest = { workspace = true }
 node-semver = { workspace = true }
-pipe-trait  = { workspace = true }
-serde       = { workspace = true }
-serde_json  = { workspace = true }
-tracing     = { workspace = true }
-ssri        = { workspace = true }
-tokio       = { workspace = true }
-miette      = { workspace = true }
+pipe-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+ssri = { workspace = true }
+tokio = { workspace = true }
+miette = { workspace = true }
 
 [dev-dependencies]
-mockito           = { workspace = true }
+mockito = { workspace = true }
 pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/reporter/Cargo.toml
+++ b/pnpm/crates/reporter/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name                  = "pnpm-reporter"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-reporter"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 gethostname = { workspace = true }
-serde       = { workspace = true }
-serde_json  = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
-insta             = { workspace = true }
-pipe-trait        = { workspace = true }
+insta = { workspace = true }
+pipe-trait = { workspace = true }
 pretty_assertions = { workspace = true }
 
 [lints]

--- a/pnpm/crates/resolving-default-resolver/Cargo.toml
+++ b/pnpm/crates/resolving-default-resolver/Cargo.toml
@@ -1,35 +1,35 @@
 [package]
-name                  = "pnpm-resolving-default-resolver"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-resolving-default-resolver"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-config                       = { workspace = true }
-pnpm-engine-pm-yarn-resolver      = { workspace = true }
-pnpm-engine-runtime-bun-resolver  = { workspace = true }
+pnpm-config = { workspace = true }
+pnpm-engine-pm-yarn-resolver = { workspace = true }
+pnpm-engine-runtime-bun-resolver = { workspace = true }
 pnpm-engine-runtime-deno-resolver = { workspace = true }
 pnpm-engine-runtime-node-resolver = { workspace = true }
-pnpm-network                      = { workspace = true }
-pnpm-resolving-git-resolver       = { workspace = true }
-pnpm-resolving-local-resolver     = { workspace = true }
-pnpm-resolving-npm-resolver       = { workspace = true }
-pnpm-resolving-resolver-base      = { workspace = true }
-pnpm-resolving-tarball-resolver   = { workspace = true }
+pnpm-network = { workspace = true }
+pnpm-resolving-git-resolver = { workspace = true }
+pnpm-resolving-local-resolver = { workspace = true }
+pnpm-resolving-npm-resolver = { workspace = true }
+pnpm-resolving-resolver-base = { workspace = true }
+pnpm-resolving-tarball-resolver = { workspace = true }
 
 derive_more = { workspace = true }
-miette      = { workspace = true }
+miette = { workspace = true }
 
 [dev-dependencies]
 pnpm-lockfile = { workspace = true }
 
-ssri  = { workspace = true }
+ssri = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]

--- a/pnpm/crates/resolving-deps-resolver/Cargo.toml
+++ b/pnpm/crates/resolving-deps-resolver/Cargo.toml
@@ -1,50 +1,50 @@
 [package]
-name                  = "pnpm-resolving-deps-resolver"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-resolving-deps-resolver"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-package-name                      = { workspace = true }
-tracing                                = { workspace = true }
-rustc-hash                             = { workspace = true }
-pnpm-catalogs-resolver                 = { workspace = true }
-pnpm-catalogs-types                    = { workspace = true }
-pnpm-deps-path                         = { workspace = true }
-pnpm-fs                                = { workspace = true }
-pnpm-hooks                             = { workspace = true }
-pnpm-lockfile                          = { workspace = true }
-pnpm-package-manifest                  = { workspace = true }
-pnpm-patching                          = { workspace = true }
+pnpm-package-name = { workspace = true }
+tracing = { workspace = true }
+rustc-hash = { workspace = true }
+pnpm-catalogs-resolver = { workspace = true }
+pnpm-catalogs-types = { workspace = true }
+pnpm-deps-path = { workspace = true }
+pnpm-fs = { workspace = true }
+pnpm-hooks = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-package-manifest = { workspace = true }
+pnpm-patching = { workspace = true }
 pnpm-resolving-parse-wanted-dependency = { workspace = true }
-pnpm-resolving-resolver-base           = { workspace = true }
-pnpm-semver-include-prerelease         = { workspace = true }
+pnpm-resolving-resolver-base = { workspace = true }
+pnpm-semver-include-prerelease = { workspace = true }
 
-async-recursion                     = { workspace = true }
-chrono                              = { workspace = true }
-derive_more                         = { workspace = true }
-futures-util                        = { workspace = true }
-miette                              = { workspace = true }
-node-semver                         = { workspace = true }
+async-recursion = { workspace = true }
+chrono = { workspace = true }
+derive_more = { workspace = true }
+futures-util = { workspace = true }
+miette = { workspace = true }
+node-semver = { workspace = true }
 pnpm-resolving-jsr-specifier-parser = { workspace = true }
-pathdiff                            = { workspace = true }
-pipe-trait                          = { workspace = true }
-serde_json                          = { workspace = true }
-smart-default                       = { workspace = true }
-tokio                               = { workspace = true, features = ["sync"] }
+pathdiff = { workspace = true }
+pipe-trait = { workspace = true }
+serde_json = { workspace = true }
+smart-default = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
-async-trait       = { workspace = true }
-node-semver       = { workspace = true }
+async-trait = { workspace = true }
+node-semver = { workspace = true }
 pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
-tokio             = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/resolving-git-resolver/Cargo.toml
+++ b/pnpm/crates/resolving-git-resolver/Cargo.toml
@@ -1,36 +1,36 @@
 [package]
-name                  = "pnpm-resolving-git-resolver"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-resolving-git-resolver"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-git-fetcher             = { workspace = true }
-pnpm-lockfile                = { workspace = true }
-pnpm-network                 = { workspace = true }
-pnpm-reporter                = { workspace = true }
+pnpm-git-fetcher = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-network = { workspace = true }
+pnpm-reporter = { workspace = true }
 pnpm-resolving-resolver-base = { workspace = true }
-pnpm-store-dir               = { workspace = true }
-pnpm-tarball                 = { workspace = true }
+pnpm-store-dir = { workspace = true }
+pnpm-tarball = { workspace = true }
 
 derive_more = { workspace = true }
-miette      = { workspace = true }
+miette = { workspace = true }
 node-semver = { workspace = true }
-reqwest     = { workspace = true }
-serde_json  = { workspace = true }
-tokio       = { workspace = true }
-tracing     = { workspace = true }
+reqwest = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-mockito           = { workspace = true }
+mockito = { workspace = true }
 pretty_assertions = { workspace = true }
-tokio             = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/resolving-jsr-specifier-parser/Cargo.toml
+++ b/pnpm/crates/resolving-jsr-specifier-parser/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
-name                  = "pnpm-resolving-jsr-specifier-parser"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-resolving-jsr-specifier-parser"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 pnpm-package-name = { workspace = true }
 
 derive_more = { workspace = true }
-miette      = { workspace = true }
+miette = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/resolving-local-resolver/Cargo.toml
+++ b/pnpm/crates/resolving-local-resolver/Cargo.toml
@@ -1,36 +1,36 @@
 [package]
-name                  = "pnpm-resolving-local-resolver"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-resolving-local-resolver"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-package-name            = { workspace = true }
-pnpm-lockfile                = { workspace = true }
-pnpm-package-manifest        = { workspace = true }
+pnpm-package-name = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-package-manifest = { workspace = true }
 pnpm-resolving-resolver-base = { workspace = true }
-pnpm-tarball                 = { workspace = true }
+pnpm-tarball = { workspace = true }
 
 derive_more = { workspace = true }
-home        = { workspace = true }
-miette      = { workspace = true }
-pathdiff    = { workspace = true }
-serde_json  = { workspace = true }
-tracing     = { workspace = true }
+home = { workspace = true }
+miette = { workspace = true }
+pathdiff = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 pnpm-resolving-default-resolver = { workspace = true }
-pnpm-testing-utils              = { workspace = true }
+pnpm-testing-utils = { workspace = true }
 
 pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
-tokio             = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/resolving-npm-resolver/Cargo.toml
+++ b/pnpm/crates/resolving-npm-resolver/Cargo.toml
@@ -1,54 +1,54 @@
 [package]
-name                  = "pnpm-resolving-npm-resolver"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-resolving-npm-resolver"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-package-name                   = { workspace = true }
-pnpm-config                         = { workspace = true }
-pnpm-deps-path                      = { workspace = true }
-pnpm-lockfile                       = { workspace = true }
-pnpm-network                        = { workspace = true }
-pnpm-registry                       = { workspace = true }
+pnpm-package-name = { workspace = true }
+pnpm-config = { workspace = true }
+pnpm-deps-path = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-network = { workspace = true }
+pnpm-registry = { workspace = true }
 pnpm-resolving-jsr-specifier-parser = { workspace = true }
-pnpm-resolving-resolver-base        = { workspace = true }
-pnpm-workspace-range-resolver       = { workspace = true }
-pnpm-workspace-spec                 = { workspace = true }
+pnpm-resolving-resolver-base = { workspace = true }
+pnpm-workspace-range-resolver = { workspace = true }
+pnpm-workspace-spec = { workspace = true }
 
-chrono           = { workspace = true }
-dashmap          = { workspace = true }
-derive_more      = { workspace = true }
-httpdate         = { workspace = true }
-indexmap         = { workspace = true }
-libc             = { workspace = true }
-miette           = { workspace = true }
-node-semver      = { workspace = true }
+chrono = { workspace = true }
+dashmap = { workspace = true }
+derive_more = { workspace = true }
+httpdate = { workspace = true }
+indexmap = { workspace = true }
+libc = { workspace = true }
+miette = { workspace = true }
+node-semver = { workspace = true }
 percent-encoding = { workspace = true }
-pipe-trait       = { workspace = true }
-reqwest          = { workspace = true }
-serde            = { workspace = true }
-serde_json       = { workspace = true }
-sha2             = { workspace = true }
-ssri             = { workspace = true }
-tokio            = { workspace = true }
-tracing          = { workspace = true }
+pipe-trait = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+ssri = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 pnpm-resolving-default-resolver = { workspace = true }
-pnpm-resolving-local-resolver   = { workspace = true }
+pnpm-resolving-local-resolver = { workspace = true }
 
-futures-util      = { workspace = true }
-mockito           = { workspace = true }
+futures-util = { workspace = true }
+mockito = { workspace = true }
 pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
-tokio             = { workspace = true, features = ["macros", "rt"] }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/resolving-parse-wanted-dependency/Cargo.toml
+++ b/pnpm/crates/resolving-parse-wanted-dependency/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name                  = "pnpm-resolving-parse-wanted-dependency"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-resolving-parse-wanted-dependency"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 pnpm-package-name = { workspace = true }

--- a/pnpm/crates/resolving-resolver-base/Cargo.toml
+++ b/pnpm/crates/resolving-resolver-base/Cargo.toml
@@ -1,30 +1,30 @@
 [package]
-name                  = "pnpm-resolving-resolver-base"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-resolving-resolver-base"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-config   = { workspace = true }
+pnpm-config = { workspace = true }
 pnpm-lockfile = { workspace = true }
-pnpm-network  = { workspace = true }
+pnpm-network = { workspace = true }
 pnpm-registry = { workspace = true }
 
-chrono      = { workspace = true }
+chrono = { workspace = true }
 derive_more = { workspace = true }
-miette      = { workspace = true }
+miette = { workspace = true }
 node-semver = { workspace = true }
-serde       = { workspace = true }
-serde_json  = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
-ssri  = { workspace = true }
+ssri = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]

--- a/pnpm/crates/resolving-tarball-resolver/Cargo.toml
+++ b/pnpm/crates/resolving-tarball-resolver/Cargo.toml
@@ -1,31 +1,31 @@
 [package]
-name                  = "pnpm-resolving-tarball-resolver"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-resolving-tarball-resolver"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-lockfile                = { workspace = true }
-pnpm-network                 = { workspace = true }
-pnpm-reporter                = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-network = { workspace = true }
+pnpm-reporter = { workspace = true }
 pnpm-resolving-resolver-base = { workspace = true }
-pnpm-store-dir               = { workspace = true }
-pnpm-tarball                 = { workspace = true }
+pnpm-store-dir = { workspace = true }
+pnpm-tarball = { workspace = true }
 
-reqwest    = { workspace = true }
+reqwest = { workspace = true }
 serde_json = { workspace = true }
-ssri       = { workspace = true }
+ssri = { workspace = true }
 
 [dev-dependencies]
-mockito           = { workspace = true }
+mockito = { workspace = true }
 pretty_assertions = { workspace = true }
-tokio             = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/pnpm/crates/semver-include-prerelease/Cargo.toml
+++ b/pnpm/crates/semver-include-prerelease/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name                  = "pnpm-semver-include-prerelease"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-semver-include-prerelease"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 node-semver = { workspace = true }

--- a/pnpm/crates/shared-artifact-protocol/Cargo.toml
+++ b/pnpm/crates/shared-artifact-protocol/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
-name                 = "pnpm-shared-artifact-protocol"
-version              = "0.0.1"
-publish              = false
-authors.workspace    = true
-description          = "Wire contract for signed pnpm shared artifacts"
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
+name = "pnpm-shared-artifact-protocol"
+version = "0.0.1"
+publish = false
+authors.workspace = true
+description = "Wire contract for signed pnpm shared artifacts"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [dependencies]
-base64      = { workspace = true }
+base64 = { workspace = true }
 derive_more = { workspace = true }
-p256        = { workspace = true }
-serde       = { workspace = true }
-serde_json  = { workspace = true }
-sha2        = { workspace = true }
+p256 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/store-dir/Cargo.toml
+++ b/pnpm/crates/store-dir/Cargo.toml
@@ -1,37 +1,37 @@
 [package]
-name                 = "pnpm-store-dir"
-description          = "Abstraction over store-dir paths"
-version              = "0.0.1"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
+name = "pnpm-store-dir"
+description = "Abstraction over store-dir paths"
+version = "0.0.1"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [dependencies]
-pnpm-package-name             = { workspace = true }
-pnpm-crypto-hash              = { workspace = true }
-pnpm-deps-path                = { workspace = true }
-pnpm-fs                       = { workspace = true }
+pnpm-package-name = { workspace = true }
+pnpm-crypto-hash = { workspace = true }
+pnpm-deps-path = { workspace = true }
+pnpm-fs = { workspace = true }
 pnpm-shared-artifact-protocol = { workspace = true }
 
-dashmap       = { workspace = true }
-derive_more   = { workspace = true }
-dunce         = { workspace = true }
-miette        = { workspace = true }
-node-semver   = { workspace = true }
-rmp-serde     = { workspace = true }
-rusqlite      = { workspace = true }
-serde         = { workspace = true }
-serde_json    = { workspace = true }
-sha2          = { workspace = true }
+dashmap = { workspace = true }
+derive_more = { workspace = true }
+dunce = { workspace = true }
+miette = { workspace = true }
+node-semver = { workspace = true }
+rmp-serde = { workspace = true }
+rusqlite = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
 smart-default = { workspace = true }
-ssri          = { workspace = true }
-tokio         = { workspace = true, features = ["sync"] }
-tracing       = { workspace = true }
-url           = { workspace = true }
+ssri = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+tracing = { workspace = true }
+url = { workspace = true }
 
 # Enable `sha2`'s `asm` feature on non-MSVC targets only. The feature
 # activates the `sha2-asm` crate (hand-written `.S` assembly files for
@@ -45,10 +45,10 @@ url           = { workspace = true }
 sha2 = { workspace = true, features = ["asm"] }
 
 [dev-dependencies]
-pipe-trait        = { workspace = true }
+pipe-trait = { workspace = true }
 pretty_assertions = { workspace = true }
-sha2              = { workspace = true }
-tempfile          = { workspace = true }
+sha2 = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/tarball/Cargo.toml
+++ b/pnpm/crates/tarball/Cargo.toml
@@ -1,49 +1,49 @@
 [package]
-name                  = "pnpm-tarball"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-tarball"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-diagnostics      = { workspace = true }
-pnpm-fs               = { workspace = true }
-pnpm-network          = { workspace = true }
+pnpm-diagnostics = { workspace = true }
+pnpm-fs = { workspace = true }
+pnpm-network = { workspace = true }
 pnpm-package-manifest = { workspace = true }
-pnpm-reporter         = { workspace = true }
-pnpm-store-dir        = { workspace = true }
+pnpm-reporter = { workspace = true }
+pnpm-store-dir = { workspace = true }
 
-bytes        = { workspace = true }
-dashmap      = { workspace = true }
-derive_more  = { workspace = true }
-flate2       = { workspace = true }
+bytes = { workspace = true }
+dashmap = { workspace = true }
+derive_more = { workspace = true }
+flate2 = { workspace = true }
 futures-util = { workspace = true }
-miette       = { workspace = true }
-num_cpus     = { workspace = true }
-pipe-trait   = { workspace = true }
-rayon        = { workspace = true }
-reqwest      = { workspace = true }
-rustls       = { workspace = true }
-serde        = { workspace = true }
-serde_json   = { workspace = true }
-ssri         = { workspace = true }
-tar          = { workspace = true }
-tokio        = { workspace = true }
-tracing      = { workspace = true }
-url          = { workspace = true }
-zip          = { workspace = true }
+miette = { workspace = true }
+num_cpus = { workspace = true }
+pipe-trait = { workspace = true }
+rayon = { workspace = true }
+reqwest = { workspace = true }
+rustls = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+ssri = { workspace = true }
+tar = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+url = { workspace = true }
+zip = { workspace = true }
 zune-inflate = { workspace = true }
 
 [dev-dependencies]
-dashmap           = { workspace = true, features = ["raw-api"] }
-mockito           = { workspace = true }
+dashmap = { workspace = true, features = ["raw-api"] }
+mockito = { workspace = true }
 pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/testing-utils/Cargo.toml
+++ b/pnpm/crates/testing-utils/Cargo.toml
@@ -1,32 +1,32 @@
 [package]
-name                 = "pnpm-testing-utils"
-version              = "0.0.0"
-description          = "Common utilities to test pacquet code"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
+name = "pnpm-testing-utils"
+version = "0.0.0"
+description = "Common utilities to test pacquet code"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [dependencies]
-assert_cmd        = { workspace = true }
-command-extra     = { workspace = true }
-dunce             = { workspace = true }
-flate2            = { workspace = true }
-pipe-trait        = { workspace = true }
-pnpr              = { workspace = true }
-serde_json        = { workspace = true }
-ssri              = { workspace = true }
-tar               = { workspace = true }
-tempfile          = { workspace = true }
-tokio             = { workspace = true }
-url               = { workspace = true }
-walkdir           = { workspace = true }
+assert_cmd = { workspace = true }
+command-extra = { workspace = true }
+dunce = { workspace = true }
+flate2 = { workspace = true }
+pipe-trait = { workspace = true }
+pnpr = { workspace = true }
+serde_json = { workspace = true }
+ssri = { workspace = true }
+tar = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }
+walkdir = { workspace = true }
 text-block-macros = { workspace = true }
-pnpr-fixtures     = { workspace = true }
-pnpm-fs           = { workspace = true }
+pnpr-fixtures = { workspace = true }
+pnpm-fs = { workspace = true }
 
 pnpm-workspace-state = { workspace = true }
 

--- a/pnpm/crates/text-sanitize/Cargo.toml
+++ b/pnpm/crates/text-sanitize/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name                  = "pnpm-text-sanitize"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-text-sanitize"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 

--- a/pnpm/crates/versioning/Cargo.toml
+++ b/pnpm/crates/versioning/Cargo.toml
@@ -1,32 +1,32 @@
 [package]
-name                  = "pnpm-versioning"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-versioning"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-matcher          = { workspace = true }
+pnpm-matcher = { workspace = true }
 pnpm-package-manifest = { workspace = true }
 
-derive_more  = { workspace = true }
-getrandom    = { workspace = true }
-indexmap     = { workspace = true }
-miette       = { workspace = true }
-node-semver  = { workspace = true }
-pathdiff     = { workspace = true }
-serde        = { workspace = true }
+derive_more = { workspace = true }
+getrandom = { workspace = true }
+indexmap = { workspace = true }
+miette = { workspace = true }
+node-semver = { workspace = true }
+pathdiff = { workspace = true }
+serde = { workspace = true }
 serde-saphyr = { workspace = true }
-serde_json   = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/workspace-manifest-writer/Cargo.toml
+++ b/pnpm/crates/workspace-manifest-writer/Cargo.toml
@@ -1,31 +1,31 @@
 [package]
-name                  = "pnpm-workspace-manifest-writer"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-workspace-manifest-writer"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-catalogs-types         = { workspace = true }
-pnpm-config                 = { workspace = true }
+pnpm-catalogs-types = { workspace = true }
+pnpm-config = { workspace = true }
 pnpm-config-parse-overrides = { workspace = true }
-pnpm-package-manifest       = { workspace = true }
+pnpm-package-manifest = { workspace = true }
 
-derive_more  = { workspace = true }
-indexmap     = { workspace = true }
-miette       = { workspace = true }
-serde        = { workspace = true }
+derive_more = { workspace = true }
+indexmap = { workspace = true }
+miette = { workspace = true }
+serde = { workspace = true }
 serde-saphyr = { workspace = true }
-serde_json   = { workspace = true }
-tempfile     = { workspace = true }
-yaml_serde   = { workspace = true }
-yamlpatch    = { workspace = true }
-yamlpath     = { workspace = true }
+serde_json = { workspace = true }
+tempfile = { workspace = true }
+yaml_serde = { workspace = true }
+yamlpatch = { workspace = true }
+yamlpath = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/pnpm/crates/workspace-projects-filter/Cargo.toml
+++ b/pnpm/crates/workspace-projects-filter/Cargo.toml
@@ -1,28 +1,28 @@
 [package]
-name                  = "pnpm-workspace-projects-filter"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-workspace-projects-filter"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-matcher                  = { workspace = true }
+pnpm-matcher = { workspace = true }
 pnpm-workspace-projects-graph = { workspace = true }
 
 derive_more = { workspace = true }
-indexmap    = { workspace = true }
-miette      = { workspace = true }
-pathdiff    = { workspace = true }
-wax         = { workspace = true }
+indexmap = { workspace = true }
+miette = { workspace = true }
+pathdiff = { workspace = true }
+wax = { workspace = true }
 
 [dev-dependencies]
 pnpm-testing-utils = { workspace = true }
-tempfile           = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/workspace-projects-graph/Cargo.toml
+++ b/pnpm/crates/workspace-projects-graph/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name                  = "pnpm-workspace-projects-graph"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-workspace-projects-graph"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-fs                       = { workspace = true }
+pnpm-fs = { workspace = true }
 pnpm-workspace-range-resolver = { workspace = true }
-pnpm-workspace-spec           = { workspace = true }
+pnpm-workspace-spec = { workspace = true }
 
-indexmap    = { workspace = true }
+indexmap = { workspace = true }
 node-semver = { workspace = true }
-rayon       = { workspace = true }
+rayon = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/workspace-range-resolver/Cargo.toml
+++ b/pnpm/crates/workspace-range-resolver/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name                  = "pnpm-workspace-range-resolver"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-workspace-range-resolver"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 node-semver = { workspace = true }

--- a/pnpm/crates/workspace-spec/Cargo.toml
+++ b/pnpm/crates/workspace-spec/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name                  = "pnpm-workspace-spec"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-workspace-spec"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [lints]
 workspace = true

--- a/pnpm/crates/workspace-state/Cargo.toml
+++ b/pnpm/crates/workspace-state/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name                  = "pnpm-workspace-state"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-workspace-state"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 pnpm-diagnostics = { workspace = true }
 
 derive_more = { workspace = true }
-indexmap    = { workspace = true }
-serde       = { workspace = true }
-serde_json  = { workspace = true }
-tempfile    = { workspace = true }
+indexmap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tempfile = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/pnpm/crates/workspace-task-scheduler/Cargo.toml
+++ b/pnpm/crates/workspace-task-scheduler/Cargo.toml
@@ -1,31 +1,31 @@
 [package]
-name                  = "pnpm-workspace-task-scheduler"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-workspace-task-scheduler"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-config   = { workspace = true }
-pnpm-fs       = { workspace = true }
+pnpm-config = { workspace = true }
+pnpm-fs = { workspace = true }
 pnpm-reporter = { workspace = true }
 
-derive_more  = { workspace = true }
+derive_more = { workspace = true }
 futures-util = { workspace = true }
-indexmap     = { workspace = true }
-miette       = { workspace = true }
-rustc-hash   = { workspace = true }
-serde        = { workspace = true }
+indexmap = { workspace = true }
+miette = { workspace = true }
+rustc-hash = { workspace = true }
+serde = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-serde_json        = { workspace = true }
-tokio             = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/workspace/Cargo.toml
+++ b/pnpm/crates/workspace/Cargo.toml
@@ -1,30 +1,30 @@
 [package]
-name                  = "pnpm-workspace"
-version               = "0.0.1"
-publish               = false
-authors.workspace     = true
+name = "pnpm-workspace"
+version = "0.0.1"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-pnpm-catalogs-types           = { workspace = true }
-pnpm-fs                       = { workspace = true }
-pnpm-package-manifest         = { workspace = true }
+pnpm-catalogs-types = { workspace = true }
+pnpm-fs = { workspace = true }
+pnpm-package-manifest = { workspace = true }
 pnpm-workspace-projects-graph = { workspace = true }
 
 cap-primitives = { workspace = true }
-derive_more    = { workspace = true }
-indexmap       = { workspace = true }
-miette         = { workspace = true }
-pathdiff       = { workspace = true }
-rayon          = { workspace = true }
-serde          = { workspace = true }
-serde-saphyr   = { workspace = true }
-wax            = { workspace = true }
+derive_more = { workspace = true }
+indexmap = { workspace = true }
+miette = { workspace = true }
+pathdiff = { workspace = true }
+rayon = { workspace = true }
+serde = { workspace = true }
+serde-saphyr = { workspace = true }
+wax = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
@@ -40,7 +40,7 @@ windows-sys = { workspace = true, features = [
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-tempfile          = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/tasks/ecosystem-e2e/Cargo.toml
+++ b/pnpm/tasks/ecosystem-e2e/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name                  = "pnpm-ecosystem-e2e"
-version               = "0.0.0"
-publish               = false
-authors.workspace     = true
+name = "pnpm-ecosystem-e2e"
+version = "0.0.0"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [[bin]]
 name = "ecosystem-e2e"
 path = "src/main.rs"
 
 [dependencies]
-clap       = { workspace = true }
+clap = { workspace = true }
 serde_json = { workspace = true }
-which      = { workspace = true }
+which = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/tasks/integrated-benchmark/Cargo.toml
+++ b/pnpm/tasks/integrated-benchmark/Cargo.toml
@@ -1,33 +1,33 @@
 [package]
-name                  = "pnpm-integrated-benchmark"
-version               = "0.0.0"
-publish               = false
-authors.workspace     = true
+name = "pnpm-integrated-benchmark"
+version = "0.0.0"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [[bin]]
 name = "integrated-benchmark"
 path = "src/main.rs"
 
 [dependencies]
-pnpm-fs            = { workspace = true }
+pnpm-fs = { workspace = true }
 pnpm-registry-mock = { workspace = true }
 
-clap         = { workspace = true }
-itertools    = { workspace = true }
-os_display   = { workspace = true }
-pipe-trait   = { workspace = true }
-reqwest      = { workspace = true }
-serde        = { workspace = true }
-serde_json   = { workspace = true }
+clap = { workspace = true }
+itertools = { workspace = true }
+os_display = { workspace = true }
+pipe-trait = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 serde-saphyr = { workspace = true }
-tokio        = { workspace = true }
-which        = { workspace = true }
+tokio = { workspace = true }
+which = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/tasks/micro-benchmark/Cargo.toml
+++ b/pnpm/tasks/micro-benchmark/Cargo.toml
@@ -1,46 +1,46 @@
 [package]
-name                  = "pnpm-micro-benchmark"
-version               = "0.0.0"
-publish               = false
-authors.workspace     = true
+name = "pnpm-micro-benchmark"
+version = "0.0.0"
+publish = false
+authors.workspace = true
 description.workspace = true
-edition.workspace     = true
-homepage.workspace    = true
-keywords.workspace    = true
-license.workspace     = true
-repository.workspace  = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [[bin]]
 name = "micro-benchmark"
 path = "src/main.rs"
 
 [dependencies]
-pnpm-catalogs-types           = { workspace = true }
-pnpm-package-manifest         = { workspace = true }
-pnpm-registry                 = { workspace = true }
-pnpm-resolving-deps-resolver  = { workspace = true }
-pnpm-resolving-resolver-base  = { workspace = true }
-pnpm-network                  = { workspace = true }
-pnpm-reporter                 = { workspace = true }
-pnpm-store-dir                = { workspace = true }
-pnpm-tarball                  = { workspace = true }
-pnpm-lockfile                 = { workspace = true }
+pnpm-catalogs-types = { workspace = true }
+pnpm-package-manifest = { workspace = true }
+pnpm-registry = { workspace = true }
+pnpm-resolving-deps-resolver = { workspace = true }
+pnpm-resolving-resolver-base = { workspace = true }
+pnpm-network = { workspace = true }
+pnpm-reporter = { workspace = true }
+pnpm-store-dir = { workspace = true }
+pnpm-tarball = { workspace = true }
+pnpm-lockfile = { workspace = true }
 pnpm-workspace-projects-graph = { workspace = true }
 pnpm-workspace-task-scheduler = { workspace = true }
 
-clap         = { workspace = true }
-criterion    = { workspace = true }
-flate2       = { workspace = true }
+clap = { workspace = true }
+criterion = { workspace = true }
+flate2 = { workspace = true }
 futures-util = { workspace = true }
-mockito      = { workspace = true }
-tokio        = { workspace = true }
-tempfile     = { workspace = true }
-pipe-trait   = { workspace = true }
+mockito = { workspace = true }
+tokio = { workspace = true }
+tempfile = { workspace = true }
+pipe-trait = { workspace = true }
 project-root = { workspace = true }
-ssri         = { workspace = true }
-tar          = { workspace = true }
-node-semver  = { workspace = true }
-serde_json   = { workspace = true }
+ssri = { workspace = true }
+tar = { workspace = true }
+node-semver = { workspace = true }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/tasks/registry-mock/Cargo.toml
+++ b/pnpm/tasks/registry-mock/Cargo.toml
@@ -1,37 +1,37 @@
 [package]
-name                 = "pnpm-registry-mock"
-version              = "0.0.0"
-description          = "Drives pnpr against the in-repo registry fixtures for pacquet benchmarks"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license.workspace    = true
+name = "pnpm-registry-mock"
+version = "0.0.0"
+description = "Drives pnpr against the in-repo registry fixtures for pacquet benchmarks"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [lib]
 name = "pnpm_registry_mock"
 path = "src/lib.rs"
-doc  = true
+doc = true
 
 [[bin]]
 name = "pnpm-registry-mock"
 path = "src/main.rs"
-doc  = false
+doc = false
 
 [dependencies]
-assert_cmd    = { workspace = true }
-clap          = { workspace = true }
-home          = { workspace = true }
-pipe-trait    = { workspace = true }
+assert_cmd = { workspace = true }
+clap = { workspace = true }
+home = { workspace = true }
+pipe-trait = { workspace = true }
 pnpr-fixtures = { workspace = true }
-reqwest       = { workspace = true }
-serde         = { workspace = true }
-serde_json    = { workspace = true }
-sysinfo       = { workspace = true }
-tokio         = { workspace = true }
-walkdir       = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sysinfo = { workspace = true }
+tokio = { workspace = true }
+walkdir = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpr/crates/auth/Cargo.toml
+++ b/pnpr/crates/auth/Cargo.toml
@@ -1,47 +1,47 @@
 [package]
-name                 = "pnpr-auth"
-version              = "0.0.1"
-description          = "pnpr's user and token stores: htpasswd, SQLite, and the networked SQL backends"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license-file         = "../../LICENSE.md"
+name = "pnpr-auth"
+version = "0.0.1"
+description = "pnpr's user and token stores: htpasswd, SQLite, and the networked SQL backends"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license-file = "../../LICENSE.md"
 repository.workspace = true
 
 [features]
-backend-libsql   = ["dep:libsql", "pnpr-error/backend-libsql"]
-backend-mysql    = ["dep:sqlx", "sqlx/mysql", "pnpr-error/backend-mysql"]
+backend-libsql = ["dep:libsql", "pnpr-error/backend-libsql"]
+backend-mysql = ["dep:sqlx", "sqlx/mysql", "pnpr-error/backend-mysql"]
 backend-postgres = ["dep:sqlx", "sqlx/postgres", "pnpr-error/backend-postgres"]
 
 [dependencies]
-pnpm-network  = { workspace = true }
-p256          = { workspace = true }
-serde         = { workspace = true }
-pnpr-config   = { workspace = true }
-pnpr-error    = { workspace = true }
-async-trait   = { workspace = true }
-base64        = { workspace = true }
-bcrypt        = { workspace = true }
-chrono        = { workspace = true }
-getrandom     = { workspace = true }
-libsql        = { workspace = true, optional = true }
+pnpm-network = { workspace = true }
+p256 = { workspace = true }
+serde = { workspace = true }
+pnpr-config = { workspace = true }
+pnpr-error = { workspace = true }
+async-trait = { workspace = true }
+base64 = { workspace = true }
+bcrypt = { workspace = true }
+chrono = { workspace = true }
+getrandom = { workspace = true }
+libsql = { workspace = true, optional = true }
 openidconnect = { workspace = true }
-reqwest       = { workspace = true }
-rusqlite      = { workspace = true }
-serde_json    = { workspace = true }
-sha2          = { workspace = true }
-sqlx          = { workspace = true, optional = true }
-tokio         = { workspace = true }
-tracing       = { workspace = true }
-url           = { workspace = true }
+reqwest = { workspace = true }
+rusqlite = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+sqlx = { workspace = true, optional = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
-axum     = { workspace = true, features = ["form", "json"] }
+axum = { workspace = true, features = ["form", "json"] }
 tempfile = { workspace = true }
-tokio    = { workspace = true }
-tower    = { workspace = true, features = ["util"] }
+tokio = { workspace = true }
+tower = { workspace = true, features = ["util"] }
 
 [lints]
 workspace = true

--- a/pnpr/crates/cargo/Cargo.toml
+++ b/pnpr/crates/cargo/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
-name                 = "pnpr-cargo"
-version              = "0.0.1"
-description          = "The Cargo registry protocol pnpr speaks: sparse index layout, index entries, the publish request body, and the download URL template"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license-file         = "../../LICENSE.md"
+name = "pnpr-cargo"
+version = "0.0.1"
+description = "The Cargo registry protocol pnpr speaks: sparse index layout, index entries, the publish request body, and the download URL template"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license-file = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
-derive_more         = { workspace = true }
-flate2              = { workspace = true }
-pnpr-package-name   = { workspace = true }
+derive_more = { workspace = true }
+flate2 = { workspace = true }
+pnpr-package-name = { workspace = true }
 pnpm-cargo-resolver = { workspace = true }
-semver              = { workspace = true }
-serde               = { workspace = true }
-serde_json          = { workspace = true }
-tar                 = { workspace = true }
-toml                = { workspace = true }
+semver = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tar = { workspace = true }
+toml = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpr/crates/config/Cargo.toml
+++ b/pnpr/crates/config/Cargo.toml
@@ -1,35 +1,35 @@
 [package]
-name                 = "pnpr-config"
-version              = "0.0.1"
-description          = "The pnpr YAML configuration: parsing, validation, and the resolved server settings"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license-file         = "../../LICENSE.md"
+name = "pnpr-config"
+version = "0.0.1"
+description = "The pnpr YAML configuration: parsing, validation, and the resolved server settings"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license-file = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
-pnpr-error        = { workspace = true }
+pnpr-error = { workspace = true }
 pnpr-package-name = { workspace = true }
-pnpr-policy       = { workspace = true }
-pnpr-registry     = { workspace = true }
-pnpm-config-dir   = { workspace = true }
-pnpm-env-replace  = { workspace = true }
-getrandom         = { workspace = true }
-home              = { workspace = true }
-indexmap          = { workspace = true }
-object_store      = { workspace = true }
-reqwest           = { workspace = true }
-serde             = { workspace = true }
-serde-saphyr      = { workspace = true }
-tracing           = { workspace = true }
-url               = { workspace = true }
+pnpr-policy = { workspace = true }
+pnpr-registry = { workspace = true }
+pnpm-config-dir = { workspace = true }
+pnpm-env-replace = { workspace = true }
+getrandom = { workspace = true }
+home = { workspace = true }
+indexmap = { workspace = true }
+object_store = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde-saphyr = { workspace = true }
+tracing = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 pnpm-testing-utils = { workspace = true }
-tempfile           = { workspace = true }
+tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [lints]

--- a/pnpr/crates/error/Cargo.toml
+++ b/pnpr/crates/error/Cargo.toml
@@ -1,33 +1,33 @@
 [package]
-name                 = "pnpr-error"
-version              = "0.0.1"
-description          = "The error type every pnpr layer returns, and how it renders as an HTTP response"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license-file         = "../../LICENSE.md"
+name = "pnpr-error"
+version = "0.0.1"
+description = "The error type every pnpr layer returns, and how it renders as an HTTP response"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license-file = "../../LICENSE.md"
 repository.workspace = true
 
 [features]
-backend-libsql   = ["dep:libsql"]
-backend-mysql    = ["dep:sqlx", "sqlx/mysql"]
+backend-libsql = ["dep:libsql"]
+backend-mysql = ["dep:sqlx", "sqlx/mysql"]
 backend-postgres = ["dep:sqlx", "sqlx/postgres"]
 
 [dependencies]
-axum         = { workspace = true }
-bcrypt       = { workspace = true }
-derive_more  = { workspace = true }
-libsql       = { workspace = true, optional = true }
+axum = { workspace = true }
+bcrypt = { workspace = true }
+derive_more = { workspace = true }
+libsql = { workspace = true, optional = true }
 object_store = { workspace = true }
-reqwest      = { workspace = true }
-rusqlite     = { workspace = true }
-serde_json   = { workspace = true }
-tracing      = { workspace = true }
-sqlx         = { workspace = true, optional = true }
-tokio        = { workspace = true }
-url          = { workspace = true }
+reqwest = { workspace = true }
+rusqlite = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+sqlx = { workspace = true, optional = true }
+tokio = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/pnpr/crates/oci/Cargo.toml
+++ b/pnpr/crates/oci/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-name                 = "pnpr-oci"
-version              = "0.0.1"
-description          = "The OCI distribution protocol pnpr speaks: digests, image manifests and indexes, the stored image document, and the error body"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license-file         = "../../LICENSE.md"
+name = "pnpr-oci"
+version = "0.0.1"
+description = "The OCI distribution protocol pnpr speaks: digests, image manifests and indexes, the stored image document, and the error body"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license-file = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
-derive_more       = { workspace = true }
+derive_more = { workspace = true }
 pnpr-package-name = { workspace = true }
-serde             = { workspace = true }
-serde_json        = { workspace = true }
-sha2              = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpr/crates/osv/Cargo.toml
+++ b/pnpr/crates/osv/Cargo.toml
@@ -1,30 +1,30 @@
 [package]
-name                 = "pnpr-osv"
-version              = "0.0.1"
-description          = "The OSV advisory index pnpr consults to refuse vulnerable versions"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license-file         = "../../LICENSE.md"
+name = "pnpr-osv"
+version = "0.0.1"
+description = "The OSV advisory index pnpr consults to refuse vulnerable versions"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license-file = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
-pnpr-config                  = { workspace = true }
-pnpr-error                   = { workspace = true }
+pnpr-config = { workspace = true }
+pnpr-error = { workspace = true }
 pnpm-resolving-resolver-base = { workspace = true }
-libc                         = { workspace = true }
-node-semver                  = { workspace = true }
-serde                        = { workspace = true }
-serde_json                   = { workspace = true }
-sha2                         = { workspace = true }
-tracing                      = { workspace = true }
-zip                          = { workspace = true }
+libc = { workspace = true }
+node-semver = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+tracing = { workspace = true }
+zip = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-tokio    = { workspace = true }
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpr/crates/package-name/Cargo.toml
+++ b/pnpr/crates/package-name/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-name                 = "pnpr-package-name"
-version              = "0.0.1"
-description          = "a validated package name and the npm tarball names derived from it"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license-file         = "../../LICENSE.md"
+name = "pnpr-package-name"
+version = "0.0.1"
+description = "a validated package name and the npm tarball names derived from it"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license-file = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
-pnpr-error  = { workspace = true }
+pnpr-error = { workspace = true }
 derive_more = { workspace = true }
-pep508_rs   = { workspace = true }
-serde       = { workspace = true }
-strum       = { workspace = true }
+pep508_rs = { workspace = true }
+serde = { workspace = true }
+strum = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpr/crates/pipeline-runs/Cargo.toml
+++ b/pnpr/crates/pipeline-runs/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
-name                 = "pnpr-pipeline-runs"
-version              = "0.0.1"
-description          = "The pipeline run-record store: append-only CI run summaries and event streams, by workspace"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license-file         = "../../LICENSE.md"
+name = "pnpr-pipeline-runs"
+version = "0.0.1"
+description = "The pipeline run-record store: append-only CI run summaries and event streams, by workspace"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license-file = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
-pnpr-error   = { workspace = true }
+pnpr-error = { workspace = true }
 pnpr-storage = { workspace = true }
-serde        = { workspace = true }
-serde_json   = { workspace = true }
-tokio        = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 object_store = { workspace = true }
-pnpr-config  = { workspace = true }
-tempfile     = { workspace = true }
+pnpr-config = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpr/crates/pnpr-fixtures/Cargo.toml
+++ b/pnpr/crates/pnpr-fixtures/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
-name                 = "pnpr-fixtures"
-version              = "0.0.1"
-description          = "Build static pnpr storage from shared test package fixtures"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license-file         = "../../LICENSE.md"
+name = "pnpr-fixtures"
+version = "0.0.1"
+description = "Build static pnpr storage from shared test package fixtures"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license-file = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
-base64      = { workspace = true }
-chrono      = { workspace = true }
-clap        = { workspace = true }
-flate2      = { workspace = true }
+base64 = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true }
+flate2 = { workspace = true }
 node-semver = { workspace = true }
-serde_json  = { workspace = true }
-sha2        = { workspace = true }
-tar         = { workspace = true }
-walkdir     = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+tar = { workspace = true }
+walkdir = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/pnpr/crates/pnpr/Cargo.toml
+++ b/pnpr/crates/pnpr/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name              = "pnpr"
-description       = "pnpm-compatible npm registry server"
-version           = "0.1.0-alpha.11"
-authors           = ["pnpm contributors"]
+name = "pnpr"
+description = "pnpm-compatible npm registry server"
+version = "0.1.0-alpha.11"
+authors = ["pnpm contributors"]
 edition.workspace = true
-license-file      = "../../LICENSE.md"
-homepage          = "https://pnpm.io"
-repository        = "https://github.com/pnpm/pnpm"
-keywords          = ["npm", "registry", "pnpm", "verdaccio"]
-categories        = ["development-tools", "web-programming::http-server"]
-readme            = "README.md"
+license-file = "../../LICENSE.md"
+homepage = "https://pnpm.io"
+repository = "https://github.com/pnpm/pnpm"
+keywords = ["npm", "registry", "pnpm", "verdaccio"]
+categories = ["development-tools", "web-programming::http-server"]
+readme = "README.md"
 
 [lib]
 path = "src/lib.rs"
@@ -19,95 +19,95 @@ name = "pnpr"
 path = "src/main.rs"
 
 [features]
-default          = ["backend-libsql"]
-backend-libsql   = ["dep:libsql", "pnpr-error/backend-libsql", "pnpr-auth/backend-libsql"]
-backend-mysql    = ["dep:sqlx", "sqlx/mysql", "pnpr-error/backend-mysql", "pnpr-auth/backend-mysql"]
+default = ["backend-libsql"]
+backend-libsql = ["dep:libsql", "pnpr-error/backend-libsql", "pnpr-auth/backend-libsql"]
+backend-mysql = ["dep:sqlx", "sqlx/mysql", "pnpr-error/backend-mysql", "pnpr-auth/backend-mysql"]
 backend-postgres = ["dep:sqlx", "sqlx/postgres", "pnpr-error/backend-postgres", "pnpr-auth/backend-postgres"]
 
 [dependencies]
-pnpr-auth                     = { workspace = true }
-pnpr-cargo                    = { workspace = true }
-pnpr-config                   = { workspace = true }
-pnpr-error                    = { workspace = true }
-pnpr-oci                      = { workspace = true }
-pnpr-osv                      = { workspace = true }
-pnpr-package-name             = { workspace = true }
-pnpr-policy                   = { workspace = true }
-pnpr-pypi                     = { workspace = true }
-pnpr-registry                 = { workspace = true }
-pnpr-storage                  = { workspace = true }
-pnpr-route                    = { workspace = true }
-pnpr-search                   = { workspace = true }
-pnpr-pipeline-runs            = { workspace = true }
-pnpr-shared-artifacts         = { workspace = true }
-pnpr-upstream                 = { workspace = true }
-pnpm-cargo-resolver           = { workspace = true }
-pnpm-catalogs-types           = { workspace = true }
-pnpm-config                   = { workspace = true }
-pnpm-config-dir               = { workspace = true }
-pnpm-crypto-hash              = { workspace = true }
-pnpm-env-replace              = { workspace = true }
-pnpm-fs                       = { workspace = true }
-pnpm-lockfile                 = { workspace = true }
-pnpm-lockfile-verification    = { workspace = true }
-pnpm-network                  = { workspace = true }
-pnpm-package-manager          = { workspace = true }
-pnpm-package-manifest         = { workspace = true }
-pnpm-python-resolver          = { workspace = true }
-pnpm-reporter                 = { workspace = true }
-pnpm-resolving-npm-resolver   = { workspace = true }
-pnpm-resolving-resolver-base  = { workspace = true }
-pnpm-store-dir                = { workspace = true }
+pnpr-auth = { workspace = true }
+pnpr-cargo = { workspace = true }
+pnpr-config = { workspace = true }
+pnpr-error = { workspace = true }
+pnpr-oci = { workspace = true }
+pnpr-osv = { workspace = true }
+pnpr-package-name = { workspace = true }
+pnpr-policy = { workspace = true }
+pnpr-pypi = { workspace = true }
+pnpr-registry = { workspace = true }
+pnpr-storage = { workspace = true }
+pnpr-route = { workspace = true }
+pnpr-search = { workspace = true }
+pnpr-pipeline-runs = { workspace = true }
+pnpr-shared-artifacts = { workspace = true }
+pnpr-upstream = { workspace = true }
+pnpm-cargo-resolver = { workspace = true }
+pnpm-catalogs-types = { workspace = true }
+pnpm-config = { workspace = true }
+pnpm-config-dir = { workspace = true }
+pnpm-crypto-hash = { workspace = true }
+pnpm-env-replace = { workspace = true }
+pnpm-fs = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-lockfile-verification = { workspace = true }
+pnpm-network = { workspace = true }
+pnpm-package-manager = { workspace = true }
+pnpm-package-manifest = { workspace = true }
+pnpm-python-resolver = { workspace = true }
+pnpm-reporter = { workspace = true }
+pnpm-resolving-npm-resolver = { workspace = true }
+pnpm-resolving-resolver-base = { workspace = true }
+pnpm-store-dir = { workspace = true }
 pnpm-shared-artifact-protocol = { workspace = true }
-pnpm-tarball                  = { workspace = true }
-async-trait                   = { workspace = true }
-axum                          = { workspace = true, features = ["query"] }
-base64                        = { workspace = true }
-bcrypt                        = { workspace = true }
-chrono                        = { workspace = true }
-clap                          = { workspace = true, features = ["env"] }
-dashmap                       = { workspace = true }
-derive_more                   = { workspace = true }
-flate2                        = { workspace = true }
-futures-util                  = { workspace = true }
-getrandom                     = { workspace = true }
-home                          = { workspace = true }
-indexmap                      = { workspace = true }
-libc                          = { workspace = true }
-libsql                        = { workspace = true, optional = true }
-miette                        = { workspace = true }
-node-semver                   = { workspace = true }
-pep440_rs                     = { workspace = true }
-pep508_rs                     = { workspace = true }
-p256                          = { workspace = true }
-object_store                  = { workspace = true }
-reqwest                       = { workspace = true }
-rusqlite                      = { workspace = true }
-serde                         = { workspace = true }
-serde-saphyr                  = { workspace = true }
-serde_json                    = { workspace = true }
-sha2                          = { workspace = true }
-sqlx                          = { workspace = true, optional = true }
-ssri                          = { workspace = true }
-tempfile                      = { workspace = true }
-tokio                         = { workspace = true }
-tower-http                    = { workspace = true }
-tracing                       = { workspace = true }
-tracing-subscriber            = { workspace = true, features = ["json"] }
-url                           = { workspace = true }
-wax                           = { workspace = true }
-zip                           = { workspace = true }
+pnpm-tarball = { workspace = true }
+async-trait = { workspace = true }
+axum = { workspace = true, features = ["query"] }
+base64 = { workspace = true }
+bcrypt = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true, features = ["env"] }
+dashmap = { workspace = true }
+derive_more = { workspace = true }
+flate2 = { workspace = true }
+futures-util = { workspace = true }
+getrandom = { workspace = true }
+home = { workspace = true }
+indexmap = { workspace = true }
+libc = { workspace = true }
+libsql = { workspace = true, optional = true }
+miette = { workspace = true }
+node-semver = { workspace = true }
+pep440_rs = { workspace = true }
+pep508_rs = { workspace = true }
+p256 = { workspace = true }
+object_store = { workspace = true }
+reqwest = { workspace = true }
+rusqlite = { workspace = true }
+serde = { workspace = true }
+serde-saphyr = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+sqlx = { workspace = true, optional = true }
+ssri = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+tower-http = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["json"] }
+url = { workspace = true }
+wax = { workspace = true }
+zip = { workspace = true }
 
 [dev-dependencies]
-chrono             = { workspace = true }
-mockito            = { workspace = true }
-walkdir            = { workspace = true }
-tar                = { workspace = true }
-pipe-trait         = { workspace = true }
+chrono = { workspace = true }
+mockito = { workspace = true }
+walkdir = { workspace = true }
+tar = { workspace = true }
+pipe-trait = { workspace = true }
 pnpm-testing-utils = { workspace = true }
-tempfile           = { workspace = true }
-tokio              = { workspace = true }
-tower              = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+tower = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpr/crates/policy/Cargo.toml
+++ b/pnpr/crates/policy/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name                 = "pnpr-policy"
-version              = "0.0.1"
-description          = "Access policy gating the pnpr registry routes"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license-file         = "../../LICENSE.md"
+name = "pnpr-policy"
+version = "0.0.1"
+description = "Access policy gating the pnpr registry routes"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license-file = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
 pnpr-registry = { workspace = true }
-indexmap      = { workspace = true }
+indexmap = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpr/crates/pypi/Cargo.toml
+++ b/pnpr/crates/pypi/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
-name                 = "pnpr-pypi"
-version              = "0.0.1"
-description          = "The Python Simple Repository API (PEP 503 / PEP 691) and legacy upload API pieces pnpr speaks"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license-file         = "../../LICENSE.md"
+name = "pnpr-pypi"
+version = "0.0.1"
+description = "The Python Simple Repository API (PEP 503 / PEP 691) and legacy upload API pieces pnpr speaks"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license-file = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
-pnpm-network      = { workspace = true }
-derive_more       = { workspace = true }
+pnpm-network = { workspace = true }
+derive_more = { workspace = true }
 pnpr-package-name = { workspace = true }
-pep440_rs         = { workspace = true }
-regex             = { workspace = true }
-serde             = { workspace = true }
-serde_json        = { workspace = true }
+pep440_rs = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpr/crates/registry/Cargo.toml
+++ b/pnpr/crates/registry/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-name                 = "pnpr-registry"
-version              = "0.0.1"
-description          = "The pnpr registry routing table: which registry serves which package pattern"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license-file         = "../../LICENSE.md"
+name = "pnpr-registry"
+version = "0.0.1"
+description = "The pnpr registry routing table: which registry serves which package pattern"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license-file = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
-pnpr-error        = { workspace = true }
+pnpr-error = { workspace = true }
 pnpr-package-name = { workspace = true }
-derive_more       = { workspace = true }
-indexmap          = { workspace = true }
-wax               = { workspace = true }
+derive_more = { workspace = true }
+indexmap = { workspace = true }
+wax = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpr/crates/route/Cargo.toml
+++ b/pnpr/crates/route/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
-name                 = "pnpr-route"
-version              = "0.0.1"
-description          = "Classifies each fetch route as public or private, so a shared resolution never leaks private data"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license-file         = "../../LICENSE.md"
+name = "pnpr-route"
+version = "0.0.1"
+description = "Classifies each fetch route as public or private, so a shared resolution never leaks private data"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license-file = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
-pnpr-config   = { workspace = true }
-pnpr-policy   = { workspace = true }
+pnpr-config = { workspace = true }
+pnpr-policy = { workspace = true }
 pnpr-registry = { workspace = true }
-pnpm-network  = { workspace = true }
-indexmap      = { workspace = true }
-reqwest       = { workspace = true }
-sha2          = { workspace = true }
-tracing       = { workspace = true }
-wax           = { workspace = true }
+pnpm-network = { workspace = true }
+indexmap = { workspace = true }
+reqwest = { workspace = true }
+sha2 = { workspace = true }
+tracing = { workspace = true }
+wax = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpr/crates/search/Cargo.toml
+++ b/pnpr/crates/search/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
-name                 = "pnpr-search"
-version              = "0.0.1"
-description          = "The local /-/v1/search index scan over hosted packages"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license-file         = "../../LICENSE.md"
+name = "pnpr-search"
+version = "0.0.1"
+description = "The local /-/v1/search index scan over hosted packages"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license-file = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
-pnpr-error        = { workspace = true }
+pnpr-error = { workspace = true }
 pnpr-package-name = { workspace = true }
-pnpr-storage      = { workspace = true }
-serde_json        = { workspace = true }
+pnpr-storage = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-tokio    = { workspace = true }
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpr/crates/shared-artifacts/Cargo.toml
+++ b/pnpr/crates/shared-artifacts/Cargo.toml
@@ -1,30 +1,30 @@
 [package]
-name                 = "pnpr-shared-artifacts"
-version              = "0.0.1"
-description          = "The shared build-artifact store: reservations, blob storage, and the usage accounting that bounds it"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license-file         = "../../LICENSE.md"
+name = "pnpr-shared-artifacts"
+version = "0.0.1"
+description = "The shared build-artifact store: reservations, blob storage, and the usage accounting that bounds it"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license-file = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
-pnpr-config                   = { workspace = true }
-pnpr-error                    = { workspace = true }
+pnpr-config = { workspace = true }
+pnpr-error = { workspace = true }
 pnpm-shared-artifact-protocol = { workspace = true }
-base64                        = { workspace = true }
-bytes                         = { workspace = true }
-futures-util                  = { workspace = true }
-getrandom                     = { workspace = true }
-object_store                  = { workspace = true }
-serde                         = { workspace = true }
-serde_json                    = { workspace = true }
-sha2                          = { workspace = true }
-tempfile                      = { workspace = true }
-tokio                         = { workspace = true }
-tracing                       = { workspace = true }
+base64 = { workspace = true }
+bytes = { workspace = true }
+futures-util = { workspace = true }
+getrandom = { workspace = true }
+object_store = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/pnpr/crates/storage/Cargo.toml
+++ b/pnpr/crates/storage/Cargo.toml
@@ -1,40 +1,40 @@
 [package]
-name                 = "pnpr-storage"
-version              = "0.0.1"
-description          = "Where pnpr keeps packages: the hosted store and its backends, the proxy cache, and the journal that makes a publish crash-safe"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license-file         = "../../LICENSE.md"
+name = "pnpr-storage"
+version = "0.0.1"
+description = "Where pnpr keeps packages: the hosted store and its backends, the proxy cache, and the journal that makes a publish crash-safe"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license-file = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
-pnpm-network      = { workspace = true }
-pnpr-config       = { workspace = true }
-pnpr-error        = { workspace = true }
+pnpm-network = { workspace = true }
+pnpr-config = { workspace = true }
+pnpr-error = { workspace = true }
 pnpr-package-name = { workspace = true }
-pnpr-registry     = { workspace = true }
-pnpm-crypto-hash  = { workspace = true }
-async-trait       = { workspace = true }
-axum              = { workspace = true }
-base64            = { workspace = true }
-futures-util      = { workspace = true }
-getrandom         = { workspace = true }
-object_store      = { workspace = true }
-reqwest           = { workspace = true }
-serde             = { workspace = true }
-serde_json        = { workspace = true }
-ssri              = { workspace = true }
-tokio             = { workspace = true }
-tempfile          = { workspace = true }
-tracing           = { workspace = true }
+pnpr-registry = { workspace = true }
+pnpm-crypto-hash = { workspace = true }
+async-trait = { workspace = true }
+axum = { workspace = true }
+base64 = { workspace = true }
+futures-util = { workspace = true }
+getrandom = { workspace = true }
+object_store = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+ssri = { workspace = true }
+tokio = { workspace = true }
+tempfile = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-reqwest  = { workspace = true }
+reqwest = { workspace = true }
 tempfile = { workspace = true }
-tokio    = { workspace = true }
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpr/crates/upstream/Cargo.toml
+++ b/pnpr/crates/upstream/Cargo.toml
@@ -1,34 +1,34 @@
 [package]
-name                 = "pnpr-upstream"
-version              = "0.0.1"
-description          = "The upstream registry proxy client: packument and tarball fetches, caching validators, and the failure circuit breaker"
-publish              = false
-authors.workspace    = true
-edition.workspace    = true
-homepage.workspace   = true
-keywords.workspace   = true
-license-file         = "../../LICENSE.md"
+name = "pnpr-upstream"
+version = "0.0.1"
+description = "The upstream registry proxy client: packument and tarball fetches, caching validators, and the failure circuit breaker"
+publish = false
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license-file = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
-pnpr-config       = { workspace = true }
-pnpr-error        = { workspace = true }
+pnpr-config = { workspace = true }
+pnpr-error = { workspace = true }
 pnpr-package-name = { workspace = true }
-pnpm-lockfile     = { workspace = true }
-pnpm-network      = { workspace = true }
-chrono            = { workspace = true }
-reqwest           = { workspace = true }
-serde             = { workspace = true }
-serde_json        = { workspace = true }
-ssri              = { workspace = true }
-tracing           = { workspace = true }
+pnpm-lockfile = { workspace = true }
+pnpm-network = { workspace = true }
+chrono = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+ssri = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-pnpr-policy  = { workspace = true }
+pnpr-policy = { workspace = true }
 futures-util = { workspace = true }
-mockito      = { workspace = true }
-tempfile     = { workspace = true }
-tokio        = { workspace = true }
+mockito = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

taplo was padding TOML with spaces so that things line up in a column, which makes unrelated lines show up in diffs. Two separate options did this, and this PR turns both off.

`align_entries` padded the key of every entry so the `=` signs share a column. In `[workspace.dependencies]` that meant padding every entry out to the width of the longest crate name, so adding or renaming one crate reflowed the whole block:

```toml
pnpm-cli                               = { path = "pnpm/crates/cli" }
pnpm-shared-artifact-protocol          = { path = "pnpm/crates/shared-artifact-protocol" }
```

`align_comments` did the same for trailing comments. The clippy lint tables in the root manifest repadded every comment whenever a lint name grew:

```toml
use_self = "allow"                            # spelling out the concrete type name over Self is left to author discretion
missing_const_for_fn = "allow"                # const-ness is a forward semver commitment and this nursery lint is noisy
```

Both are now `false`, and the covered files are reformatted:

```toml
pnpm-cli = { path = "pnpm/crates/cli" }
pnpm-shared-artifact-protocol = { path = "pnpm/crates/shared-artifact-protocol" }

use_self = "allow" # spelling out the concrete type name over Self is left to author discretion
missing_const_for_fn = "allow" # const-ness is a forward semver commitment and this nursery lint is noisy
```

The diff is whitespace only. `git diff -w main..HEAD` reports `.taplo.toml` as the only file that differs, so no key, value, or ordering changed in any manifest. Verified with both taplo 0.10.0 and the 0.8.1 that `pacquet-ci.yml` pins, so `pnpm ci:toml-fmt` passes on both.

Because this touches every `Cargo.toml`, it will conflict with any open PR that edits one. Worth merging quickly.

## Squash Commit Body

```text
taplo padded TOML with spaces so that things line up in a column, which makes
unrelated lines show up in diffs. Two separate options did this.

`align_entries` padded the key of every entry so the `=` signs share a column.
In `[workspace.dependencies]` that meant padding every entry out to the width of
the longest crate name, so adding or renaming one crate reflowed the whole
block. `align_comments` did the same for trailing comments, so the clippy lint
tables in the root manifest repadded every comment whenever a lint name grew.

Set both to false and reformat the 107 files taplo covers. The diff is
whitespace only: `git diff -w` reports `.taplo.toml` as the only file that
differs. Verified with both the locally installed taplo 0.10.0 and the 0.8.1
that CI pins, so `pnpm ci:toml-fmt` passes on both.
```

## Checklist

- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
  <!-- Not applicable: formatting only, no published package changes. -->
- [x] Added or updated tests.
  <!-- Not applicable: `pnpm ci:toml-fmt` already covers this. -->
- [x] Updated the documentation if needed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01996wtGzfdHDBvKxNnJniwA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Standardized TOML formatting across workspace manifests by removing alignment padding around assignments.
  - Updated formatting rules for consistent entry and comment alignment.
  - Normalized dependency declaration ordering.
- **Chores**
  - Updated selected internal dependency references and workspace lint inheritance settings.
- **Impact**
  - No changes to package versions, feature behavior, or runtime functionality.
  - These updates improve configuration consistency without affecting end-user workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->