### PR TITLE
refactor(task-scheduler): separate requested projects from graph scope

### DIFF
--- a/.changeset/task-graph-requested-projects.md
+++ b/.changeset/task-graph-requested-projects.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Prepared workspace task scheduling to retain dependency tasks when only some projects are requested. This supports the workspace task cache planned in [pnpm/pnpm#14279](https://github.com/pnpm/pnpm/issues/14279).

--- a/pnpm/crates/cli/src/cli_args/run/recursive/selection.rs
+++ b/pnpm/crates/cli/src/cli_args/run/recursive/selection.rs
@@ -264,6 +264,7 @@ pub(super) fn build_run_task_graph(
         project_dependencies: &project_dependencies,
         select_scripts,
         task_name: script_name,
+        requested_projects: None,
         tasks: (args.sort && !config.tasks.is_empty()).then_some(&config.tasks),
     });
     if args.reverse {

--- a/pnpm/crates/cli/tests/suite/run_recursive/task_graph.rs
+++ b/pnpm/crates/cli/tests/suite/run_recursive/task_graph.rs
@@ -4,6 +4,38 @@ use super::{
 };
 use assert_cmd::assert::OutputAssertExt;
 
+#[test]
+fn filter_keeps_dependency_tasks_outside_the_selection_from_running() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[
+            (
+                "app",
+                json!({
+                    "name": "app",
+                    "version": "1.0.0",
+                    "dependencies": { "lib": "workspace:*" },
+                    "scripts": { "build": "echo app >> ../order.log" },
+                }),
+            ),
+            ("lib", build_appends_run_order("lib")),
+        ],
+    );
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "packages:\n  - app\n  - lib\ntasks:\n  build:\n    dependsOn: ['^build']\n",
+    )
+    .expect("write workspace settings");
+
+    pacquet.with_args(["--filter", "app", "run", "build"]).assert().success();
+
+    let order = fs::read_to_string(workspace.join("order.log")).expect("read order log");
+    assert_eq!(order, "app\n");
+
+    drop(root);
+}
+
 /// `slow` waits for a marker only `mid` writes, and `mid` may start only
 /// once `dep` is done — so the run completes only if `mid` is dispatched
 /// while the unrelated `slow` is still in flight. Any barrier between

--- a/pnpm/crates/workspace-task-scheduler/src/build.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/build.rs
@@ -4,7 +4,7 @@ use super::{
 };
 
 /// Build the graph of tasks the invocation runs: a task named `task_name`
-/// in every selected project, plus every task those transitively pull in
+/// in every requested project, plus every task those transitively pull in
 /// through `dependsOn`. A task with no `tasks` entry behaves as
 /// `dependsOn: ['^<its own name>']`: plain topological order over the
 /// project graph.
@@ -14,12 +14,14 @@ pub fn build_task_graph<SelectScripts>(
 where
     SelectScripts: Fn(&Path, &str) -> Vec<String>,
 {
-    build_task_graph_from_seeds(
-        options.project_dependencies,
-        &options.select_scripts,
-        std::slice::from_ref(&options.task_name),
-        options.tasks,
-    )
+    let seeded = SeededBuildOptions {
+        project_dependencies: options.project_dependencies,
+        select_scripts: &options.select_scripts,
+        task_names: std::slice::from_ref(&options.task_name),
+        requested_projects: options.requested_projects,
+        tasks: options.tasks,
+    };
+    seeded.build()
 }
 
 /// [`build_task_graph`] for a `pnpm pipeline` invocation, which requests
@@ -38,25 +40,6 @@ where
         tasks: options.tasks,
     };
     seeded.build()
-}
-
-fn build_task_graph_from_seeds<SelectScripts>(
-    project_dependencies: &IndexMap<PathBuf, Vec<PathBuf>>,
-    select_scripts: &SelectScripts,
-    task_names: &[&str],
-    tasks: Option<&IndexMap<String, TaskSettings>>,
-) -> TaskGraph
-where
-    SelectScripts: Fn(&Path, &str) -> Vec<String>,
-{
-    let options = SeededBuildOptions {
-        project_dependencies,
-        select_scripts,
-        task_names,
-        requested_projects: None,
-        tasks,
-    };
-    options.build()
 }
 
 struct SeededBuildOptions<'a, SelectScripts>

--- a/pnpm/crates/workspace-task-scheduler/src/lib.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/lib.rs
@@ -83,15 +83,18 @@ pub struct BuildTaskGraphOptions<'a, SelectScripts>
 where
     SelectScripts: Fn(&Path, &str) -> Vec<String>,
 {
-    /// The dependency edges among the selected projects, already resolved
-    /// through the full workspace graph. Tasks are created only for these
-    /// projects: `dependsOn` never runs anything in a project the filter
-    /// did not select.
+    /// The projects the graph can contain and their dependency edges.
+    /// Every dependency and requested project must be present in this map.
+    /// Callers that apply `--filter` narrow both the map and the requested
+    /// projects to preserve the filter's execution boundary.
     pub project_dependencies: &'a IndexMap<PathBuf, Vec<PathBuf>>,
     pub select_scripts: SelectScripts,
-    /// The script the invocation runs; every selected project gets a task
-    /// named this.
+    /// The script the invocation requests in each requested project.
     pub task_name: &'a str,
+    /// The projects whose tasks the invocation requests, in dispatch
+    /// tie-break order. `None` requests every project in the map's order.
+    /// Other projects participate only through `dependsOn` edges.
+    pub requested_projects: Option<&'a [PathBuf]>,
     pub tasks: Option<&'a IndexMap<String, TaskSettings>>,
 }
 

--- a/pnpm/crates/workspace-task-scheduler/src/tests.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/tests.rs
@@ -20,6 +20,8 @@ use std::{
 
 const WORKSPACE_DIR: &str = "/workspace";
 
+mod requested_projects;
+
 fn dir(name: &str) -> PathBuf {
     Path::new(WORKSPACE_DIR).join(name)
 }
@@ -96,6 +98,7 @@ fn build_graph(
             scripts_by_dir[project].iter().filter(|script| *script == task_name).cloned().collect()
         },
         task_name,
+        requested_projects: None,
         tasks: task_settings,
     })
 }

--- a/pnpm/crates/workspace-task-scheduler/src/tests/requested_projects.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/tests/requested_projects.rs
@@ -1,0 +1,107 @@
+use super::{dir, key, sequence, tasks};
+use crate::{BuildTaskGraphOptions, build_task_graph};
+use indexmap::IndexMap;
+use std::path::Path;
+
+#[test]
+fn requested_projects_retain_transitive_dependencies_through_missing_scripts() {
+    let projects = IndexMap::from([
+        (dir("app"), vec![dir("middle")]),
+        (dir("middle"), vec![dir("lib")]),
+        (dir("lib"), vec![]),
+        (dir("unrelated"), vec![]),
+    ]);
+    let requested = [dir("app")];
+    let select_scripts = |project: &Path, task_name: &str| {
+        if project == dir("middle") { vec![] } else { vec![task_name.to_string()] }
+    };
+    let mut options = BuildTaskGraphOptions {
+        project_dependencies: &projects,
+        select_scripts,
+        task_name: "build",
+        requested_projects: Some(&requested),
+        tasks: None,
+    };
+    let mut graph = build_task_graph(&options);
+    dbg!(&graph);
+    assert_eq!(graph.len(), 3);
+    assert!(graph[&key("app", "build")].requested);
+    assert!(!graph[&key("middle", "build")].requested);
+    assert!(!graph[&key("lib", "build")].requested);
+    assert!(graph[&key("middle", "build")].scripts.is_empty());
+    assert_eq!(graph[&key("app", "build")].dependencies, vec![key("middle", "build")]);
+    assert_eq!(graph[&key("middle", "build")].dependencies, vec![key("lib", "build")]);
+
+    options.requested_projects = None;
+    let full_graph = build_task_graph(&options);
+    dbg!(&full_graph);
+    for (key, node) in &graph {
+        assert_eq!(node.dependencies, full_graph[key].dependencies);
+        assert_eq!(node.scripts, full_graph[key].scripts);
+    }
+    assert_eq!(
+        sequence(&mut graph).unwrap(),
+        vec![key("lib", "build"), key("middle", "build"), key("app", "build")],
+    );
+}
+
+#[test]
+fn requested_projects_pull_only_declared_tasks_from_other_projects() {
+    let projects = IndexMap::from([
+        (dir("app"), vec![dir("lib")]),
+        (dir("lib"), vec![]),
+        (dir("unrelated"), vec![]),
+    ]);
+    let settings = tasks(&[("test", Some(&["build"])), ("build", Some(&["^build"]))]);
+    let graph = build_task_graph(&BuildTaskGraphOptions {
+        project_dependencies: &projects,
+        select_scripts: |_, name: &str| vec![name.to_string()],
+        task_name: "test",
+        requested_projects: Some(&[dir("app")]),
+        tasks: Some(&settings),
+    });
+    dbg!(&graph);
+    assert_eq!(
+        graph.keys().cloned().collect::<Vec<_>>(),
+        vec![key("app", "test"), key("app", "build"), key("lib", "build")],
+    );
+    assert_eq!(graph[&key("app", "test")].dependencies, vec![key("app", "build")]);
+    assert_eq!(graph[&key("app", "build")].dependencies, vec![key("lib", "build")]);
+    assert!(graph[&key("app", "test")].requested);
+    assert!(!graph[&key("app", "build")].requested);
+    assert!(!graph[&key("lib", "build")].requested);
+}
+
+#[test]
+fn requested_projects_preserve_request_order_and_deduplicate_tasks() {
+    let projects = IndexMap::from([(dir("app"), vec![dir("lib")]), (dir("lib"), vec![])]);
+    let requested = [dir("lib"), dir("app"), dir("lib")];
+    let graph = build_task_graph(&BuildTaskGraphOptions {
+        project_dependencies: &projects,
+        select_scripts: |_, name: &str| vec![name.to_string()],
+        task_name: "build",
+        requested_projects: Some(&requested),
+        tasks: None,
+    });
+    dbg!(&graph);
+    assert_eq!(
+        graph.keys().cloned().collect::<Vec<_>>(),
+        vec![key("lib", "build"), key("app", "build")],
+    );
+    assert!(graph.values().all(|node| node.requested));
+    assert_eq!(graph[&key("app", "build")].dependencies, vec![key("lib", "build")]);
+}
+
+#[test]
+fn empty_requested_projects_builds_no_tasks() {
+    let projects = IndexMap::from([(dir("app"), vec![dir("lib")]), (dir("lib"), vec![])]);
+    let graph = build_task_graph(&BuildTaskGraphOptions {
+        project_dependencies: &projects,
+        select_scripts: |_, _| panic!("an empty request must not select scripts"),
+        task_name: "build",
+        requested_projects: Some(&[]),
+        tasks: None,
+    });
+    dbg!(&graph);
+    assert!(graph.is_empty());
+}


### PR DESCRIPTION
## Summary

The regular task graph builder requests a task in every project it receives, so callers cannot narrow the requested projects while retaining their dependency tasks. Add a separate requested-project list and reuse the traversal already used by `pnpm pipeline`.

Implements item 1 of pnpm/pnpm#14279 for pnpm v12. The recursive CLI still requests every project in its filtered graph, preserving `--filter` behavior. Items 2 through 11 remain outside this PR.

Validation: `just ready` passed, including 11,121 tests (13 skipped), formatting, workspace compilation, and Clippy. Dylint also passed. All 45 scheduler tests pass. Each of the four new scheduler tests fails with the original builder, and the new CLI test verifies that filtered-out dependency tasks do not run.

## Squash Commit Body

```text
Separate the Rust task graph's requested projects from the project map
that supplies its dependency closure. BuildTaskGraphOptions accepts an
optional requested_projects list; None requests all projects in map order.
Other projects enter the graph only through dependsOn edges.

Reuse SeededBuildOptions, which already supports this distinction for
pipeline invocations, and remove the redundant helper. Recursive run
continues to pass its filtered dependency graph and request every project
in that graph, preserving the existing CLI execution boundary.

Cover transitive dependencies through missing scripts, declared task
edges, request ordering and deduplication, empty requests, and filtered
CLI execution. Verify that narrowed and full graphs retain identical
dependencies and scripts for shared tasks.

This is item 1 of pnpm/pnpm#14279. The current development policy limits
new features to pnpm v12, so the TypeScript v11 builder is unchanged.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791665198&installation_model_id=426870&pr_number=14820&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14820&signature=c16719b750ea2090f8fbdf045934fafc7a39d0a8cc1319ac275404926b7fc9b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->