### PR TITLE
style(rust): cap nesting depth at three

### DIFF
--- a/dylint.toml
+++ b/dylint.toml
@@ -8,7 +8,7 @@
 # or via the `just dylint` recipe.
 [workspace.metadata.dylint]
 libraries = [
-    { git = "https://github.com/KSXGitHub/perfectionist", rev = "c18c52b8c17aae38207aa38575c919df52287f01" },
+    { git = "https://github.com/KSXGitHub/perfectionist", rev = "495d33163b1e4ab6b0cbb4742a2130c655849f7d" },
 ]
 
 # Project-local DSL / test macros that perfectionist's exactly-once
@@ -113,3 +113,7 @@ exempt_tests = true
 ["perfectionist::overly_long_function"]
 max_lines = 40
 exempt_tests = true
+
+["perfectionist::excessive_nesting"]
+max_depth = 3
+exempt_tests = false

--- a/pnpm/CODE_STYLE_GUIDE.md
+++ b/pnpm/CODE_STYLE_GUIDE.md
@@ -46,6 +46,12 @@ Keep production function bodies within 40 lines of code. Extract helpers around 
 
 Tests are exempt, so a test can keep its setup, action, and assertions together.
 
+### Nesting depth
+
+Keep function and method bodies within three levels of nesting, including tests. Prefer guard clauses, match guards, and helpers named for a distinct responsibility. `perfectionist::excessive_nesting` enforces this across the Rust workspace through [`dylint.toml`](../dylint.toml).
+
+Keep iterator closures simple. A single expression can make a chain easy to follow. When a closure needs several statements, prefer an explicit loop or a named helper. Preserve lazy evaluation, allocation behavior, and short-circuiting when choosing between them.
+
 ### File length
 
 Keep production Rust files within 400 lines of code and test-only Rust files within 800. Count nonblank lines containing code, including multiline string content, and exclude comment-only lines. Split files into modules around distinct responsibilities or test scenarios. Keep tests in their existing test binary.

--- a/pnpm/crates/cli/src/cargo_deps/workspace_directory.rs
+++ b/pnpm/crates/cli/src/cargo_deps/workspace_directory.rs
@@ -66,12 +66,7 @@ fn open_or_create_directory_at(
             Ok(handle) => return Ok(handle),
             Err(error) if error.kind() == io::ErrorKind::NotFound => {
                 create_directory_at(parent, component)
-                    .or_else(|error| match error.kind() {
-                        // Lost the race with a concurrent install; its
-                        // directory is as good as ours.
-                        io::ErrorKind::AlreadyExists => Ok(()),
-                        _ => Err(error),
-                    })
+                    .or_else(accept_existing_directory)
                     .into_diagnostic()
                     .wrap_err_with(|| format!("create Cargo directory {}", path.display()))?;
             }
@@ -91,6 +86,14 @@ fn open_or_create_directory_at(
                     .wrap_err_with(|| format!("inspect Cargo directory {}", path.display()));
             }
         }
+    }
+}
+
+fn accept_existing_directory(error: io::Error) -> io::Result<()> {
+    match error.kind() {
+        // Lost the race with a concurrent install; its directory is as good as ours.
+        io::ErrorKind::AlreadyExists => Ok(()),
+        _ => Err(error),
     }
 }
 

--- a/pnpm/crates/cli/src/cargo_deps/workspace_directory/windows.rs
+++ b/pnpm/crates/cli/src/cargo_deps/workspace_directory/windows.rs
@@ -1,4 +1,6 @@
-use super::{IntoDiagnostic, ManagedDirectory, Path, PathBuf, Result, fs, io};
+use super::{
+    IntoDiagnostic, ManagedDirectory, Path, PathBuf, Result, accept_existing_directory, fs, io,
+};
 use miette::WrapErr;
 
 #[cfg(windows)]
@@ -24,27 +26,7 @@ pub(in super::super) fn ensure_workspace_directory_windows(
     let mut path = root;
     for component in components {
         path.push(component);
-        let handle = loop {
-            match open_pinned_windows_directory(&path) {
-                Ok(handle) => break handle,
-                Err(error) if error.kind() == io::ErrorKind::NotFound => {
-                    match fs::create_dir(&path) {
-                        Ok(()) => {}
-                        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
-                        Err(error) => {
-                            return Err(error).into_diagnostic().wrap_err_with(|| {
-                                format!("create Cargo directory {}", path.display())
-                            });
-                        }
-                    }
-                }
-                Err(error) => {
-                    return Err(error)
-                        .into_diagnostic()
-                        .wrap_err_with(|| format!("inspect Cargo directory {}", path.display()));
-                }
-            }
-        };
+        let handle = open_or_create_pinned_windows_directory(&path)?;
         let metadata = handle
             .metadata()
             .into_diagnostic()
@@ -62,6 +44,26 @@ pub(in super::super) fn ensure_workspace_directory_windows(
     // every component open without FILE_SHARE_DELETE prevents a checked parent
     // from being renamed or replaced while the path-based helpers run.
     Ok(ManagedDirectory { path, _pinned_components: handles })
+}
+
+#[cfg(windows)]
+fn open_or_create_pinned_windows_directory(path: &Path) -> Result<fs::File> {
+    loop {
+        match open_pinned_windows_directory(path) {
+            Ok(handle) => return Ok(handle),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                fs::create_dir(path)
+                    .or_else(accept_existing_directory)
+                    .into_diagnostic()
+                    .wrap_err_with(|| format!("create Cargo directory {}", path.display()))?;
+            }
+            Err(error) => {
+                return Err(error)
+                    .into_diagnostic()
+                    .wrap_err_with(|| format!("inspect Cargo directory {}", path.display()));
+            }
+        }
+    }
 }
 
 #[cfg(windows)]

--- a/pnpm/crates/cli/src/cli_args/audit/advisories.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/advisories.rs
@@ -152,27 +152,29 @@ impl<'a> AuditGraph<'a> {
     pub(super) fn env(env_lockfile: &'a EnvLockfile) -> Self {
         let importer = env_lockfile.importers.get(EnvLockfile::ROOT_IMPORTER_KEY);
         let mut importers = Vec::new();
-        if let Some(importer) = importer {
-            let config_roots = env_roots(&importer.config_dependencies);
-            if !config_roots.is_empty() {
+        let Some(importer) = importer else {
+            return Self { importers, snapshots: &env_lockfile.snapshots };
+        };
+        let config_roots = env_roots(&importer.config_dependencies);
+        if !config_roots.is_empty() {
+            importers.push(GraphImporter {
+                path_segment: "configDependencies".to_string(),
+                roots: config_roots.into_iter().map(|edge| (DepKind::Prod, edge)).collect(),
+            });
+        }
+        if let Some(package_manager_dependencies) = &importer.package_manager_dependencies {
+            let package_manager_roots = env_roots(package_manager_dependencies);
+            if !package_manager_roots.is_empty() {
                 importers.push(GraphImporter {
-                    path_segment: "configDependencies".to_string(),
-                    roots: config_roots.into_iter().map(|edge| (DepKind::Prod, edge)).collect(),
+                    path_segment: "packageManagerDependencies".to_string(),
+                    roots: package_manager_roots
+                        .into_iter()
+                        .map(|edge| (DepKind::Prod, edge))
+                        .collect(),
                 });
             }
-            if let Some(package_manager_dependencies) = &importer.package_manager_dependencies {
-                let package_manager_roots = env_roots(package_manager_dependencies);
-                if !package_manager_roots.is_empty() {
-                    importers.push(GraphImporter {
-                        path_segment: "packageManagerDependencies".to_string(),
-                        roots: package_manager_roots
-                            .into_iter()
-                            .map(|edge| (DepKind::Prod, edge))
-                            .collect(),
-                    });
-                }
-            }
         }
+
         Self { importers, snapshots: &env_lockfile.snapshots }
     }
 

--- a/pnpm/crates/cli/src/cli_args/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/cache.rs
@@ -116,16 +116,17 @@ impl CacheCommand {
                 println!("{}", Self::cleaned_cache_dir(config).display());
             }
             CacheCommand::ListRegistries => {
-                if let Ok(entries) = fs::read_dir(&cache_dir) {
-                    let mut registries: Vec<String> = entries
-                        .filter_map(std::result::Result::ok)
-                        .filter(|entry| entry.file_type().is_ok_and(|file_type| file_type.is_dir()))
-                        .map(|entry| entry.file_name().to_string_lossy().into_owned())
-                        .collect();
-                    registries.sort();
-                    if !registries.is_empty() {
-                        println!("{}", registries.join("\n"));
-                    }
+                let Ok(entries) = fs::read_dir(&cache_dir) else {
+                    return Ok(());
+                };
+                let mut registries: Vec<String> = entries
+                    .filter_map(std::result::Result::ok)
+                    .filter(|entry| entry.file_type().is_ok_and(|file_type| file_type.is_dir()))
+                    .map(|entry| entry.file_name().to_string_lossy().into_owned())
+                    .collect();
+                registries.sort();
+                if !registries.is_empty() {
+                    println!("{}", registries.join("\n"));
                 }
             }
             CacheCommand::List { packages } => {

--- a/pnpm/crates/cli/src/cli_args/find_hash.rs
+++ b/pnpm/crates/cli/src/cli_args/find_hash.rs
@@ -198,16 +198,33 @@ fn decode_find_hash_index(bytes: &[u8]) -> Result<FindHashPackageIndex, StoreInd
 }
 
 fn contains_hash(data: &FindHashPackageIndex, hash: &str) -> bool {
-    data.algo == "sha512"
-        && (data.files.values().any(|file| file.digest == hash)
-            || data.side_effects.as_ref().is_some_and(|side_effects| {
-                side_effects.values().any(|side_effect| {
-                    side_effect
-                        .added
-                        .as_ref()
-                        .is_some_and(|added| added.values().any(|file| file.digest == hash))
-                })
-            }))
+    if data.algo != "sha512" {
+        return false;
+    }
+    if contains_file_hash(&data.files, hash) {
+        return true;
+    }
+    let Some(side_effects) = &data.side_effects else {
+        return false;
+    };
+    for side_effect in side_effects.values() {
+        let Some(added) = &side_effect.added else {
+            continue;
+        };
+        if contains_file_hash(added, hash) {
+            return true;
+        }
+    }
+    false
+}
+
+fn contains_file_hash(files: &HashMap<String, FindHashFileInfo>, hash: &str) -> bool {
+    for file in files.values() {
+        if file.digest == hash {
+            return true;
+        }
+    }
+    false
 }
 
 fn package_identity(bytes: &[u8]) -> Result<(String, String), StoreIndexError> {

--- a/pnpm/crates/cli/src/cli_args/owner.rs
+++ b/pnpm/crates/cli/src/cli_args/owner.rs
@@ -138,10 +138,8 @@ impl OwnerArgs {
             let origins: Vec<(String, String, Option<u16>)> = registries
                 .values()
                 .filter_map(|registry| {
-                    reqwest::Url::parse(registry).ok().and_then(|url| {
-                        url.host_str()
-                            .map(|host| (url.scheme().to_string(), host.to_string(), url.port()))
-                    })
+                    let url = reqwest::Url::parse(registry).ok()?;
+                    Some((url.scheme().to_string(), url.host_str()?.to_string(), url.port()))
                 })
                 .collect();
             let guard: RedirectGuard = Arc::new(move |target: &reqwest::Url| -> bool {

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
@@ -375,17 +375,18 @@ fn collect_output_files(project_dir: &Path, outputs: &[String]) -> io::Result<Ve
             .map_err(io::Error::other)?
         {
             let entry = entry.map_err(io::Error::other)?;
-            if entry.file_type().is_file() {
-                let relative = entry
-                    .path()
-                    .strip_prefix(project_dir)
-                    .map_err(|_| io::Error::other("output glob must stay inside the project"))?
-                    .to_string_lossy()
-                    .replace(std::path::MAIN_SEPARATOR, "/");
-                validate_relative_path(Path::new(&relative))?;
-                check_ancestors(project_dir, Path::new(&relative))?;
-                files.push(relative);
+            if !entry.file_type().is_file() {
+                continue;
             }
+            let relative = entry
+                .path()
+                .strip_prefix(project_dir)
+                .map_err(|_| io::Error::other("output glob must stay inside the project"))?
+                .to_string_lossy()
+                .replace(std::path::MAIN_SEPARATOR, "/");
+            validate_relative_path(Path::new(&relative))?;
+            check_ancestors(project_dir, Path::new(&relative))?;
+            files.push(relative);
         }
     }
     files.sort();

--- a/pnpm/crates/cli/src/cli_args/pkg.rs
+++ b/pnpm/crates/cli/src/cli_args/pkg.rs
@@ -155,12 +155,9 @@ impl PkgArgs {
                 PkgSubcommand::Set(args) => edit_project_manifest(project, |value| {
                     apply_set_pairs(value, &args.pairs, self.json)
                 })?,
-                PkgSubcommand::Delete(args) => edit_project_manifest(project, |value| {
-                    for key in &args.keys {
-                        delete_object_value_by_property_path(value, key)?;
-                    }
-                    Ok(())
-                })?,
+                PkgSubcommand::Delete(args) => {
+                    edit_project_manifest(project, |value| apply_delete_keys(value, &args.keys))?;
+                }
                 PkgSubcommand::Fix => edit_project_manifest(project, |value| {
                     fix_manifest(value);
                     Ok(())
@@ -297,11 +294,15 @@ fn pkg_delete(manifest_path: &Path, keys: &[String]) -> miette::Result<()> {
     }
     let mut manifest =
         PackageManifest::from_path(manifest_path.to_path_buf()).wrap_err("reading package.json")?;
-    let value = manifest.value_mut();
+    apply_delete_keys(manifest.value_mut(), keys)?;
+    manifest.save().wrap_err("saving package.json")?;
+    Ok(())
+}
+
+fn apply_delete_keys(value: &mut Value, keys: &[String]) -> miette::Result<()> {
     for key in keys {
         delete_object_value_by_property_path(value, key)?;
     }
-    manifest.save().wrap_err("saving package.json")?;
     Ok(())
 }
 

--- a/pnpm/crates/cli/src/cli_args/pre_command/lockfile.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/lockfile.rs
@@ -4,6 +4,7 @@ use super::{
     PreCommandPlan, SwitchSource, Value, VersionPart, is_package_manager_resolved,
     package_manager_to_sync, pnpm_package_to_install, version_satisfies,
 };
+use pnpm_lockfile::SnapshotEntry;
 
 pub(super) fn env_lockfile_sync_plan(
     input: &PreCommandInput,
@@ -157,15 +158,23 @@ fn assert_package_manager_lockfile_uses_registry_resolutions(
         assert_registry_package_path(&key, package_info)?;
         assert_integrity_only_resolution(&key, &package_info.resolution)?;
 
-        for dependencies in
-            [&snapshot.dependencies, &snapshot.optional_dependencies].into_iter().flatten()
-        {
-            for (name, reference) in dependencies {
-                let next_key = reference
-                    .resolve(name)
-                    .ok_or_else(|| invalid_package_manager_lockfile(&key))?;
-                pending.push(next_key);
-            }
+        append_snapshot_dependencies(snapshot, &key, &mut pending)?;
+    }
+    Ok(())
+}
+
+fn append_snapshot_dependencies(
+    snapshot: &SnapshotEntry,
+    key: &PackageKey,
+    pending: &mut Vec<PackageKey>,
+) -> miette::Result<()> {
+    for dependencies in
+        [&snapshot.dependencies, &snapshot.optional_dependencies].into_iter().flatten()
+    {
+        for (name, reference) in dependencies {
+            let next_key =
+                reference.resolve(name).ok_or_else(|| invalid_package_manager_lockfile(key))?;
+            pending.push(next_key);
         }
     }
     Ok(())

--- a/pnpm/crates/cli/src/cli_args/sbom/workspace.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom/workspace.rs
@@ -139,14 +139,15 @@ fn selected_and_reachable_project_dirs(
     let mut seen: HashSet<PathBuf> = project_dirs.iter().cloned().collect();
     let mut index = 0;
     while let Some(project_dir) = project_dirs.get(index) {
-        if let Some(project) = graph.get(project_dir) {
-            for dependency_dir in &project.dependencies {
-                if seen.insert(dependency_dir.clone()) {
-                    project_dirs.push(dependency_dir.clone());
-                }
+        index += 1;
+        let Some(project) = graph.get(project_dir) else {
+            continue;
+        };
+        for dependency_dir in &project.dependencies {
+            if seen.insert(dependency_dir.clone()) {
+                project_dirs.push(dependency_dir.clone());
             }
         }
-        index += 1;
     }
     project_dirs
 }

--- a/pnpm/crates/cli/src/cli_args/team.rs
+++ b/pnpm/crates/cli/src/cli_args/team.rs
@@ -250,10 +250,8 @@ impl TeamArgs {
             let origins: Vec<(String, String, Option<u16>)> = registries
                 .values()
                 .filter_map(|registry| {
-                    reqwest::Url::parse(registry).ok().and_then(|url| {
-                        url.host_str()
-                            .map(|host| (url.scheme().to_string(), host.to_string(), url.port()))
-                    })
+                    let url = reqwest::Url::parse(registry).ok()?;
+                    Some((url.scheme().to_string(), url.host_str()?.to_string(), url.port()))
                 })
                 .collect();
             let guard: RedirectGuard = Arc::new(move |target: &reqwest::Url| -> bool {

--- a/pnpm/crates/cli/src/cli_args/update_changeset.rs
+++ b/pnpm/crates/cli/src/cli_args/update_changeset.rs
@@ -353,15 +353,23 @@ fn uses_changed_catalog_entry<'a>(
     dependency_groups: impl IntoIterator<Item = Option<&'a BTreeMap<String, String>>>,
     changed_catalog_entries: &BTreeMap<String, BTreeSet<String>>,
 ) -> bool {
-    dependency_groups.into_iter().flatten().any(|dependencies| {
-        dependencies.iter().any(|(dependency_name, spec)| {
-            parse_catalog_protocol(spec).is_some_and(|catalog_name| {
-                changed_catalog_entries
-                    .get(catalog_name)
-                    .is_some_and(|names| names.contains(dependency_name))
-            })
-        })
-    })
+    for dependencies in dependency_groups {
+        let Some(dependencies) = dependencies else {
+            continue;
+        };
+        for (dependency_name, spec) in dependencies {
+            let Some(catalog_name) = parse_catalog_protocol(spec) else {
+                continue;
+            };
+            let Some(names) = changed_catalog_entries.get(catalog_name) else {
+                continue;
+            };
+            if names.contains(dependency_name) {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 fn global_log<Output: Reporter>(level: LogLevel, message: String) {

--- a/pnpm/crates/deps-path/src/suffix_index.rs
+++ b/pnpm/crates/deps-path/src/suffix_index.rs
@@ -28,18 +28,21 @@ pub fn index_of_dep_path_suffix(dep_path: &str) -> DepPathSuffixIndex {
             b'(' => open -= 1,
             b')' => open += 1,
             _ if open == 0 => {
-                let start = idx + 1;
-                if dep_path[start..].starts_with("(patch_hash=") {
-                    let peers_index = dep_path[start + 2..].find('(').map(|off| start + 2 + off);
-                    return DepPathSuffixIndex { peers_index, patch_hash_index: Some(start) };
-                }
-                return DepPathSuffixIndex { peers_index: Some(start), patch_hash_index: None };
+                return suffix_index_from_start(dep_path, idx + 1);
             }
             _ => {}
         }
         cursor = idx.checked_sub(1);
     }
     absent
+}
+
+fn suffix_index_from_start(dep_path: &str, start: usize) -> DepPathSuffixIndex {
+    if dep_path[start..].starts_with("(patch_hash=") {
+        let peers_index = dep_path[start + 2..].find('(').map(|off| start + 2 + off);
+        return DepPathSuffixIndex { peers_index, patch_hash_index: Some(start) };
+    }
+    DepPathSuffixIndex { peers_index: Some(start), patch_hash_index: None }
 }
 
 /// Strip the peer-suffix and `(patch_hash=…)` segments from `dep_path`,

--- a/pnpm/crates/deps-restorer/src/create_virtual_dir_by_snapshot/tests.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_dir_by_snapshot/tests.rs
@@ -175,14 +175,10 @@ async fn run_emits_imported_event_after_import_indexed_dir() {
     .expect("empty-cas-paths run should succeed");
 
     let captured = EVENTS.lock().unwrap();
-    let imported = captured.iter().find_map(|event| match event {
-        LogEvent::Progress(log) => match &log.message {
-            ProgressMessage::Imported { method, requester, to } => {
-                Some((*method, requester.clone(), to.clone()))
-            }
-            _ => None,
-        },
-        _ => None,
+    let imported = captured.iter().find_map(|event| {
+        let LogEvent::Progress(log) = event else { return None };
+        let ProgressMessage::Imported { method, requester, to } = &log.message else { return None };
+        Some((*method, requester.clone(), to.clone()))
     });
     let (method, requester, to) =
         imported.unwrap_or_else(|| panic!("imported must fire; got {captured:?}"));

--- a/pnpm/crates/deps-restorer/src/hoist.rs
+++ b/pnpm/crates/deps-restorer/src/hoist.rs
@@ -92,20 +92,7 @@ pub fn build_hoist_graph_with_max_length(
         .filter_map(|(key, snapshot)| {
             let metadata_key = key.without_peer();
             let metadata = packages.get(&metadata_key)?;
-            let mut children = IndexMap::new();
-            for dependency_map in [&snapshot.dependencies, &snapshot.optional_dependencies] {
-                let mut dep_entries: Vec<_> =
-                    dependency_map.iter().flat_map(|map| map.iter()).collect();
-                dep_entries.sort_by_cached_key(|entry| entry.0.to_string());
-                for (alias, dep_ref) in dep_entries {
-                    // `dep_ref.resolve` is `None` for `link:` deps —
-                    // workspace siblings that live outside the virtual
-                    // store, which are skipped here.
-                    if let Some(child) = dep_ref.resolve(alias) {
-                        children.insert(alias.to_string(), child);
-                    }
-                }
-            }
+            let children = snapshot_children(snapshot);
             Some((
                 key.clone(),
                 HoistGraphNode {
@@ -270,6 +257,23 @@ pub struct HoistResult {
     /// out of `.modules.yaml`'s `hoistedDependencies` too (its graph
     /// lookup misses for a `ProjectId` before the record is written).
     pub hoisted_workspace_aliases: Vec<(String, HoistKind, PathBuf)>,
+}
+
+fn snapshot_children(snapshot: &SnapshotEntry) -> IndexMap<String, PackageKey> {
+    let mut children = IndexMap::new();
+    for dependency_map in [&snapshot.dependencies, &snapshot.optional_dependencies] {
+        let mut dep_entries: Vec<_> = dependency_map.iter().flat_map(|map| map.iter()).collect();
+        dep_entries.sort_by_cached_key(|entry| entry.0.to_string());
+        for (alias, dep_ref) in dep_entries {
+            // `dep_ref.resolve` is `None` for `link:` deps —
+            // workspace siblings that live outside the virtual
+            // store, which are skipped here.
+            if let Some(child) = dep_ref.resolve(alias) {
+                children.insert(alias.to_string(), child);
+            }
+        }
+    }
+    children
 }
 
 /// Walk the dependency graph in pnpm's graph-walker order and decide

--- a/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
@@ -447,14 +447,14 @@ async fn second_visit_skips_progress_emits_but_still_links() {
         .lock()
         .unwrap()
         .iter()
-        .filter_map(|event| match event {
-            LogEvent::Progress(log) => Some(match &log.message {
+        .filter_map(|event| {
+            let LogEvent::Progress(log) = event else { return None };
+            Some(match &log.message {
                 ProgressMessage::Resolved { .. } => "resolved",
                 ProgressMessage::Fetched { .. } => "fetched",
                 ProgressMessage::FoundInStore { .. } => "found_in_store",
                 ProgressMessage::Imported { .. } => "imported",
-            }),
-            _ => None,
+            })
         })
         .collect();
     assert!(kinds.is_empty(), "second visit must not emit progress events, got {kinds:?}");

--- a/pnpm/crates/deps-restorer/src/package_map/dependencies.rs
+++ b/pnpm/crates/deps-restorer/src/package_map/dependencies.rs
@@ -157,10 +157,8 @@ pub(super) fn physical_dependencies(
     let mut current = package_dir.to_path_buf();
     loop {
         let modules_dir = normalize_path(&current.join("node_modules"));
-        if let Some(locations) = loose_index.by_modules_dir.get(&modules_dir) {
-            for (name, id) in locations {
-                dependencies.entry(name.clone()).or_insert_with(|| id.clone());
-            }
+        for (name, id) in loose_index.by_modules_dir.get(&modules_dir).into_iter().flatten() {
+            dependencies.entry(name.clone()).or_insert_with(|| id.clone());
         }
         if !current.pop() {
             break;

--- a/pnpm/crates/executor/src/lifecycle.rs
+++ b/pnpm/crates/executor/src/lifecycle.rs
@@ -234,7 +234,8 @@ fn run_lifecycle_stages<Reporter: self::Reporter>(
         let script = if stage == "install" {
             get_script("install").map(String::from).or_else(|| {
                 (get_script("preinstall").is_none() && opts.pkg_root.join("binding.gyp").exists())
-                    .then(|| "node-gyp rebuild".to_string())
+                    .then_some("node-gyp rebuild")
+                    .map(String::from)
             })
         } else {
             get_script(stage).map(String::from)

--- a/pnpm/crates/fs/src/write_atomic/tests.rs
+++ b/pnpm/crates/fs/src/write_atomic/tests.rs
@@ -84,15 +84,19 @@ fn concurrent_replacements_leave_complete_content() {
             let barrier = &barrier;
             scope.spawn(move || {
                 barrier.wait();
-                for _ in 0..20 {
-                    write_atomic(path, &[byte; 4096]).unwrap();
-                }
+                replace_repeatedly(path, byte);
             });
         }
     });
     let contents = std::fs::read(path).unwrap();
     assert_eq!(contents.len(), 4096);
     assert!(contents.iter().all(|byte| *byte == contents[0]));
+}
+
+fn replace_repeatedly(path: &std::path::Path, byte: u8) {
+    for _ in 0..20 {
+        write_atomic(path, &[byte; 4096]).unwrap();
+    }
 }
 
 #[cfg(windows)]

--- a/pnpm/crates/install-coordinator/src/tests.rs
+++ b/pnpm/crates/install-coordinator/src/tests.rs
@@ -71,18 +71,20 @@ impl PreparedInstall for Projection {
 async fn polls_participants_concurrently() {
     let root = tempfile::tempdir().unwrap();
     let started = Arc::new(AtomicU8::new(0));
-    let installer = |own| {
-        let started = Arc::clone(&started);
+    fn wait_for_participants(
+        own: u8,
+        started: Arc<AtomicU8>,
+    ) -> impl std::future::Future<Output = Result<()>> {
         poll_fn(move |context| {
             let running = started.fetch_or(own, Ordering::AcqRel) | own;
             if running == 0b111 {
-                Poll::Ready(Ok(()))
-            } else {
-                context.waker().wake_by_ref();
-                Poll::Pending
+                return Poll::Ready(Ok(()));
             }
+            context.waker().wake_by_ref();
+            Poll::Pending
         })
-    };
+    }
+    let installer = |own| wait_for_participants(own, Arc::clone(&started));
     tokio::time::timeout(
         Duration::from_secs(1),
         InstallPlan::new(root.path().to_path_buf())

--- a/pnpm/crates/lockfile-verification/src/verify_lockfile_resolutions.rs
+++ b/pnpm/crates/lockfile-verification/src/verify_lockfile_resolutions.rs
@@ -451,12 +451,11 @@ fn collect_invalid_dependency_names(lockfile: &Lockfile) -> std::collections::BT
             push_invalid_aliases(deps.iter().flatten().map(|(alias, _)| alias), &mut invalid);
         }
     }
-    if let Some(snapshots) = lockfile.snapshots.as_ref() {
-        for (key, snapshot) in snapshots {
-            push_invalid_aliases(std::iter::once(&key.name), &mut invalid);
-            for deps in [&snapshot.dependencies, &snapshot.optional_dependencies] {
-                push_invalid_aliases(deps.iter().flatten().map(|(alias, _)| alias), &mut invalid);
-            }
+    let Some(snapshots) = lockfile.snapshots.as_ref() else { return invalid };
+    for (key, snapshot) in snapshots {
+        push_invalid_aliases(std::iter::once(&key.name), &mut invalid);
+        for deps in [&snapshot.dependencies, &snapshot.optional_dependencies] {
+            push_invalid_aliases(deps.iter().flatten().map(|(alias, _)| alias), &mut invalid);
         }
     }
     invalid

--- a/pnpm/crates/network/src/retry/tests.rs
+++ b/pnpm/crates/network/src/retry/tests.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use reqwest::StatusCode;
+use tokio::{io::AsyncReadExt, net::TcpStream};
 
 use super::{RetryOpts, SecureAttemptError, get_secure_bytes, retry_async, should_retry_status};
 use crate::{
@@ -209,10 +210,7 @@ fn metadata_retry_diagnostics_do_not_include_response_body_or_url() {
 
 #[tokio::test]
 async fn metadata_retry_recovers_an_interrupted_response_body() {
-    use tokio::{
-        io::{AsyncReadExt, AsyncWriteExt},
-        net::TcpListener,
-    };
+    use tokio::{io::AsyncWriteExt, net::TcpListener};
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let url = format!("http://{}/metadata", listener.local_addr().unwrap());
@@ -222,13 +220,7 @@ async fn metadata_retry_recovers_an_interrupted_response_body() {
             b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok".as_slice(),
         ] {
             let (mut socket, _) = listener.accept().await.unwrap();
-            let mut request = Vec::new();
-            let mut buffer = [0u8; 1024];
-            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
-                let count = socket.read(&mut buffer).await.unwrap();
-                assert_ne!(count, 0, "request ended before its headers: {request:?}");
-                request.extend_from_slice(&buffer[..count]);
-            }
+            read_request_headers(&mut socket).await;
             socket.write_all(response).await.unwrap();
             socket.shutdown().await.unwrap();
         }
@@ -264,30 +256,7 @@ fn default_matches_pnpm_fetch_retries() {
 async fn bounded_metadata_stops_at_limit_without_retrying_oversized_bodies() {
     for status in [200, 503, 302] {
         for chunked in [false, true] {
-            eprintln!("status={status}, chunked={chunked}");
-            let mut server = mockito::Server::new_async().await;
-            let request = server.mock("GET", "/metadata").with_status(status).expect(1);
-            let request = if chunked {
-                request.with_chunked_body(|writer| writer.write_all(b"0123456789abcdefEXCESS"))
-            } else {
-                request.with_body("0123456789abcdefEXCESS")
-            }
-            .create_async()
-            .await;
-            let response = ThrottledClient::default()
-                .get_limited_bytes_with_secure_auth_and_retry(
-                    &format!("{}/metadata", server.url()),
-                    &AuthHeaders::default(),
-                    None,
-                    instant_retry_opts(2),
-                    16,
-                )
-                .await
-                .unwrap();
-            assert_eq!(response.body, b"0123456789abcdef");
-            assert!(response.body_truncated, "oversized response was accepted");
-            assert_eq!(response.status.as_u16(), status as u16);
-            request.assert_async().await;
+            assert_bounded_metadata(status, chunked).await;
         }
     }
 }
@@ -417,4 +386,41 @@ async fn retry_async_gives_up_after_the_retry_budget() {
     .await;
     assert_eq!(result, Err("error decoding response body"));
     assert_eq!(calls.load(Ordering::Relaxed), 3, "initial attempt plus `retries` retries");
+}
+
+async fn read_request_headers(socket: &mut TcpStream) {
+    let mut request = Vec::new();
+    let mut buffer = [0u8; 1024];
+    while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+        let count = socket.read(&mut buffer).await.unwrap();
+        assert_ne!(count, 0, "request ended before its headers: {request:?}");
+        request.extend_from_slice(&buffer[..count]);
+    }
+}
+
+async fn assert_bounded_metadata(status: usize, chunked: bool) {
+    eprintln!("status={status}, chunked={chunked}");
+    let mut server = mockito::Server::new_async().await;
+    let request = server.mock("GET", "/metadata").with_status(status).expect(1);
+    let request = if chunked {
+        request.with_chunked_body(|writer| writer.write_all(b"0123456789abcdefEXCESS"))
+    } else {
+        request.with_body("0123456789abcdefEXCESS")
+    }
+    .create_async()
+    .await;
+    let response = ThrottledClient::default()
+        .get_limited_bytes_with_secure_auth_and_retry(
+            &format!("{}/metadata", server.url()),
+            &AuthHeaders::default(),
+            None,
+            instant_retry_opts(2),
+            16,
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.body, b"0123456789abcdef");
+    assert!(response.body_truncated, "oversized response was accepted");
+    assert_eq!(response.status.as_u16(), status as u16);
+    request.assert_async().await;
 }

--- a/pnpm/crates/network/src/tests/streaming.rs
+++ b/pnpm/crates/network/src/tests/streaming.rs
@@ -28,17 +28,22 @@ async fn streamed_responses_retain_both_permits_until_consumed_or_dropped() {
     let mock =
         server.mock("GET", "/artifact").with_body("artifact bytes").expect(3).create_async().await;
     let client = ThrottledClient::new_for_installs().with_max_sockets_per_host(Some(1));
+    let initial_permits = client.semaphore.available_permits();
     let url = format!("{}/artifact", server.url());
     for mode in 0..3 {
-        assert_streamed_response_permits(&client, &url, mode).await;
+        assert_streamed_response_permits(&client, &url, mode, initial_permits).await;
     }
     mock.assert_async().await;
 }
 
-async fn assert_streamed_response_permits(client: &ThrottledClient, url: &str, mode: u8) {
+async fn assert_streamed_response_permits(
+    client: &ThrottledClient,
+    url: &str,
+    mode: u8,
+    initial_permits: usize,
+) {
     use futures_util::StreamExt;
 
-    let initial_permits = client.semaphore.available_permits();
     let guard = client.acquire_for_url(url).await;
     let response = guard.get(url).send().await.unwrap();
     let response = guard.retain_for_body(response, Duration::from_secs(30));

--- a/pnpm/crates/network/src/tests/streaming.rs
+++ b/pnpm/crates/network/src/tests/streaming.rs
@@ -24,41 +24,42 @@ fn origin_of_extracts_scheme_host_and_port() {
 
 #[tokio::test]
 async fn streamed_responses_retain_both_permits_until_consumed_or_dropped() {
-    use futures_util::StreamExt;
-
     let mut server = mockito::Server::new_async().await;
     let mock =
         server.mock("GET", "/artifact").with_body("artifact bytes").expect(3).create_async().await;
     let client = ThrottledClient::new_for_installs().with_max_sockets_per_host(Some(1));
-    let initial_permits = client.semaphore.available_permits();
     let url = format!("{}/artifact", server.url());
     for mode in 0..3 {
-        let guard = client.acquire_for_url(&url).await;
-        let response = guard.get(&url).send().await.unwrap();
-        let response = guard.retain_for_body(response, Duration::from_secs(30));
-        assert_eq!(response.url().as_str(), url);
-        assert_eq!(response.content_length(), Some(14));
-        assert_eq!(client.semaphore.available_permits(), initial_permits - 1);
-        assert!(
-            tokio::time::timeout(Duration::from_millis(20), client.acquire_for_url(&url))
-                .await
-                .is_err(),
-        );
-        if mode == 0 {
-            assert_eq!(response.bytes().await.unwrap(), "artifact bytes");
-        } else {
-            let mut stream = Box::pin(response.bytes_stream());
-            assert_eq!(stream.next().await.unwrap().unwrap(), "artifact bytes");
-            if mode == 1 {
-                assert!(stream.next().await.is_none());
-                assert_eq!(client.semaphore.available_permits(), initial_permits);
-            }
-            drop(stream);
-        }
-        let guard = tokio::time::timeout(Duration::from_secs(1), client.acquire_for_url(&url))
-            .await
-            .unwrap();
-        drop(guard);
+        assert_streamed_response_permits(&client, &url, mode).await;
     }
     mock.assert_async().await;
+}
+
+async fn assert_streamed_response_permits(client: &ThrottledClient, url: &str, mode: u8) {
+    use futures_util::StreamExt;
+
+    let initial_permits = client.semaphore.available_permits();
+    let guard = client.acquire_for_url(url).await;
+    let response = guard.get(url).send().await.unwrap();
+    let response = guard.retain_for_body(response, Duration::from_secs(30));
+    assert_eq!(response.url().as_str(), url);
+    assert_eq!(response.content_length(), Some(14));
+    assert_eq!(client.semaphore.available_permits(), initial_permits - 1);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), client.acquire_for_url(url)).await.is_err(),
+    );
+    if mode == 0 {
+        assert_eq!(response.bytes().await.unwrap(), "artifact bytes");
+    } else {
+        let mut stream = Box::pin(response.bytes_stream());
+        assert_eq!(stream.next().await.unwrap().unwrap(), "artifact bytes");
+        if mode == 1 {
+            assert!(stream.next().await.is_none());
+            assert_eq!(client.semaphore.available_permits(), initial_permits);
+        }
+        drop(stream);
+    }
+    let guard =
+        tokio::time::timeout(Duration::from_secs(1), client.acquire_for_url(url)).await.unwrap();
+    drop(guard);
 }

--- a/pnpm/crates/package-manager/src/add/tests/reporting.rs
+++ b/pnpm/crates/package-manager/src/add/tests/reporting.rs
@@ -136,6 +136,52 @@ async fn add_resolves_package_selectors_concurrently_and_reports_in_selector_ord
     // whole suite in parallel, since expiry is itself a failure.
     const OVERLAP_BARRIER_TIMEOUT: Duration = Duration::from_secs(15);
 
+    fn start_request(state: &(Mutex<RequestState>, Condvar), expected_requests: usize) {
+        let (lock, ready) = state;
+        let mut requests = lock.lock().unwrap();
+        requests.active += 1;
+        requests.started += 1;
+        requests.max_active = requests.max_active.max(requests.active);
+        ready.notify_all();
+        let (mut requests, wait) = ready
+            .wait_timeout_while(requests, OVERLAP_BARRIER_TIMEOUT, |requests| {
+                requests.started < expected_requests && !requests.barrier_expired
+            })
+            .unwrap();
+        // `wait_timeout_while` re-checks the predicate before it
+        // reports a timeout, so `timed_out()` means the peers were
+        // still missing when the budget ran out — never that the
+        // last one arrived on the deadline.
+        if wait.timed_out() {
+            requests.barrier_expired = true;
+            ready.notify_all();
+        }
+        drop(requests);
+    }
+
+    fn assert_catalog_warning_order(events: &[LogEvent]) {
+        let warning_messages: Vec<_> = events
+            .iter()
+            .filter_map(|event| match event {
+                LogEvent::Pnpm(log)
+                    if log.level == LogLevel::Warn
+                        && log.message.starts_with("Catalog version mismatch") =>
+                {
+                    Some(log.message.as_str())
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            warning_messages,
+            [
+                r#"Catalog version mismatch for "@one/a": using direct version "1.0.0" instead of catalog version "9.0.0"."#,
+                r#"Catalog version mismatch for "@two/b": using direct version "1.0.0" instead of catalog version "9.0.0"."#,
+                r#"Catalog version mismatch for "@three/c": using direct version "1.0.0" instead of catalog version "9.0.0"."#,
+            ],
+        );
+    }
+
     let dir = tempdir().unwrap();
     let project_root = dir.path().join("project");
     let modules_dir = project_root.join("node_modules");
@@ -175,28 +221,9 @@ async fn add_resolves_package_selectors_concurrently_and_reports_in_selector_ord
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_chunked_body(move |writer| {
-                let (lock, ready) = &*state;
-                let mut requests = lock.lock().unwrap();
-                requests.active += 1;
-                requests.started += 1;
-                requests.max_active = requests.max_active.max(requests.active);
-                ready.notify_all();
-                let (mut requests, wait) = ready
-                    .wait_timeout_while(requests, OVERLAP_BARRIER_TIMEOUT, |requests| {
-                        requests.started < packages.len() && !requests.barrier_expired
-                    })
-                    .unwrap();
-                // `wait_timeout_while` re-checks the predicate before it
-                // reports a timeout, so `timed_out()` means the peers were
-                // still missing when the budget ran out — never that the
-                // last one arrived on the deadline.
-                if wait.timed_out() {
-                    requests.barrier_expired = true;
-                    ready.notify_all();
-                }
-                drop(requests);
+                start_request(&state, packages.len());
                 std::thread::sleep(Duration::from_millis(response_delay_ms));
-                requests = lock.lock().unwrap();
+                let mut requests = state.0.lock().unwrap();
                 requests.active -= 1;
                 drop(requests);
                 writer.write_all(response_body.as_bytes())
@@ -256,26 +283,7 @@ async fn add_resolves_package_selectors_concurrently_and_reports_in_selector_ord
 
     {
         let events = EVENTS.lock().unwrap();
-        let warning_messages: Vec<_> = events
-            .iter()
-            .filter_map(|event| match event {
-                LogEvent::Pnpm(log)
-                    if log.level == LogLevel::Warn
-                        && log.message.starts_with("Catalog version mismatch") =>
-                {
-                    Some(log.message.as_str())
-                }
-                _ => None,
-            })
-            .collect();
-        assert_eq!(
-            warning_messages,
-            [
-                r#"Catalog version mismatch for "@one/a": using direct version "1.0.0" instead of catalog version "9.0.0"."#,
-                r#"Catalog version mismatch for "@two/b": using direct version "1.0.0" instead of catalog version "9.0.0"."#,
-                r#"Catalog version mismatch for "@three/c": using direct version "1.0.0" instead of catalog version "9.0.0"."#,
-            ],
-        );
+        assert_catalog_warning_order(&events);
     }
 
     for (latest, _packument) in mocks {

--- a/pnpm/crates/package-manager/src/fast_update_importers/locked_versions.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/locked_versions.rs
@@ -1,5 +1,6 @@
 use node_semver::{Range, Version};
 use pnpm_lockfile::{Lockfile, PackageKey, PkgName};
+use pnpm_package_manifest::DependencyGroup;
 use std::collections::HashMap;
 
 /// The lockfile's `snapshots:` block, which an absorbed edge reads the
@@ -13,25 +14,24 @@ pub(super) fn is_linked_from_a_survivor(
     importer_id: &str,
     stale: &[String],
 ) -> bool {
-    lockfile.importers.iter().any(|(survivor_id, importer)| {
-        if stale.iter().any(|id| id == survivor_id) {
-            return false;
+    for (survivor_id, importer) in &lockfile.importers {
+        if stale.contains(survivor_id) {
+            continue;
         }
-        [
-            importer.dependencies.as_ref(),
-            importer.dev_dependencies.as_ref(),
-            importer.optional_dependencies.as_ref(),
-        ]
-        .into_iter()
-        .flatten()
-        .any(|group| {
-            group.values().any(|spec| {
-                spec.version
-                    .as_link_target()
-                    .is_some_and(|target| link_resolves_to(survivor_id, target, importer_id))
-            })
-        })
-    })
+        for (_, spec) in importer.dependencies_by_groups([
+            DependencyGroup::Prod,
+            DependencyGroup::Dev,
+            DependencyGroup::Optional,
+        ]) {
+            let Some(target) = spec.version.as_link_target() else {
+                continue;
+            };
+            if link_resolves_to(survivor_id, target, importer_id) {
+                return true;
+            }
+        }
+    }
+    false
 }
 /// Whether `target`, a `link:` path relative to `from`'s directory,
 /// names the importer `importer_id`.

--- a/pnpm/crates/package-manager/src/install/lockfile_freshness/manifest.rs
+++ b/pnpm/crates/package-manager/src/install/lockfile_freshness/manifest.rs
@@ -105,16 +105,13 @@ pub(in super::super) fn exclude_linked_dependencies(manifest: &mut PackageManife
     };
     for group in [DependencyGroup::Dev, DependencyGroup::Prod, DependencyGroup::Optional] {
         let group: &str = group.into();
-        if let Some(dependencies) =
-            manifest.get_mut(group).and_then(serde_json::Value::as_object_mut)
-        {
-            dependencies.retain(|_, specifier| {
-                let Some(specifier) = specifier.as_str() else {
-                    return true;
-                };
-                !specifier.starts_with("link:")
-            });
-        }
+        let Some(dependencies) = manifest.get_mut(group).and_then(serde_json::Value::as_object_mut)
+        else {
+            continue;
+        };
+        dependencies.retain(|_, specifier| {
+            specifier.as_str().is_none_or(|specifier| !specifier.starts_with("link:"))
+        });
     }
 }
 // Only overrides and excluded links require a clone; all other freshness checks borrow the manifest.

--- a/pnpm/crates/package-manager/src/install/tests/hooks.rs
+++ b/pnpm/crates/package-manager/src/install/tests/hooks.rs
@@ -2,7 +2,7 @@ use super::{
     super::{apply_deploy_manifest_hook, apply_deploy_manifest_hook_to_arc},
     first_hook_log, install_with_pnpmfile, install_with_pnpmfile_reporter,
 };
-use pnpm_reporter::{LogEvent, LogLevel, Reporter};
+use pnpm_reporter::{HookLog, LogEvent, LogLevel, Reporter};
 use pnpm_testing_utils::registry::TestRegistry;
 use std::sync::{Arc, Mutex};
 use tempfile::tempdir;
@@ -332,7 +332,11 @@ async fn pre_resolution_hook_log_is_forwarded_to_pnpm_hook_channel() {
     .expect("install should succeed");
 
     let captured = EVENTS.lock().unwrap();
-    let find_hook_event = |level: LogLevel, message: &str| {
+    fn find_hook_event<'a>(
+        captured: &'a [LogEvent],
+        level: LogLevel,
+        message: &str,
+    ) -> &'a HookLog {
         captured
             .iter()
             .find_map(|event| match event {
@@ -348,12 +352,12 @@ async fn pre_resolution_hook_log_is_forwarded_to_pnpm_hook_channel() {
             .unwrap_or_else(|| {
                 panic!("a pnpm:hook {level:?} event with message {message:?} must be emitted")
             })
-    };
+    }
 
     for log in [
-        find_hook_event(LogLevel::Info, "Starting resolution"),
-        find_hook_event(LogLevel::Warn, "Some packages may need updates"),
-        find_hook_event(LogLevel::Info, "raw hook output"),
+        find_hook_event(&captured, LogLevel::Info, "Starting resolution"),
+        find_hook_event(&captured, LogLevel::Warn, "Some packages may need updates"),
+        find_hook_event(&captured, LogLevel::Info, "raw hook output"),
     ] {
         assert_eq!(log.from, "pnpmfile", "preResolution from is hardcoded to 'pnpmfile'");
         assert_eq!(log.prefix, *dir.path().to_string_lossy(), "prefix must be the lockfile dir");

--- a/pnpm/crates/package-manager/src/update/seed_policy.rs
+++ b/pnpm/crates/package-manager/src/update/seed_policy.rs
@@ -203,12 +203,13 @@ pub(super) fn name_matched_seed_policy(
         scope.selectors.iter().map(|selector| selector.pattern.clone()).collect::<Vec<_>>();
     let matcher = create_matcher(&patterns);
     for (name, group, previous) in scope.direct {
-        if matcher.matches(name) {
-            if scope.save {
-                plan.bump_targets.entry(name.clone()).or_insert_with(|| (*group, previous.clone()));
-            }
-            plan.drop_targets.insert(name.clone(), None);
+        if !matcher.matches(name) {
+            continue;
         }
+        if scope.save {
+            plan.bump_targets.entry(name.clone()).or_insert_with(|| (*group, previous.clone()));
+        }
+        plan.drop_targets.insert(name.clone(), None);
     }
     widen_drop_targets_by_matcher(scope.lockfile, plan, &matcher);
     plan.drop_only(scope.max_depth)

--- a/pnpm/crates/package-manifest/src/lib.rs
+++ b/pnpm/crates/package-manifest/src/lib.rs
@@ -523,20 +523,18 @@ fn extract_license_field(field: &serde_json::Value) -> Option<String> {
 }
 
 fn extract_license_type(entry: &serde_json::Value) -> Option<&str> {
-    entry.as_str().filter(|license| !license.is_empty()).or_else(|| {
-        entry.as_object().and_then(|entry| {
-            entry
-                .get("type")
-                .and_then(serde_json::Value::as_str)
-                .filter(|license| !license.is_empty())
-                .or_else(|| {
-                    entry
-                        .get("name")
-                        .and_then(serde_json::Value::as_str)
-                        .filter(|license| !license.is_empty())
-                })
-        })
-    })
+    if let Some(license) = entry.as_str().filter(|license| !license.is_empty()) {
+        return Some(license);
+    }
+    let entry = entry.as_object()?;
+    for key in ["type", "name"] {
+        if let Some(license) =
+            entry.get(key).and_then(serde_json::Value::as_str).filter(|license| !license.is_empty())
+        {
+            return Some(license);
+        }
+    }
+    None
 }
 
 mod runtime;

--- a/pnpm/crates/pnpr-client/tests/integration.rs
+++ b/pnpm/crates/pnpr-client/tests/integration.rs
@@ -164,21 +164,22 @@ async fn capture_one_request_with_response(listener: TcpListener, response: Stri
         // boundary is located in the raw bytes so the index stays aligned
         // with `buffer.len()` below: decoding first would rewrite any
         // non-UTF-8 byte as a longer replacement character and shift it.
-        if let Some(headers_end) = buffer.windows(4).position(|window| window == b"\r\n\r\n") {
-            let headers = String::from_utf8_lossy(&buffer[..headers_end]);
-            let content_length = headers
-                .lines()
-                .find_map(|line| {
-                    let (name, value) = line.split_once(':')?;
-                    name.trim()
-                        .eq_ignore_ascii_case("content-length")
-                        .then(|| value.trim().parse::<usize>().ok())
-                        .flatten()
-                })
-                .unwrap_or(0);
-            if buffer.len() >= headers_end + 4 + content_length {
-                break;
-            }
+        let Some(headers_end) = buffer.windows(4).position(|window| window == b"\r\n\r\n") else {
+            continue;
+        };
+        let headers = String::from_utf8_lossy(&buffer[..headers_end]);
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.trim()
+                    .eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().ok())
+                    .flatten()
+            })
+            .unwrap_or(0);
+        if buffer.len() >= headers_end + 4 + content_length {
+            break;
         }
     }
     let _ = socket.write_all(response.as_bytes()).await;

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tree_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tree_ctx.rs
@@ -457,10 +457,8 @@ impl TreeCtx {
         for name in names {
             let mut bucket = seed.get(name).cloned().unwrap_or_default();
             bucket.retain(|_, entry| entry.selector_type() == VersionSelectorType::Version);
-            if let Some(run_bucket) = run.versions.get(name) {
-                for (selector, entry) in run_bucket {
-                    bucket.entry(selector.clone()).or_insert_with(|| entry.clone());
-                }
+            for (selector, entry) in run.versions.get(name).into_iter().flatten() {
+                bucket.entry(selector.clone()).or_insert_with(|| entry.clone());
             }
             if !bucket.is_empty() {
                 out.insert(name.to_string(), bucket);

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache/realize_children.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache/realize_children.rs
@@ -75,10 +75,11 @@ impl Walker<'_> {
                 .dependencies_tree
                 .get(parent_node_id)
                 .is_some_and(|node| &*node.resolved_package_id == current_pkg_id);
-            if same_pkg {
-                for (alias, child_node_id) in self.realize_children(parent_node_id).0.iter() {
-                    children.entry(alias.clone()).or_insert_with(|| child_node_id.clone());
-                }
+            if !same_pkg {
+                continue;
+            }
+            for (alias, child_node_id) in self.realize_children(parent_node_id).0.iter() {
+                children.entry(alias.clone()).or_insert_with(|| child_node_id.clone());
             }
         }
         children

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests/behavior.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests/behavior.rs
@@ -177,24 +177,24 @@ async fn deprecated_manifests_notify_the_deprecation_sink_unless_allowed() {
         .expect("resolve workspace with a deprecated dependency");
 
         let notifications = notifications.lock().unwrap();
-        if expect_notification {
-            let [deprecation] = notifications.as_slice() else {
-                panic!("expected one deprecation for range {allowed_range:?}: {notifications:?}");
-            };
-            assert_eq!(deprecation.pkg_name, "old");
-            assert_eq!(deprecation.pkg_version, "1.2.0");
-            assert_eq!(deprecation.deprecated, "use new instead");
-            assert_eq!(deprecation.depth, 0);
-            assert_eq!(
-                deprecation.prefix,
-                std::path::PathBuf::from("/repo").join("root").display().to_string(),
-            );
-        } else {
+        if !expect_notification {
             assert!(
                 notifications.is_empty(),
                 "range {allowed_range:?} must suppress the warning: {notifications:?}",
             );
+            continue;
         }
+        let [deprecation] = notifications.as_slice() else {
+            panic!("expected one deprecation for range {allowed_range:?}: {notifications:?}");
+        };
+        assert_eq!(deprecation.pkg_name, "old");
+        assert_eq!(deprecation.pkg_version, "1.2.0");
+        assert_eq!(deprecation.deprecated, "use new instead");
+        assert_eq!(deprecation.depth, 0);
+        assert_eq!(
+            deprecation.prefix,
+            std::path::PathBuf::from("/repo").join("root").display().to_string(),
+        );
     }
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests/optional_dependencies.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests/optional_dependencies.rs
@@ -281,10 +281,9 @@ async fn skips_an_optional_dependency_for_every_coded_resolver_failure() {
         let importers = [WorkspaceImporter { id: ".".to_string(), manifest: &manifest }];
         let skipped = std::sync::Arc::new(Mutex::new(Vec::new()));
         let mut opts = workspace_opts(false, false);
-        opts.skipped_optional_log = Some(std::sync::Arc::new({
-            let skipped = std::sync::Arc::clone(&skipped);
-            move |notification| skipped.lock().unwrap().push(notification)
-        }));
+        let sink = std::sync::Arc::clone(&skipped);
+        opts.skipped_optional_log =
+            Some(std::sync::Arc::new(move |notification| sink.lock().unwrap().push(notification)));
         let result = resolve_workspace(
             &resolver,
             &importers,

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/metadata_fetch.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/metadata_fetch.rs
@@ -154,7 +154,8 @@ impl NpmResolutionVerifier {
             let time_map = pkg.time.as_ref().map(|raw| {
                 raw.iter()
                     .filter_map(|(version, value)| {
-                        value.as_str().map(|ts| (version.clone(), ts.to_string()))
+                        let timestamp = value.as_str()?;
+                        Some((version.clone(), timestamp.to_string()))
                     })
                     .collect::<PublishedAtTimeMap>()
                     .pipe(Arc::new)

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta/release_age.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta/release_age.rs
@@ -182,7 +182,8 @@ pub(super) fn repopulate_dist_tags(
             filtered_versions
                 .keys()
                 .filter_map(|raw| {
-                    Version::parse(raw).ok().map(|parsed| (parsed, raw, OnceCell::new()))
+                    let parsed = Version::parse(raw).ok()?;
+                    Some((parsed, raw, OnceCell::new()))
                 })
                 .collect()
         });

--- a/pnpm/crates/resolving-resolver-base/src/resolve.rs
+++ b/pnpm/crates/resolving-resolver-base/src/resolve.rs
@@ -177,14 +177,13 @@ impl PreferredVersionsOverlay {
         let mut versions: Vec<&str> = Vec::new();
         let mut layer = Some(self);
         while let Some(current) = layer {
-            if let Some(found) = current.entries.get(name) {
-                for version in found {
-                    if !versions.contains(&version.as_str()) {
-                        versions.push(version);
-                    }
+            layer = current.parent.as_deref();
+            let Some(found) = current.entries.get(name) else { continue };
+            for version in found {
+                if !versions.contains(&version.as_str()) {
+                    versions.push(version);
                 }
             }
-            layer = current.parent.as_deref();
         }
         versions
     }

--- a/pnpm/crates/shared-artifact-protocol/src/compatibility.rs
+++ b/pnpm/crates/shared-artifact-protocol/src/compatibility.rs
@@ -25,23 +25,25 @@ pub fn compatibility_rank_prevalidated(
             .iter()
             .enumerate()
             .flat_map(|(index, supported)| {
-                tags.iter().filter_map(move |artifact| {
-                    if artifact == supported {
-                        return u64::try_from(index).ok();
-                    }
-                    let distance = version_floor_rank(
-                        parse_compatibility_tag(supported).ok()?,
-                        parse_compatibility_tag(artifact).ok()?,
-                    )?;
-                    u64::try_from(index)
-                        .ok()?
-                        .checked_mul(COMPATIBILITY_FLOOR_RANK_STRIDE)?
-                        .checked_add(COMPATIBILITY_FLOOR_RANK_OFFSET)?
-                        .checked_add(distance)
-                })
+                tags.iter().filter_map(move |artifact| rank_tag(index, supported, artifact))
             })
             .min(),
     }
+}
+
+fn rank_tag(index: usize, supported: &str, artifact: &str) -> Option<u64> {
+    if artifact == supported {
+        return u64::try_from(index).ok();
+    }
+    let distance = version_floor_rank(
+        parse_compatibility_tag(supported).ok()?,
+        parse_compatibility_tag(artifact).ok()?,
+    )?;
+    u64::try_from(index)
+        .ok()?
+        .checked_mul(COMPATIBILITY_FLOOR_RANK_STRIDE)?
+        .checked_add(COMPATIBILITY_FLOOR_RANK_OFFSET)?
+        .checked_add(distance)
 }
 
 pub fn linux_glibc_tag(platform: LinuxGlibcPlatform<'_>) -> Result<String, ArtifactProtocolError> {

--- a/pnpm/crates/tarball/src/tests/archive_contract.rs
+++ b/pnpm/crates/tarball/src/tests/archive_contract.rs
@@ -336,11 +336,7 @@ async fn formats_share_retry_classification_and_never_publish_failed_integrity()
             };
             let error = container.ingest(&input).await.unwrap_err();
             eprintln!("failed fetch: {error}");
-            if status == 200 {
-                assert!(matches!(error, TarballError::Checksum(_)));
-            } else {
-                assert!(matches!(error, TarballError::HttpStatus(_)));
-            }
+            assert_fetch_error(status, &error);
             input.store_index_writer = None;
             drop(writer);
             StoreIndexWriter::drain(task, "contract test").await;
@@ -351,5 +347,13 @@ async fn formats_share_retry_classification_and_never_publish_failed_integrity()
             assert!(matches!(error, TarballError::NoOfflineTarball { .. }));
             request.assert_async().await;
         }
+    }
+}
+
+fn assert_fetch_error(status: usize, error: &TarballError) {
+    if status == 200 {
+        assert!(matches!(error, TarballError::Checksum(_)));
+    } else {
+        assert!(matches!(error, TarballError::HttpStatus(_)));
     }
 }

--- a/pnpm/crates/tarball/src/tests/behavior_retries_other_4xx_codes.rs
+++ b/pnpm/crates/tarball/src/tests/behavior_retries_other_4xx_codes.rs
@@ -392,7 +392,7 @@ async fn run_with_mem_cache_recovers_from_owning_fetch_error() {
 async fn started_fires_for_connection_level_failures() {
     use std::sync::Mutex;
 
-    use pnpm_reporter::{FetchingProgressMessage, LogEvent};
+    use pnpm_reporter::{FetchingProgressLog, FetchingProgressMessage, LogEvent};
 
     static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
 
@@ -435,10 +435,10 @@ async fn started_fires_for_connection_level_failures() {
     let started: Vec<Option<u64>> = captured
         .iter()
         .filter_map(|event| match event {
-            LogEvent::FetchingProgress(log) => match &log.message {
-                FetchingProgressMessage::Started { size, .. } => Some(*size),
-                FetchingProgressMessage::InProgress { .. } => None,
-            },
+            LogEvent::FetchingProgress(FetchingProgressLog {
+                message: FetchingProgressMessage::Started { size, .. },
+                ..
+            }) => Some(*size),
             _ => None,
         })
         .collect();

--- a/pnpm/crates/tarball/src/tests/streaming_fetching_progress_and_fetched.rs
+++ b/pnpm/crates/tarball/src/tests/streaming_fetching_progress_and_fetched.rs
@@ -27,7 +27,9 @@ use super::{
 async fn fetching_progress_and_fetched_events_fire_during_download() {
     use std::sync::Mutex;
 
-    use pnpm_reporter::{FetchingProgressMessage, LogEvent, ProgressMessage, Reporter as _};
+    use pnpm_reporter::{
+        FetchingProgressLog, FetchingProgressMessage, LogEvent, ProgressMessage, Reporter as _,
+    };
 
     static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
 
@@ -81,13 +83,13 @@ async fn fetching_progress_and_fetched_events_fire_during_download() {
     let started: Vec<(u32, Option<u64>)> = captured
         .iter()
         .filter_map(|event| match event {
-            LogEvent::FetchingProgress(log) => match &log.message {
-                FetchingProgressMessage::Started { attempt, package_id, size } => {
-                    assert_eq!(package_id, "@fastify/error@3.3.0");
-                    Some((*attempt, *size))
-                }
-                FetchingProgressMessage::InProgress { .. } => None,
-            },
+            LogEvent::FetchingProgress(FetchingProgressLog {
+                message: FetchingProgressMessage::Started { attempt, package_id, size },
+                ..
+            }) => {
+                assert_eq!(package_id, "@fastify/error@3.3.0");
+                Some((*attempt, *size))
+            }
             _ => None,
         })
         .collect();

--- a/pnpm/crates/versioning/src/plan/configuration.rs
+++ b/pnpm/crates/versioning/src/plan/configuration.rs
@@ -35,17 +35,25 @@ pub(super) fn resolve_fixed_groups(
 ) -> Result<Vec<Vec<String>>, VersioningError> {
     let mut groups = Vec::new();
     for group in versioning.map(|settings| settings.fixed.as_slice()).unwrap_or_default() {
-        let mut dirs = Vec::new();
-        for reference in group {
-            for dir in resolve_config_ref(refs, reference, "versioning.fixed")? {
-                if participants.contains_key(&dir) {
-                    dirs.push(dir);
-                }
-            }
-        }
-        groups.push(dirs);
+        groups.push(resolve_fixed_group(refs, participants, group)?);
     }
     Ok(groups)
+}
+
+fn resolve_fixed_group(
+    refs: &ProjectRefIndex,
+    participants: &BTreeMap<String, Participant<'_>>,
+    group: &[String],
+) -> Result<Vec<String>, VersioningError> {
+    let mut dirs = Vec::new();
+    for reference in group {
+        for dir in resolve_config_ref(refs, reference, "versioning.fixed")? {
+            if participants.contains_key(&dir) {
+                dirs.push(dir);
+            }
+        }
+    }
+    Ok(dirs)
 }
 
 pub(super) fn validate_fixed_group_lanes(

--- a/pnpm/crates/workspace-manifest-writer/src/edit/scanning.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/edit/scanning.rs
@@ -313,26 +313,27 @@ fn collect_entries(all: &[Line<'_>], from: usize, to: usize, entry_indent: usize
     let mut entries = Vec::new();
     let mut idx = from;
     while idx < to {
-        if structural_indent(all[idx].content) == Some(entry_indent)
-            && let Some(key) = line_key(all[idx].content)
-        {
-            let block_end_idx = ((idx + 1)..to)
-                .find(|&next| {
-                    structural_indent(all[next].content)
-                        .is_some_and(|indent| indent <= entry_indent)
-                })
-                .unwrap_or(to);
-            let block_end = all.get(block_end_idx).map_or(all[to - 1].end, |line| line.start);
-            entries.push(EntryPos {
-                key,
-                line_start: all[idx].start,
-                line_end: all[idx].end,
-                block_end,
-            });
-            idx = block_end_idx;
-        } else {
+        if structural_indent(all[idx].content) != Some(entry_indent) {
             idx += 1;
+            continue;
         }
+        let Some(key) = line_key(all[idx].content) else {
+            idx += 1;
+            continue;
+        };
+        let block_end_idx = ((idx + 1)..to)
+            .find(|&next| {
+                structural_indent(all[next].content).is_some_and(|indent| indent <= entry_indent)
+            })
+            .unwrap_or(to);
+        let block_end = all.get(block_end_idx).map_or(all[to - 1].end, |line| line.start);
+        entries.push(EntryPos {
+            key,
+            line_start: all[idx].start,
+            line_end: all[idx].end,
+            block_end,
+        });
+        idx = block_end_idx;
     }
     entries
 }

--- a/pnpm/tasks/micro-benchmark/src/workspace_sort.rs
+++ b/pnpm/tasks/micro-benchmark/src/workspace_sort.rs
@@ -84,32 +84,34 @@ pub fn bench_workspace_sort(criterion: &mut Criterion) {
     let projects = synthetic_workspace();
     let mut group = criterion.benchmark_group("workspace_sort");
     group.bench_function("chained_projects", |bencher| {
-        bencher.iter(|| {
-            let graph = create_projects_graph(
-                projects.iter().map(SyntheticRef).collect(),
-                &CreateProjectsGraphOptions {
-                    link_workspace_packages: Some(true),
-                    ..CreateProjectsGraphOptions::default()
-                },
-            )
-            .graph;
-            let dirs: Vec<PathBuf> = graph.keys().cloned().collect();
-            let included: HashSet<&Path> = dirs.iter().map(PathBuf::as_path).collect();
-            let edges: HashMap<PathBuf, Vec<PathBuf>> = graph
-                .iter()
-                .map(|(dir, node)| {
-                    let dependencies = node
-                        .dependencies
-                        .iter()
-                        .filter(|dependency| included.contains(dependency.as_path()))
-                        .cloned()
-                        .collect();
-                    (dir.clone(), dependencies)
-                })
-                .collect();
-            let sequenced = graph_sequencer(&edges, &dirs);
-            black_box((sequenced.cycles.len(), sequenced.order.len()))
-        });
+        bencher.iter(|| black_box(sort_workspace(&projects)));
     });
     group.finish();
+}
+
+fn sort_workspace(projects: &[SyntheticProject]) -> (usize, usize) {
+    let graph = create_projects_graph(
+        projects.iter().map(SyntheticRef).collect(),
+        &CreateProjectsGraphOptions {
+            link_workspace_packages: Some(true),
+            ..CreateProjectsGraphOptions::default()
+        },
+    )
+    .graph;
+    let dirs: Vec<PathBuf> = graph.keys().cloned().collect();
+    let included: HashSet<&Path> = dirs.iter().map(PathBuf::as_path).collect();
+    let edges: HashMap<PathBuf, Vec<PathBuf>> = graph
+        .iter()
+        .map(|(dir, node)| {
+            let dependencies = node
+                .dependencies
+                .iter()
+                .filter(|dependency| included.contains(dependency.as_path()))
+                .cloned()
+                .collect();
+            (dir.clone(), dependencies)
+        })
+        .collect();
+    let sequenced = graph_sequencer(&edges, &dirs);
+    (sequenced.cycles.len(), sequenced.order.len())
 }

--- a/pnpr/crates/auth/src/lib.rs
+++ b/pnpr/crates/auth/src/lib.rs
@@ -433,20 +433,17 @@ impl UserBackend for UserStore {
         }
         let next_step = {
             let mut users = self.users.lock().expect("UserStore mutex poisoned");
-            if let Some(stored) = users.get(username).cloned() {
-                NextStep::VerifyExisting(stored)
-            } else {
-                // Re-check the cap under the lock to make the limit hold
-                // under concurrent adduser bursts. A second writer that
-                // raced in while we were hashing could otherwise push
-                // past the cap.
-                if let MaxUsers::Limited(max) = self.max_users
-                    && (users.len() as u64) >= max
-                {
+            match (users.get(username).cloned(), self.max_users) {
+                (Some(stored), _) => NextStep::VerifyExisting(stored),
+                // Re-check under the lock because another registration may
+                // have filled the store while we were hashing.
+                (None, MaxUsers::Limited(max)) if users.len() as u64 >= max => {
                     return Err(RegistryError::TooManyUsers { max });
                 }
-                users.insert(username.to_string(), hash);
-                NextStep::Persist(serialize_htpasswd(&users))
+                (None, _) => {
+                    users.insert(username.to_string(), hash);
+                    NextStep::Persist(serialize_htpasswd(&users))
+                }
             }
         };
         match next_step {

--- a/pnpr/crates/auth/src/sqlx_backend.rs
+++ b/pnpr/crates/auth/src/sqlx_backend.rs
@@ -45,6 +45,26 @@ impl<Db> SqlAuth<Db> {
         }
     }
 
+    async fn check_registration_capacity(&self) -> Result<()>
+    where
+        Db: AuthSqlBackend,
+    {
+        let max = match self.max_users {
+            MaxUsers::Disabled => return Err(RegistryError::RegistrationDisabled),
+            MaxUsers::Unlimited => return Ok(()),
+            MaxUsers::Limited(max) => max,
+        };
+        if with_auth_timeout(self.timeout, self.db.user_count()).await? < max {
+            return Ok(());
+        }
+        if self.reconcile_capped_counter_once_per_interval().await?
+            && with_auth_timeout(self.timeout, self.db.user_count()).await? < max
+        {
+            return Ok(());
+        }
+        Err(RegistryError::TooManyUsers { max })
+    }
+
     async fn reconcile_capped_counter_once_per_interval(&self) -> Result<bool>
     where
         Db: AuthSqlBackend,
@@ -113,20 +133,7 @@ where
             return verify_returning_user(&stored.username, password, stored.bcrypt_hash).await;
         }
 
-        match self.max_users {
-            MaxUsers::Disabled => return Err(RegistryError::RegistrationDisabled),
-            MaxUsers::Limited(max) => {
-                if with_auth_timeout(self.timeout, self.db.user_count()).await? >= max {
-                    let reconciled_below_cap =
-                        self.reconcile_capped_counter_once_per_interval().await?
-                            && with_auth_timeout(self.timeout, self.db.user_count()).await? < max;
-                    if !reconciled_below_cap {
-                        return Err(RegistryError::TooManyUsers { max });
-                    }
-                }
-            }
-            MaxUsers::Unlimited => {}
-        }
+        self.check_registration_capacity().await?;
 
         let hash = hash_bcrypt(password.to_string(), DEFAULT_BCRYPT_COST).await?;
         match self.db.insert_user(username, &hash, self.max_users).await? {

--- a/pnpr/crates/auth/src/sqlx_backend/mysql.rs
+++ b/pnpr/crates/auth/src/sqlx_backend/mysql.rs
@@ -6,7 +6,7 @@ use super::{
 use async_trait::async_trait;
 use pnpr_config::{MaxUsers, SqlBackendSettings};
 use pnpr_error::{RegistryError, Result};
-use sqlx::{MySqlPool, Row, mysql::MySqlPoolOptions};
+use sqlx::{MySqlConnection, MySqlPool, Row, mysql::MySqlPoolOptions};
 use std::time::Duration;
 
 #[derive(Debug)]
@@ -102,54 +102,33 @@ impl AuthSqlBackend for MysqlDatabase {
         max_users: MaxUsers,
     ) -> Result<InsertUser> {
         let mut can_retry_after_reconcile = matches!(max_users, MaxUsers::Limited(_));
-        loop {
+        let mut tx = loop {
             let mut tx = self.pool.begin().await?;
-            match max_users {
-                MaxUsers::Limited(max) => {
-                    let max = sql_max_users(max, "mysql")?;
-                    let updated = sqlx::query(
-                        "UPDATE auth_counters SET value = value + 1
-                         WHERE name = ? AND value < ?",
-                    )
-                    .bind("users")
-                    .bind(max)
-                    .execute(&mut *tx)
-                    .await?;
-                    if updated.rows_affected() == 0 {
-                        tx.rollback().await?;
-                        if can_retry_after_reconcile {
-                            can_retry_after_reconcile = false;
-                            if self.reconcile_user_counter_overcount_impl().await? {
-                                continue;
-                            }
-                        }
-                        return self.existing_or_cap_reached(username).await;
-                    }
-                }
-                MaxUsers::Unlimited => {
-                    sqlx::query("UPDATE auth_counters SET value = value + 1 WHERE name = ?")
-                        .bind("users")
-                        .execute(&mut *tx)
-                        .await?;
-                }
-                MaxUsers::Disabled => {}
+            if claim_user_slot(&mut tx, max_users).await? {
+                break tx;
             }
-            let inserted = sqlx::query("INSERT INTO users (username, bcrypt_hash) VALUES (?, ?)")
-                .bind(username)
-                .bind(bcrypt_hash)
-                .execute(&mut *tx)
-                .await;
-            match inserted {
-                Ok(_) => {
-                    tx.commit().await?;
-                    return Ok(InsertUser::Created);
-                }
-                Err(err) if is_unique_violation(&err) => {
-                    tx.rollback().await?;
-                    return self.existing_or_cap_reached(username).await;
-                }
-                Err(err) => return Err(err.into()),
+            tx.rollback().await?;
+            if !std::mem::take(&mut can_retry_after_reconcile)
+                || !self.reconcile_user_counter_overcount_impl().await?
+            {
+                return self.existing_or_cap_reached(username).await;
             }
+        };
+        let inserted = sqlx::query("INSERT INTO users (username, bcrypt_hash) VALUES (?, ?)")
+            .bind(username)
+            .bind(bcrypt_hash)
+            .execute(&mut *tx)
+            .await;
+        match inserted {
+            Ok(_) => {
+                tx.commit().await?;
+                Ok(InsertUser::Created)
+            }
+            Err(err) if is_unique_violation(&err) => {
+                tx.rollback().await?;
+                self.existing_or_cap_reached(username).await
+            }
+            Err(err) => Err(err.into()),
         }
     }
 
@@ -354,4 +333,29 @@ fn is_duplicate_index(err: &sqlx::Error) -> bool {
     err.as_database_error()
         .and_then(|err| err.try_downcast_ref::<sqlx::mysql::MySqlDatabaseError>())
         .is_some_and(|err| err.number() == 1061)
+}
+
+async fn claim_user_slot(connection: &mut MySqlConnection, max_users: MaxUsers) -> Result<bool> {
+    match max_users {
+        MaxUsers::Limited(max) => {
+            let max = sql_max_users(max, "mysql")?;
+            let updated = sqlx::query(
+                "UPDATE auth_counters SET value = value + 1
+                 WHERE name = ? AND value < ?",
+            )
+            .bind("users")
+            .bind(max)
+            .execute(connection)
+            .await?;
+            Ok(updated.rows_affected() != 0)
+        }
+        MaxUsers::Unlimited => {
+            sqlx::query("UPDATE auth_counters SET value = value + 1 WHERE name = ?")
+                .bind("users")
+                .execute(connection)
+                .await?;
+            Ok(true)
+        }
+        MaxUsers::Disabled => Ok(true),
+    }
 }

--- a/pnpr/crates/auth/src/sqlx_backend/postgres.rs
+++ b/pnpr/crates/auth/src/sqlx_backend/postgres.rs
@@ -6,7 +6,7 @@ use super::{
 use async_trait::async_trait;
 use pnpr_config::{MaxUsers, SqlBackendSettings};
 use pnpr_error::{RegistryError, Result};
-use sqlx::{PgPool, Row, postgres::PgPoolOptions};
+use sqlx::{PgConnection, PgPool, Row, postgres::PgPoolOptions};
 use std::time::Duration;
 
 #[derive(Debug)]
@@ -94,54 +94,33 @@ impl AuthSqlBackend for PostgresDatabase {
         max_users: MaxUsers,
     ) -> Result<InsertUser> {
         let mut can_retry_after_reconcile = matches!(max_users, MaxUsers::Limited(_));
-        loop {
+        let mut tx = loop {
             let mut tx = self.pool.begin().await?;
-            match max_users {
-                MaxUsers::Limited(max) => {
-                    let max = sql_max_users(max, "postgres")?;
-                    let updated = sqlx::query(
-                        "UPDATE auth_counters SET value = value + 1
-                         WHERE name = $1 AND value < $2",
-                    )
-                    .bind("users")
-                    .bind(max)
-                    .execute(&mut *tx)
-                    .await?;
-                    if updated.rows_affected() == 0 {
-                        tx.rollback().await?;
-                        if can_retry_after_reconcile {
-                            can_retry_after_reconcile = false;
-                            if self.reconcile_user_counter_overcount_impl().await? {
-                                continue;
-                            }
-                        }
-                        return self.existing_or_cap_reached(username).await;
-                    }
-                }
-                MaxUsers::Unlimited => {
-                    sqlx::query("UPDATE auth_counters SET value = value + 1 WHERE name = $1")
-                        .bind("users")
-                        .execute(&mut *tx)
-                        .await?;
-                }
-                MaxUsers::Disabled => {}
+            if claim_user_slot(&mut tx, max_users).await? {
+                break tx;
             }
-            let inserted = sqlx::query("INSERT INTO users (username, bcrypt_hash) VALUES ($1, $2)")
-                .bind(username)
-                .bind(bcrypt_hash)
-                .execute(&mut *tx)
-                .await;
-            match inserted {
-                Ok(_) => {
-                    tx.commit().await?;
-                    return Ok(InsertUser::Created);
-                }
-                Err(err) if is_unique_violation(&err) => {
-                    tx.rollback().await?;
-                    return self.existing_or_cap_reached(username).await;
-                }
-                Err(err) => return Err(err.into()),
+            tx.rollback().await?;
+            if !std::mem::take(&mut can_retry_after_reconcile)
+                || !self.reconcile_user_counter_overcount_impl().await?
+            {
+                return self.existing_or_cap_reached(username).await;
             }
+        };
+        let inserted = sqlx::query("INSERT INTO users (username, bcrypt_hash) VALUES ($1, $2)")
+            .bind(username)
+            .bind(bcrypt_hash)
+            .execute(&mut *tx)
+            .await;
+        match inserted {
+            Ok(_) => {
+                tx.commit().await?;
+                Ok(InsertUser::Created)
+            }
+            Err(err) if is_unique_violation(&err) => {
+                tx.rollback().await?;
+                self.existing_or_cap_reached(username).await
+            }
+            Err(err) => Err(err.into()),
         }
     }
 
@@ -328,4 +307,29 @@ fn is_unique_violation(err: &sqlx::Error) -> bool {
     err.as_database_error()
         .and_then(sqlx::error::DatabaseError::code)
         .is_some_and(|code| code.as_ref() == "23505")
+}
+
+async fn claim_user_slot(connection: &mut PgConnection, max_users: MaxUsers) -> Result<bool> {
+    match max_users {
+        MaxUsers::Limited(max) => {
+            let max = sql_max_users(max, "postgres")?;
+            let updated = sqlx::query(
+                "UPDATE auth_counters SET value = value + 1
+                 WHERE name = $1 AND value < $2",
+            )
+            .bind("users")
+            .bind(max)
+            .execute(connection)
+            .await?;
+            Ok(updated.rows_affected() != 0)
+        }
+        MaxUsers::Unlimited => {
+            sqlx::query("UPDATE auth_counters SET value = value + 1 WHERE name = $1")
+                .bind("users")
+                .execute(connection)
+                .await?;
+            Ok(true)
+        }
+        MaxUsers::Disabled => Ok(true),
+    }
 }

--- a/pnpr/crates/auth/src/sqlx_backend/tests.rs
+++ b/pnpr/crates/auth/src/sqlx_backend/tests.rs
@@ -1,5 +1,17 @@
-use super::{super::MAX_USERNAME_CHARS, *};
-use std::sync::Arc;
+use super::{
+    super::{MAX_USERNAME_CHARS, TokenBackend, TokenRecord, UpsertOutcome, UserBackend},
+    AuthSqlBackend, InsertUser, SqlAuth, StoredUser,
+};
+use async_trait::async_trait;
+use pnpr_config::MaxUsers;
+use pnpr_error::{RegistryError, Result};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
 
 struct CanonicalBackend {
     user: StoredUser,

--- a/pnpr/crates/pnpr/src/oci_maintenance.rs
+++ b/pnpr/crates/pnpr/src/oci_maintenance.rs
@@ -3,7 +3,7 @@
 
 use crate::{Config, Ecosystem, RegistryError, Result};
 use futures_util::TryStreamExt;
-use pnpr_oci::{Digest, ImageDocument, Manifest, media_type};
+use pnpr_oci::{Descriptor, Digest, ImageDocument, Manifest, media_type};
 use pnpr_package_name::CanonicalPackageName;
 use pnpr_storage::Storage;
 use rusqlite::{Connection, OptionalExtension, params};
@@ -301,9 +301,7 @@ pub(crate) async fn referenced_document_blobs(
         for reference in manifest.references() {
             reachable.insert(reference.digest.blob_filename());
             if media_type::is_index(manifest.media_type()) {
-                let content_type = reference.media_type.clone().or_else(|| {
-                    document.manifest(&reference.digest).map(|entry| entry.media_type.clone())
-                });
+                let content_type = resolve_reference_media_type(reference, document);
                 pending.push((reference.digest.clone(), content_type));
             }
         }
@@ -318,6 +316,16 @@ pub(crate) async fn referenced_document_blobs(
         });
     }
     Ok(reachable)
+}
+
+fn resolve_reference_media_type(
+    reference: &Descriptor,
+    document: &ImageDocument,
+) -> Option<String> {
+    reference
+        .media_type
+        .clone()
+        .or_else(|| document.manifest(&reference.digest).map(|entry| entry.media_type.clone()))
 }
 
 /// Read one retained manifest back and parse it, checking it is the blob its

--- a/pnpr/crates/pnpr/src/server/tests/compiler_cache.rs
+++ b/pnpr/crates/pnpr/src/server/tests/compiler_cache.rs
@@ -20,15 +20,7 @@ async fn parallel_uploads_are_rejected_before_buffering_and_cancellation_release
     let (started, mut receiver) = tokio::sync::mpsc::unbounded_channel();
     let mut uploads = Vec::new();
     for _ in 0..2 {
-        let mut started = Some(started.clone());
-        let body = Body::from_stream(futures_util::stream::poll_fn(
-            move |_| -> std::task::Poll<Option<Result<Bytes, std::io::Error>>> {
-                if let Some(started) = started.take() {
-                    started.send(()).unwrap();
-                }
-                std::task::Poll::Pending
-            },
-        ));
+        let body = pending_upload(started.clone());
         uploads.push(tokio::spawn(app.clone().oneshot(request(Method::PUT, ENTRY, body))));
     }
     tokio::time::timeout(std::time::Duration::from_secs(10), async {
@@ -193,4 +185,16 @@ async fn disabled_artifacts_and_undeclared_caches_are_not_served() {
             .status(),
         StatusCode::NOT_FOUND,
     );
+}
+
+fn pending_upload(started: tokio::sync::mpsc::UnboundedSender<()>) -> Body {
+    let mut started = Some(started);
+    Body::from_stream(futures_util::stream::poll_fn(
+        move |_| -> std::task::Poll<Option<Result<Bytes, std::io::Error>>> {
+            if let Some(started) = started.take() {
+                started.send(()).unwrap();
+            }
+            std::task::Poll::Pending
+        },
+    ))
 }

--- a/pnpr/crates/pnpr/tests/batch_publish.rs
+++ b/pnpr/crates/pnpr/tests/batch_publish.rs
@@ -225,16 +225,17 @@ async fn batch_publish_rolls_back_every_package_when_one_fails_integrity() {
 
     for name in ["rollback-good", "rollback-bad"] {
         let pkg_dir = storage.join(name);
-        if pkg_dir.exists() {
-            let entries: Vec<String> = std::fs::read_dir(&pkg_dir)
-                .unwrap()
-                .map(|entry| entry.unwrap().file_name().to_string_lossy().to_string())
-                .collect();
-            assert!(
-                entries.is_empty(),
-                "expected no artifacts for {name} after rejected batch, found: {entries:?}",
-            );
+        if !pkg_dir.exists() {
+            continue;
         }
+        let entries: Vec<String> = std::fs::read_dir(&pkg_dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().to_string())
+            .collect();
+        assert!(
+            entries.is_empty(),
+            "expected no artifacts for {name} after rejected batch, found: {entries:?}",
+        );
     }
 }
 

--- a/pnpr/crates/pnpr/tests/oci_registry/referrers.rs
+++ b/pnpr/crates/pnpr/tests/oci_registry/referrers.rs
@@ -82,35 +82,10 @@ async fn referrer_pages_bound_migration_and_keep_filter_and_registry() {
         )
         .unwrap();
         assert!(document.manifests().iter().all(|entry| entry.referrer.is_some()));
-        let mut path = format!(
+        let path = format!(
             "/oci/~images/v2/acme/paged/referrers/{subject}?artifactType=application%2Fexample%2Bjson",
         );
-        let mut received = Vec::new();
-        let mut pages = 0;
-        loop {
-            let response = get(&app, &path).await;
-            assert_eq!(response.status(), StatusCode::OK);
-            assert_eq!(response.headers()["oci-filters-applied"], "artifactType");
-            let next = response.headers().get(header::LINK).map(|link| {
-                let link = link.to_str().unwrap();
-                assert!(link.contains("artifactType=application%2Fexample%2Bjson"));
-                assert!(link.starts_with("</oci/~images/v2/"));
-                link.strip_prefix('<').unwrap().split_once('>').unwrap().0.to_string()
-            });
-            let payload: Value =
-                serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
-            received.extend(
-                payload["manifests"]
-                    .as_array()
-                    .unwrap()
-                    .iter()
-                    .map(|entry| entry["digest"].as_str().unwrap().to_string()),
-            );
-            pages += 1;
-            assert!(pages <= 2);
-            let Some(next) = next else { break };
-            path = next;
-        }
+        let (received, pages) = collect_filtered_referrer_pages(&app, path).await;
         expected.sort();
         assert_eq!(received, expected);
         assert_eq!(pages, 2);
@@ -172,4 +147,37 @@ async fn large_referrer_annotations_stay_out_of_repository_documents() {
         path = next;
     }
     assert_eq!(count, 3);
+}
+
+async fn collect_filtered_referrer_pages(
+    app: &axum::Router,
+    mut path: String,
+) -> (Vec<String>, usize) {
+    let mut received = Vec::new();
+    let mut pages = 0;
+    loop {
+        let response = get(app, &path).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()["oci-filters-applied"], "artifactType");
+        let next = response.headers().get(header::LINK).map(|link| {
+            let link = link.to_str().unwrap();
+            assert!(link.contains("artifactType=application%2Fexample%2Bjson"));
+            assert!(link.starts_with("</oci/~images/v2/"));
+            link.strip_prefix('<').unwrap().split_once('>').unwrap().0.to_string()
+        });
+        let payload: Value =
+            serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+        received.extend(
+            payload["manifests"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|entry| entry["digest"].as_str().unwrap().to_string()),
+        );
+        pages += 1;
+        assert!(pages <= 2);
+        let Some(next) = next else { break };
+        path = next;
+    }
+    (received, pages)
 }

--- a/pnpr/crates/pnpr/tests/oci_registry/uploads.rs
+++ b/pnpr/crates/pnpr/tests/oci_registry/uploads.rs
@@ -610,12 +610,10 @@ async fn proxy_does_not_cache_corrupt_content_or_download_blob_bodies_for_head()
         let response = get(&app, &path).await;
         let mut stream = response.into_body().into_data_stream();
         let mut bytes = Vec::new();
-        loop {
-            match stream.next().await {
-                Some(Ok(chunk)) => bytes.extend_from_slice(&chunk),
-                Some(Err(_)) => break,
-                None => panic!("corrupt content must terminate with an integrity error"),
-            }
+        while let Ok(chunk) =
+            stream.next().await.expect("corrupt content must terminate with an integrity error")
+        {
+            bytes.extend_from_slice(&chunk);
         }
         assert_eq!(bytes, b"poison");
         assert!(stream.next().await.is_none());

--- a/pnpr/crates/pnpr/tests/server/hosted_reads.rs
+++ b/pnpr/crates/pnpr/tests/server/hosted_reads.rs
@@ -740,6 +740,14 @@ async fn private_hosted_registry_denies_writes_from_non_members() {
 /// by name/version/description through `/-/v1/search`.
 #[tokio::test]
 async fn search_does_not_enumerate_a_private_flat_root_registry() {
+    let search_with = |url: &str, authorization: Option<String>| {
+        let mut request = Request::get(url);
+        if let Some(value) = authorization {
+            request = request.header(header::AUTHORIZATION, value);
+        }
+        request.body(Body::empty()).unwrap()
+    };
+
     for url in ["/-/v1/search?text=secret", "/-/v1/search?browse=true"] {
         let tmp = TempDir::new().unwrap();
         seed_hosted(tmp.path(), "@corp/secret-tool");
@@ -757,23 +765,16 @@ async fn search_does_not_enumerate_a_private_flat_root_registry() {
         let outsider = auth.tokens.issue("mallory").await.unwrap();
         let app = router_with_auth(config, auth);
 
-        let search_with = |authorization: Option<String>| {
-            let mut request = Request::get(url);
-            if let Some(value) = authorization {
-                request = request.header(header::AUTHORIZATION, value);
-            }
-            request.body(Body::empty()).unwrap()
-        };
-
         for authorization in [None, Some(format!("Bearer {outsider}"))] {
-            let response = app.clone().oneshot(search_with(authorization)).await.unwrap();
+            let response = app.clone().oneshot(search_with(url, authorization)).await.unwrap();
             assert_eq!(response.status(), StatusCode::OK);
             let body = body_json(response.into_body()).await;
             assert_eq!(body["total"], json!(0), "private package leaked through search");
             assert_eq!(body["objects"], json!([]));
         }
 
-        let response = app.oneshot(search_with(Some(format!("Bearer {member}")))).await.unwrap();
+        let response =
+            app.oneshot(search_with(url, Some(format!("Bearer {member}")))).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         let body = body_json(response.into_body()).await;
         assert_eq!(body["objects"][0]["package"]["name"], json!("@corp/secret-tool"));

--- a/pnpr/crates/pnpr/tests/server/surfaces.rs
+++ b/pnpr/crates/pnpr/tests/server/surfaces.rs
@@ -222,11 +222,8 @@ async fn cors_allows_only_configured_origins_and_handles_preflight() {
         allowed.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
         Some(&HeaderValue::from_static("https://npmx.example")),
     );
-    assert!(allowed.headers().get(header::VARY).is_some_and(|value| {
-        value.to_str().is_ok_and(|value| {
-            value.split(',').any(|header| header.trim().eq_ignore_ascii_case("origin"))
-        })
-    }));
+    let vary = allowed.headers().get(header::VARY).unwrap().to_str().unwrap();
+    assert!(vary.split(',').any(|header| header.trim().eq_ignore_ascii_case("origin")));
 
     let missing = app
         .clone()
@@ -274,9 +271,11 @@ async fn cors_allows_only_configured_origins_and_handles_preflight() {
         preflight.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
         Some(&HeaderValue::from_static("https://npmx.example")),
     );
-    assert!(preflight.headers().get(header::ACCESS_CONTROL_ALLOW_HEADERS).is_some_and(|value| {
-        value.to_str().is_ok_and(|value| {
-            value.split(',').any(|header| header.trim().eq_ignore_ascii_case("authorization"))
-        })
-    }),);
+    let allowed_headers =
+        preflight.headers().get(header::ACCESS_CONTROL_ALLOW_HEADERS).unwrap().to_str().unwrap();
+    assert!(
+        allowed_headers
+            .split(',')
+            .any(|header| header.trim().eq_ignore_ascii_case("authorization")),
+    );
 }

--- a/pnpr/crates/shared-artifacts/src/tests/behavior.rs
+++ b/pnpr/crates/shared-artifacts/src/tests/behavior.rs
@@ -146,22 +146,21 @@ async fn a_legacy_artifact_claims_its_slot_whatever_its_order_or_position() {
         let (payload, _) = legacy.envelope.decode_payload().unwrap();
         let owner = super::super::owner_key("acme", &payload.owner).unwrap();
         let entry = super::super::entry_digest(&legacy.key, &payload.subject);
-        if buried {
-            // Named to sort before the matching one, and more of them than a
-            // lookup would scan.
-            for index in 0..MAX_VARIANTS_PER_CANDIDATE + 2 {
-                let filler = publication_tagged(
-                    &format!("ci/filler/{index}"),
-                    &[&format!("pnpm:v1:linux-x64-node22-glibc2.{index}")],
-                );
-                store
-                    .create_object(
-                        &format!("{owner}/entries/{entry}/{index:064x}.json"),
-                        serde_json::to_vec(&filler.envelope).unwrap(),
-                    )
-                    .await
-                    .unwrap();
-            }
+        // Named to sort before the matching one, and more of them than a
+        // lookup would scan.
+        let filler_count = if buried { MAX_VARIANTS_PER_CANDIDATE + 2 } else { 0 };
+        for index in 0..filler_count {
+            let filler = publication_tagged(
+                &format!("ci/filler/{index}"),
+                &[&format!("pnpm:v1:linux-x64-node22-glibc2.{index}")],
+            );
+            store
+                .create_object(
+                    &format!("{owner}/entries/{entry}/{index:064x}.json"),
+                    serde_json::to_vec(&filler.envelope).unwrap(),
+                )
+                .await
+                .unwrap();
         }
         store
             .create_object(


### PR DESCRIPTION
## Summary

Enable `perfectionist::excessive_nesting` at a maximum depth of 3 across the Rust workspace, including tests. Update the perfectionist pin to the merge of KSXGitHub/perfectionist#405 and refactor violations in pnpm, pnpr, and the workspace-sort benchmark without adding suppression markers.

Use guard clauses, direct pattern matching, and helpers that keep iteration order, lazy work, lock scopes, and SQL transactions intact. Document the preference for simple iterator closures and explicit loops or named helpers for multi-statement bodies.

Related to pnpm/pnpm#14562. This completes the nesting portion; the issue's other pending rules remain separate. These are internal style changes with no user-visible behavior change, so no changeset is needed.

Validation: `just ready` (11,119 tests passed, 13 existing skips), strict workspace Dylint, workspace Dylint with all features, rustdoc with all features and private items, and TOML formatting. Additional `pnpr-auth` tests and Dylint with all features cover the optional SQL implementations (69 tests passed). Validation ran on Linux; Windows-specific directory handling is included for CI coverage.

## Squash Commit Body

```text
Pin perfectionist to 495d33163b1e4ab6b0cbb4742a2130c655849f7d and enforce
excessive_nesting with max_depth = 3 and exempt_tests = false.

Refactor the Rust workspace's violations with guards, pattern matching, and small helpers.
Retain short-circuiting, allocation behavior, synchronization boundaries, and SQL
registration transaction semantics. Include optional SQL auth backends and Windows
directory handling.

Keep single-expression iterator closures where they clarify transformations; prefer loops
or named helpers for multi-statement bodies.

Related to pnpm/pnpm#14562.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] Updated existing tests for the refactors and ran the Rust workspace suite.
- [x] Updated the code style documentation.

---
Written by an agent (Codex, gpt-6-astra).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791680124&installation_model_id=426870&pr_number=14825&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14825&signature=27e91591ae9f16c59014879913b3445ebea50ccc06e8a1d8dcd514de225d4854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Code Quality**
  - Improved handling of workspace directory creation when directories already exist or are created concurrently.
  - Simplified internal control flow across dependency resolution, package management, authentication, registry access, and publishing workflows without changing expected behavior.
  - Consolidated repeated operations to improve maintainability and consistency.

- **Documentation**
  - Added guidance recommending a maximum nesting depth of three levels, including in tests, with suggestions for clearer control flow.

- **Developer Experience**
  - Updated linting configuration to enforce excessive-nesting checks and refreshed the associated lint tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->