### PR TITLE
fix: auto-install transitive peers shared at different workspace depths

### DIFF
--- a/.changeset/fix-transitive-auto-install-peers.md
+++ b/.changeset/fix-transitive-auto-install-peers.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+`pnpm install` now auto-installs missing transitive peers when workspace projects share a dependency at different depths. This also removes incomplete duplicate peer contexts from the lockfile. Fixes [pnpm/pnpm#14840](https://github.com/pnpm/pnpm/issues/14840).

--- a/pnpm11/installing/deps-installer/test/install/autoInstallPeers.ts
+++ b/pnpm11/installing/deps-installer/test/install/autoInstallPeers.ts
@@ -872,3 +872,38 @@ test('a package entry keeps the declared peerDependencies ranges when the graph 
   await install(manifest('100.1.0'), opts())
   expect(declaredPeerRanges()).toStrictEqual(expectedPeerRanges)
 })
+
+test.each([false, true])('auto installs transitive peers shared at different depths (reverse importers: %s)', async (reverse) => {
+  const manifests: PackageManifest[] = [
+    { name: 'app-a', version: '1.0.0', dependencies: { parent: 'file:../parent', 'is-positive': '1.0.0' } },
+    { name: 'app-b', version: '1.0.0', dependencies: { grandparent: 'file:../grandparent' } },
+  ]
+  preparePackages([
+    ...manifests.map((manifest) => ({ location: manifest.name!, package: manifest })),
+    { location: 'parent', package: { name: 'parent', version: '1.0.0', dependencies: { child: 'file:../child' } } },
+    { location: 'grandparent', package: { name: 'grandparent', version: '1.0.0', dependencies: { parent: 'file:../parent' } } },
+    { location: 'child', package: { name: 'child', version: '1.0.0', peerDependencies: { 'is-positive': '1.0.0' } } },
+  ])
+  const allProjects = manifests.map((manifest) => ({
+    buildIndex: 0,
+    manifest,
+    rootDir: path.resolve(manifest.name!) as ProjectRootDir,
+  }))
+  if (reverse) allProjects.reverse()
+  const mutations = allProjects.map(({ rootDir }) => ({ mutation: 'install' as const, rootDir }))
+  const opts = testDefaults({
+    allProjects,
+    autoInstallPeers: true,
+    strictPeerDependencies: true,
+    resolvePeersFromWorkspaceRoot: false,
+  })
+  await mutateModules(mutations, opts)
+  const project = assertProject(process.cwd())
+  const lockfile = project.readLockfile()
+  expect(Object.keys(lockfile.snapshots).filter((key) => key.startsWith('child@'))).toStrictEqual([
+    'child@file:child(is-positive@1.0.0)',
+  ])
+  expect(lockfile.importers['app-b'].dependencies?.grandparent.version).toBe('file:grandparent(is-positive@1.0.0)')
+  await mutateModules(mutations, { ...opts, frozenLockfile: true })
+  expect(project.readLockfile()).toStrictEqual(lockfile)
+})

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -803,39 +803,50 @@ async function resolveDependenciesOfImporterDependency (
 
 // Shared child resolution can omit peers supplied by another importer's ancestors.
 // Discover required peers from the graph without waiting on child-resolution promises.
-function collectMissingRequiredPeers (
-  ctx: ResolutionContext,
-  roots: PkgAddressOrLink[]
+export function collectMissingRequiredPeers (
+  ctx: Pick<ResolutionContext, 'childrenByParentId' | 'autoInstallPeersFromHighestMatch'> & {
+    resolvedPkgsById: Record<PkgResolutionId, Pick<ResolvedPackage, 'peerDependencies'>>
+  },
+  roots: Array<Pick<PkgAddress, 'alias' | 'pkgId'>>
 ): MissingPeers {
-  const cache = new Map<PkgResolutionId, MissingPeers>()
-  const visiting = new Set<PkgResolutionId>()
   const rootAliases = new Set(roots.map(({ alias }) => alias))
-  return pickBy((_, name) => !rootAliases.has(name), mergePkgsDeps(
-    roots.map(({ pkgId }) => visit(pkgId).missingPeers), ctx
-  ))
-
-  function visit (pkgId: PkgResolutionId): { missingPeers: MissingPeers, cyclic: boolean } {
-    const cached = cache.get(pkgId)
-    if (cached) return { missingPeers: cached, cyclic: false }
+  const packages = new Map<PkgResolutionId, {
+    children: ChildrenByParentId[PkgResolutionId]
+    childAliases: Set<string>
+    requiredPeers: MissingPeers
+  }>()
+  const peerNames = new Set<string>()
+  const pending = roots.map(({ pkgId }) => pkgId)
+  while (pending.length) {
+    const pkgId = pending.pop()!
+    if (packages.has(pkgId)) continue
     const pkg = ctx.resolvedPkgsById[pkgId]
-    if (!pkg) return { missingPeers: {}, cyclic: false }
-    if (visiting.has(pkgId)) return { missingPeers: {}, cyclic: true }
-    visiting.add(pkgId)
+    if (!pkg) continue
     const children = ctx.childrenByParentId[pkgId] ?? []
-    const childAliases = new Set(children.map(({ alias }) => alias))
-    const childResults = children.map(({ id }) => visit(id))
-    const missingPeers = mergePkgsDeps([
-      pickBy(({ optional }) => !optional, getMissingPeers(pkg.peerDependencies)),
-      pickBy((_, name) => !childAliases.has(name), mergePkgsDeps(
-        childResults.map(({ missingPeers }) => missingPeers), ctx
-      )),
-    ], ctx)
-    visiting.delete(pkgId)
-    const cyclic = childResults.some(({ cyclic }) => cyclic)
-    // A cycle cut depends on the current path and cannot be reused on another path.
-    if (!cyclic) cache.set(pkgId, missingPeers)
-    return { missingPeers, cyclic }
+    const requiredPeers: MissingPeers = pickBy(({ optional }, name) => !optional && !rootAliases.has(name), getMissingPeers(pkg.peerDependencies))
+    packages.set(pkgId, { children, childAliases: new Set(children.map(({ alias }) => alias)), requiredPeers })
+    for (const name of Object.keys(requiredPeers)) peerNames.add(name)
+    for (const { id } of children) pending.push(id)
   }
+  const missingPeers: MissingPeers[] = []
+  for (const peerName of peerNames) {
+    const visited = new Set<PkgResolutionId>()
+    pending.push(...roots.map(({ pkgId }) => pkgId))
+    while (pending.length) {
+      const pkgId = pending.pop()!
+      if (visited.has(pkgId)) continue
+      visited.add(pkgId)
+      const pkg = packages.get(pkgId)
+      if (!pkg) continue
+      if (pkg.requiredPeers[peerName]) {
+        missingPeers.push({ [peerName]: pkg.requiredPeers[peerName] })
+      }
+      if (!pkg.childAliases.has(peerName)) {
+        for (const { id } of pkg.children) pending.push(id)
+      }
+    }
+  }
+  return mergePkgsDeps(missingPeers, ctx)
 }
 
 function filterMissingPeersFromPkgAddresses (

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -816,6 +816,7 @@ export function collectMissingRequiredPeers (
     requiredPeers: MissingPeers
   }>()
   const peerNames = new Set<string>()
+  const providedAliases = new Set<string>()
   const pending = roots.map(({ pkgId }) => pkgId)
   while (pending.length) {
     const pkgId = pending.pop()!
@@ -826,10 +827,17 @@ export function collectMissingRequiredPeers (
     const requiredPeers: MissingPeers = pickBy(({ optional }, name) => !optional && !rootAliases.has(name), getMissingPeers(pkg.peerDependencies))
     packages.set(pkgId, { children, childAliases: new Set(children.map(({ alias }) => alias)), requiredPeers })
     for (const name of Object.keys(requiredPeers)) peerNames.add(name)
-    for (const { id } of children) pending.push(id)
+    for (const { alias, id } of children) {
+      providedAliases.add(alias)
+      pending.push(id)
+    }
   }
   const missingPeers: MissingPeers[] = []
+  for (const { requiredPeers } of packages.values()) {
+    missingPeers.push(pickBy((_, name) => !providedAliases.has(name), requiredPeers))
+  }
   for (const peerName of peerNames) {
+    if (!providedAliases.has(peerName)) continue
     const visited = new Set<PkgResolutionId>()
     pending.push(...roots.map(({ pkgId }) => pkgId))
     while (pending.length) {

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -426,6 +426,12 @@ export async function resolveRootDependencies (
         for (const pkgAddress of importerResolutionResult.pkgAddresses) {
           parentPkgAliases[pkgAddress.alias] = true
         }
+        if (ctx.autoInstallPeers) {
+          importerResolutionResult.missingPeers = mergePkgsDeps([
+            importerResolutionResult.missingPeers,
+            collectMissingRequiredPeers(ctx, importerResolutionResult.pkgAddresses),
+          ], ctx)
+        }
         const missingOptionalPeers: Array<[string, MissingPeerInfo]> = []
         const missingRequiredPeers: Array<[string, MissingPeerInfo]> = []
         for (const [peerName, peerInfo] of Object.entries(importerResolutionResult.missingPeers ?? {})) {
@@ -793,6 +799,43 @@ async function resolveDependenciesOfImporterDependency (
   }
 
   return result
+}
+
+// Shared child resolution can omit peers supplied by another importer's ancestors.
+// Discover required peers from the graph without waiting on child-resolution promises.
+function collectMissingRequiredPeers (
+  ctx: ResolutionContext,
+  roots: PkgAddressOrLink[]
+): MissingPeers {
+  const cache = new Map<PkgResolutionId, MissingPeers>()
+  const visiting = new Set<PkgResolutionId>()
+  const rootAliases = new Set(roots.map(({ alias }) => alias))
+  return pickBy((_, name) => !rootAliases.has(name), mergePkgsDeps(
+    roots.map(({ pkgId }) => visit(pkgId).missingPeers), ctx
+  ))
+
+  function visit (pkgId: PkgResolutionId): { missingPeers: MissingPeers, cyclic: boolean } {
+    const cached = cache.get(pkgId)
+    if (cached) return { missingPeers: cached, cyclic: false }
+    const pkg = ctx.resolvedPkgsById[pkgId]
+    if (!pkg) return { missingPeers: {}, cyclic: false }
+    if (visiting.has(pkgId)) return { missingPeers: {}, cyclic: true }
+    visiting.add(pkgId)
+    const children = ctx.childrenByParentId[pkgId] ?? []
+    const childAliases = new Set(children.map(({ alias }) => alias))
+    const childResults = children.map(({ id }) => visit(id))
+    const missingPeers = mergePkgsDeps([
+      pickBy(({ optional }) => !optional, getMissingPeers(pkg.peerDependencies)),
+      pickBy((_, name) => !childAliases.has(name), mergePkgsDeps(
+        childResults.map(({ missingPeers }) => missingPeers), ctx
+      )),
+    ], ctx)
+    visiting.delete(pkgId)
+    const cyclic = childResults.some(({ cyclic }) => cyclic)
+    // A cycle cut depends on the current path and cannot be reused on another path.
+    if (!cyclic) cache.set(pkgId, missingPeers)
+    return { missingPeers, cyclic }
+  }
 }
 
 function filterMissingPeersFromPkgAddresses (

--- a/pnpm11/installing/deps-resolver/test/collectMissingRequiredPeers.test.ts
+++ b/pnpm11/installing/deps-resolver/test/collectMissingRequiredPeers.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@jest/globals'
+import type { PkgResolutionId } from '@pnpm/resolving.resolver-base'
+
+import { collectMissingRequiredPeers, type PeerDependencies } from '../lib/resolveDependencies.js'
+
+test('collects required peers through a dense dependency cycle', () => {
+  const ids = Array.from({ length: 20 }, (_, index) => `pkg-${index}`)
+  const ctx = createGraph(ids.map((id) => ({
+    id,
+    children: ids.filter((other) => other !== id),
+    peers: { peer: { version: '^1.0.0' } },
+  })))
+  expect(collectMissingRequiredPeers(ctx, [root(ids[0])])).toStrictEqual({
+    peer: { range: '>=1.0.0 <2.0.0-0', optional: false },
+  })
+})
+
+test('collects peers through a graph deeper than the call stack', () => {
+  const ctx = createGraph(Array.from({ length: 20_000 }, (_, index) => ({
+    id: `pkg-${index}`,
+    children: index === 19_999 ? [] : [`pkg-${index + 1}`],
+    peers: index === 19_999 ? { peer: { version: '1.0.0' } } : undefined,
+  })))
+  expect(collectMissingRequiredPeers(ctx, [root('pkg-0')])).toStrictEqual({
+    peer: { range: '1.0.0', optional: false },
+  })
+})
+
+test('a provider only satisfies peers in the subtree where it is available', () => {
+  const ctx = createGraph([
+    { id: 'provided', children: ['child', 'peer'] },
+    { id: 'missing', children: ['child'] },
+    { id: 'child', peers: { peer: { version: '1.0.0' }, optional: { version: '*', optional: true } } },
+    { id: 'peer' },
+  ])
+  expect(collectMissingRequiredPeers(ctx, [root('provided')])).toStrictEqual({})
+  expect(collectMissingRequiredPeers(ctx, [root('missing'), root('provided')])).toStrictEqual({
+    peer: { range: '1.0.0', optional: false },
+  })
+  expect(collectMissingRequiredPeers(ctx, [root('missing'), root('peer')])).toStrictEqual({})
+})
+
+function root (id: string): { alias: string, pkgId: PkgResolutionId } {
+  return { alias: id, pkgId: id as PkgResolutionId }
+}
+
+function createGraph (nodes: Array<{ id: string, children?: string[], peers?: PeerDependencies }>): Parameters<typeof collectMissingRequiredPeers>[0] {
+  return {
+    autoInstallPeersFromHighestMatch: false,
+    childrenByParentId: Object.fromEntries(nodes.map(({ id, children }) => [
+      id, (children ?? []).map((child) => ({ alias: child, id: child as PkgResolutionId })),
+    ])),
+    resolvedPkgsById: Object.fromEntries(nodes.map(({ id, peers }) => [id, { peerDependencies: peers ?? {} }])),
+  }
+}

--- a/pnpm11/installing/deps-resolver/test/collectMissingRequiredPeers.test.ts
+++ b/pnpm11/installing/deps-resolver/test/collectMissingRequiredPeers.test.ts
@@ -5,12 +5,16 @@ import { collectMissingRequiredPeers, type PeerDependencies } from '../lib/resol
 
 test('collects required peers through a dense dependency cycle', () => {
   const ids = Array.from({ length: 20 }, (_, index) => `pkg-${index}`)
-  const ctx = createGraph(ids.map((id) => ({
-    id,
-    children: ids.filter((other) => other !== id),
-    peers: { peer: { version: '^1.0.0' } },
-  })))
-  expect(collectMissingRequiredPeers(ctx, [root(ids[0])])).toStrictEqual({
+  const ctx = createGraph([
+    ...ids.map((id) => ({
+      id,
+      children: ids.filter((other) => other !== id),
+      peers: { peer: { version: '^1.0.0' } },
+    })),
+    { id: 'provided', children: ['peer'] },
+    { id: 'peer' },
+  ])
+  expect(collectMissingRequiredPeers(ctx, [root(ids[0]), root('provided')])).toStrictEqual({
     peer: { range: '>=1.0.0 <2.0.0-0', optional: false },
   })
 })
@@ -24,6 +28,28 @@ test('collects peers through a graph deeper than the call stack', () => {
   expect(collectMissingRequiredPeers(ctx, [root('pkg-0')])).toStrictEqual({
     peer: { range: '1.0.0', optional: false },
   })
+})
+
+test('collects distinct absent peers without scanning the graph for each name', () => {
+  const count = 500
+  const ctx = createGraph(Array.from({ length: count }, (_, index) => ({
+    id: `pkg-${index}`,
+    children: index === count - 1 ? [] : [`pkg-${index + 1}`],
+    peers: { [`peer-${index}`]: { version: '1.0.0' } },
+  })))
+  let childTraversals = 0
+  for (const children of Object.values(ctx.childrenByParentId)) {
+    const iterator = children[Symbol.iterator].bind(children)
+    children[Symbol.iterator] = () => {
+      childTraversals++
+      return iterator()
+    }
+  }
+  const missingPeers = collectMissingRequiredPeers(ctx, [root('pkg-0')])
+  expect(missingPeers).toStrictEqual(Object.fromEntries(Array.from({ length: count }, (_, index) => [
+    `peer-${index}`, { range: '1.0.0', optional: false },
+  ])))
+  expect(childTraversals).toBe(count)
 })
 
 test('a provider only satisfies peers in the subtree where it is available', () => {


### PR DESCRIPTION
## Summary

Fixes missing transitive peers when workspace projects share a dependency at different depths. A peer supplied by one project no longer prevents `autoInstallPeers` from installing it for another project, and the lockfile contains one complete peer context.

Closes pnpm/pnpm#14840.

This is a pnpm v11 bug fix. The original reproduction passes on pnpm v12, so no Rust changes are needed.

Validation:
- The new regression fails without the fix in both importer orders and passes with it, including a frozen-lockfile reinstall.
- All 27 auto-install-peers tests and 91 related peer-dependency/cyclic-determinism tests passed (one existing test is skipped).
- Four collector tests cover dense cycles, a 20,000-package chain, provider visibility, and linear traversal for distinct absent peers.
- Rebuilt the v11 CLI and ran the original reproduction: `pnpm peers check` reports no issues.
- Ran the original reproduction on pnpm v12.4.0: no peer issues.

## Squash Commit Body

```text
Shared child-resolution results can omit peers supplied by the owning
importer's ancestors. A deeper occurrence also cannot safely await the
shallower owner's promise because that can deadlock on dependency cycles.

Before auto-installing peers, collect missing required peers from the
resolved dependency graph and filter providers at each dependency level.
Collect peers with no possible provider directly in one graph pass. For
peers with possible providers, visit each package at most once per name
and stop at subtrees with a provider. Use iterative traversal to handle deep graphs
and dense dependency cycles without enumerating paths. Keep optional-peer
collection and the child-resolution ownership rules unchanged.

Cover two workspace projects sharing a local package at different depths,
both importer orders, strict peer checks, one complete child snapshot,
and a frozen-lockfile reinstall.

Closes pnpm/pnpm#14840.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm install` now automatically installs missing transitive peer dependencies when workspace projects share dependencies at different levels.
  * Improved peer dependency resolution and validation, including installations that do not require the workspace root.
  * Removed incomplete duplicate peer contexts from the lockfile, improving frozen-lockfile reproducibility and consistency across workspace installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->