### PR TITLE
fix(workspace): honor native discovery exclusions

### DIFF
--- a/.changeset/fix-native-discovery-exclusions.md
+++ b/.changeset/fix-native-discovery-exclusions.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Cargo and Python discovery now skip directories excluded by `!` patterns in `pnpm-workspace.yaml` `packages`. Excluded native projects are no longer parsed or given generated source configuration [pnpm/pnpm#14844](https://github.com/pnpm/pnpm/issues/14844).

--- a/.changeset/fix-native-discovery-exclusions.md
+++ b/.changeset/fix-native-discovery-exclusions.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Cargo and Python discovery now skip directories excluded by `!` patterns in `pnpm-workspace.yaml` `packages`. Excluded native projects are no longer parsed or given generated source configuration [pnpm/pnpm#14844](https://github.com/pnpm/pnpm/issues/14844).
+Cargo and Python discovery now skip directories excluded by `!` patterns in `pnpm-workspace.yaml` `packages`. Excluded native projects are no longer parsed. They no longer receive generated source configuration [pnpm/pnpm#14844](https://github.com/pnpm/pnpm/issues/14844).

--- a/pnpm/crates/cli/src/ecosystem_install/workspace_inventory.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/workspace_inventory.rs
@@ -26,6 +26,7 @@ impl EcosystemManifest {
 pub(crate) struct EcosystemWorkspaceInventory {
     workspace_root: PathBuf,
     managed_directories: Vec<PathBuf>,
+    package_patterns: Vec<String>,
     contents: OnceCell<pnpm_workspace::WorkspaceInventory>,
 }
 
@@ -39,7 +40,12 @@ impl EcosystemWorkspaceInventory {
             config.virtual_store_dir.clone(),
             config.global_virtual_store_dir.clone(),
         ];
-        Self { workspace_root, managed_directories, contents: OnceCell::new() }
+        Self {
+            workspace_root,
+            managed_directories,
+            package_patterns: config.workspace_package_patterns.clone().unwrap_or_default(),
+            contents: OnceCell::new(),
+        }
     }
 
     pub(crate) async fn manifests(&self, manifest: EcosystemManifest) -> Result<&[PathBuf]> {
@@ -48,6 +54,7 @@ impl EcosystemWorkspaceInventory {
             .get_or_try_init(|| {
                 let workspace_root = self.workspace_root.clone();
                 let managed_directories = self.managed_directories.clone();
+                let package_patterns = self.package_patterns.clone();
                 async move {
                     tokio::task::spawn_blocking(move || {
                         let manifest_basenames = EcosystemManifest::ALL
@@ -59,6 +66,7 @@ impl EcosystemWorkspaceInventory {
                             &manifest_basenames,
                             IGNORED_DIRECTORY_BASENAMES,
                             &managed_directories,
+                            &package_patterns,
                         )
                     })
                     .await

--- a/pnpm/crates/cli/tests/suite/cargo_install.rs
+++ b/pnpm/crates/cli/tests/suite/cargo_install.rs
@@ -307,3 +307,59 @@ fn reuses_workspace_metadata_with_aliased_paths_and_nested_workspaces() {
         assert_eq!(fs::read_to_string(&log).unwrap(), "metadata\nmetadata\n", "{alias:?}");
     }
 }
+
+#[test]
+fn install_does_not_parse_or_modify_excluded_cargo_workspaces() {
+    let root = TempDir::new().unwrap();
+    fs::write(
+        root.path().join("pnpm-workspace.yaml"),
+        "packages:\n  - 'crates/*'\n  - '!fixtures/**'\ncargo:\n  enabled: true\n",
+    )
+    .unwrap();
+    fs::write(
+        root.path().join("Cargo.toml"),
+        "[workspace]\nresolver = \"2\"\nmembers = [\"crates/selected\"]\nexclude = [\"fixtures/excluded\"]\n",
+    )
+    .unwrap();
+    let selected = root.path().join("crates/selected");
+    fs::create_dir_all(selected.join("src")).unwrap();
+    fs::write(selected.join("src/lib.rs"), "").unwrap();
+    fs::write(
+        selected.join("Cargo.toml"),
+        "[package]\nname = \"selected\"\nversion = \"0.0.0\"\nedition = \"2021\"\n",
+    )
+    .unwrap();
+    let excluded = root.path().join("fixtures/excluded");
+    fs::create_dir_all(&excluded).unwrap();
+    fs::write(excluded.join("Cargo.toml"), "not valid TOML\n").unwrap();
+    Command::new("cargo")
+        .with_current_dir(root.path())
+        .with_args(["generate-lockfile", "--offline"])
+        .assert()
+        .success();
+
+    let args = ["install", "--frozen-lockfile", "--ignore-scripts", "--offline"];
+    install_in(&root, &args);
+    eprintln!("The selected Cargo workspace must receive source configuration");
+    assert!(root.path().join(".cargo/config.toml").is_file());
+
+    fs::create_dir_all(excluded.join("src")).unwrap();
+    fs::write(excluded.join("src/lib.rs"), "").unwrap();
+    fs::write(
+        excluded.join("Cargo.toml"),
+        "[package]\nname = \"excluded\"\nversion = \"0.0.0\"\nedition = \"2021\"\n[workspace]\n",
+    )
+    .unwrap();
+    Command::new("cargo")
+        .with_current_dir(&excluded)
+        .with_args(["generate-lockfile", "--offline"])
+        .assert()
+        .success();
+    let excluded_lock = fs::read(excluded.join("Cargo.lock")).unwrap();
+
+    install_in(&root, &args);
+    assert_eq!(fs::read(excluded.join("Cargo.lock")).unwrap(), excluded_lock);
+    eprintln!("The excluded workspace must not receive pnpm files");
+    assert!(!excluded.join(".cargo").exists());
+    assert!(!excluded.join(".pnpm").exists());
+}

--- a/pnpm/crates/workspace/src/directory_patterns.rs
+++ b/pnpm/crates/workspace/src/directory_patterns.rs
@@ -1,0 +1,28 @@
+use crate::FindWorkspaceProjectsError;
+use pnpm_fs::lexical_normalize_posix;
+use wax::Glob;
+
+pub(crate) fn normalize_directory_pattern(pattern: &str) -> Option<String> {
+    let mut normalized = lexical_normalize_posix(pattern);
+    normalized.truncate(normalized.trim_end_matches('/').len());
+    if normalized.is_empty() || normalized == "." {
+        return None;
+    }
+    Some(normalized)
+}
+
+pub(crate) fn negated_directory_pattern(
+    pattern: &str,
+) -> Result<Option<String>, FindWorkspaceProjectsError> {
+    let Some(body) = pattern.strip_prefix('!').filter(|body| !body.starts_with('/')) else {
+        return Ok(None);
+    };
+    let Some(directory) = normalize_directory_pattern(body) else {
+        return Ok(None);
+    };
+    Glob::new(&directory).map_err(|error| FindWorkspaceProjectsError::InvalidGlob {
+        pattern: pattern.to_string(),
+        message: error.to_string(),
+    })?;
+    Ok(Some(directory))
+}

--- a/pnpm/crates/workspace/src/inventory.rs
+++ b/pnpm/crates/workspace/src/inventory.rs
@@ -1,4 +1,5 @@
 mod open_directory;
+use crate::{FindWorkspaceProjectsError, directory_patterns::negated_directory_pattern};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use std::{
@@ -7,6 +8,7 @@ use std::{
     fs, io,
     path::{Path, PathBuf},
 };
+use wax::Program as _;
 
 mod traversal;
 
@@ -29,6 +31,9 @@ impl WorkspaceInventory {
 #[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]
 pub enum FindWorkspaceInventoryError {
+    #[diagnostic(transparent)]
+    InvalidPattern(#[error(source)] FindWorkspaceProjectsError),
+
     #[display("Failed to read workspace inventory directory {}: {source}", path.display())]
     #[diagnostic(code(ERR_PNPM_WORKSPACE_INVENTORY_READ_DIRECTORY))]
     ReadDirectory {
@@ -60,17 +65,21 @@ pub enum FindWorkspaceInventoryError {
 /// unreadable during a nested traversal is skipped, while failure to read the
 /// inventory root is reported.
 /// Ignored directories may be absolute or relative to the inventory root.
+/// Negated package patterns prune matching directories and their descendants.
+/// Positive package patterns do not restrict this inventory; the root is always scanned.
 pub fn find_workspace_inventory(
     workspace_root: &Path,
     manifest_basenames: &[&str],
     ignored_directory_basenames: &[&str],
     ignored_directories: &[PathBuf],
+    package_patterns: &[String],
 ) -> Result<WorkspaceInventory, FindWorkspaceInventoryError> {
     find_workspace_inventory_with(
         workspace_root,
         manifest_basenames,
         ignored_directory_basenames,
         ignored_directories,
+        package_patterns,
         |_| Ok(()),
         |_| Ok(()),
     )
@@ -81,6 +90,7 @@ fn find_workspace_inventory_with(
     manifest_basenames: &[&str],
     ignored_directory_basenames: &[&str],
     ignored_directories: &[PathBuf],
+    package_patterns: &[String],
     before_read: impl FnMut(&Path) -> io::Result<()>,
     before_open_directory: impl FnMut(&Path) -> io::Result<()>,
 ) -> Result<WorkspaceInventory, FindWorkspaceInventoryError> {
@@ -90,6 +100,7 @@ fn find_workspace_inventory_with(
     })?;
     let ignored = IgnoredDirectories {
         root: workspace_root,
+        patterns: compile_excluded_directories(package_patterns)?,
         basenames: ignored_directory_basenames.iter().map(OsStr::new).collect(),
         paths: ignored_paths_under(workspace_root, &canonical_root, ignored_directories)?,
     };
@@ -115,6 +126,27 @@ fn find_workspace_inventory_with(
         manifest_paths.sort();
     }
     Ok(WorkspaceInventory { manifests })
+}
+
+fn compile_excluded_directories(
+    patterns: &[String],
+) -> Result<wax::Any<'static>, FindWorkspaceInventoryError> {
+    let globs = patterns
+        .iter()
+        .filter_map(|pattern| negated_directory_pattern(pattern).transpose())
+        .map(|directory| {
+            directory.map(|directory| {
+                wax::Glob::new(&directory).expect("validated directory pattern").into_owned()
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(FindWorkspaceInventoryError::InvalidPattern)?;
+    wax::any(globs).map_err(|error| {
+        FindWorkspaceInventoryError::InvalidPattern(FindWorkspaceProjectsError::InvalidGlob {
+            pattern: "<negated pattern>".to_string(),
+            message: error.to_string(),
+        })
+    })
 }
 
 /// The ignored directories that exist, relative to the canonical root.
@@ -144,12 +176,15 @@ struct IgnoredDirectories<'a> {
     root: &'a Path,
     basenames: BTreeSet<&'a OsStr>,
     paths: BTreeSet<PathBuf>,
+    patterns: wax::Any<'static>,
 }
 
 impl IgnoredDirectories<'_> {
     fn contains(&self, basename: &OsStr, path: &Path) -> bool {
         self.basenames.contains(basename)
-            || path.strip_prefix(self.root).is_ok_and(|relative| self.paths.contains(relative))
+            || path.strip_prefix(self.root).is_ok_and(|relative| {
+                self.paths.contains(relative) || self.patterns.is_match(relative)
+            })
     }
 }
 

--- a/pnpm/crates/workspace/src/inventory/tests.rs
+++ b/pnpm/crates/workspace/src/inventory/tests.rs
@@ -18,6 +18,7 @@ fn discovers_multiple_manifest_kinds_in_one_inventory() {
         &["package.json", "Cargo.toml", "pyproject.toml"],
         &[".git", ".pnpm", "node_modules", "target"],
         &[],
+        &[],
     )
     .unwrap();
 
@@ -38,7 +39,7 @@ fn prunes_generated_directories() {
     fs::write(generated.join("Cargo.toml"), "[workspace]\n").unwrap();
 
     let inventory =
-        find_workspace_inventory(workspace.path(), &["Cargo.toml"], &["target"], &[]).unwrap();
+        find_workspace_inventory(workspace.path(), &["Cargo.toml"], &["target"], &[], &[]).unwrap();
 
     assert_eq!(inventory.manifests("Cargo.toml").unwrap(), [project.join("Cargo.toml")]);
 }
@@ -55,6 +56,7 @@ fn skips_unreadable_unrelated_directories() {
     let inventory = find_workspace_inventory_with(
         workspace.path(),
         &["Cargo.toml"],
+        &[],
         &[],
         &[],
         |directory| {
@@ -82,6 +84,7 @@ fn reports_the_nested_directory_that_failed() {
         &["Cargo.toml"],
         &[],
         &[],
+        &[],
         |directory| {
             if directory == broken {
                 Err(std::io::Error::other("injected read failure"))
@@ -105,7 +108,8 @@ fn does_not_follow_directory_symlinks() {
     fs::write(outside.path().join("Cargo.toml"), "[workspace]\n").unwrap();
     symlink(outside.path(), &workspace.path().join("linked")).unwrap();
 
-    let inventory = find_workspace_inventory(workspace.path(), &["Cargo.toml"], &[], &[]).unwrap();
+    let inventory =
+        find_workspace_inventory(workspace.path(), &["Cargo.toml"], &[], &[], &[]).unwrap();
 
     assert!(inventory.manifests("Cargo.toml").unwrap().is_empty());
 }
@@ -121,6 +125,7 @@ fn does_not_follow_a_directory_swapped_for_a_symlink_before_descent() {
     let inventory = find_workspace_inventory_with(
         workspace.path(),
         &["Cargo.toml"],
+        &[],
         &[],
         &[],
         |_| Ok(()),
@@ -153,6 +158,7 @@ fn prunes_managed_paths_before_opening_without_excluding_matching_project_names(
             &["Cargo.toml", "pyproject.toml"],
             &[],
             &[excluded],
+            &[],
             |_| Ok(()),
             |path| {
                 assert_ne!(path, cache, "managed directory must not be opened");
@@ -183,6 +189,7 @@ fn reads_children_without_accumulating_unvisited_sibling_handles() {
         &["Cargo.toml"],
         &[],
         &[],
+        &[],
         |directory| {
             if directory != workspace.path() {
                 unread.set(unread.get() - 1);
@@ -208,11 +215,12 @@ fn discovers_deep_trees_with_a_small_handle_limit() {
     const ROOT_ENV: &str = "PNPM_TEST_DEEP_INVENTORY_ROOT";
     if let Some(root) = std::env::var_os(ROOT_ENV) {
         let inventory =
-            find_workspace_inventory(std::path::Path::new(&root), &["Cargo.toml"], &[], &[])
+            find_workspace_inventory(std::path::Path::new(&root), &["Cargo.toml"], &[], &[], &[])
                 .unwrap();
         assert_eq!(inventory.manifests("Cargo.toml").unwrap().len(), 129);
         let root = std::path::Path::new(&root);
         let ignored = super::IgnoredDirectories {
+            patterns: wax::any(std::iter::empty::<&str>()).unwrap(),
             root,
             basenames: std::collections::BTreeSet::default(),
             paths: std::collections::BTreeSet::default(),
@@ -279,6 +287,7 @@ fn does_not_follow_an_ancestor_swapped_before_a_queued_child_is_opened() {
         &["Cargo.toml"],
         &[],
         &[],
+        &[],
         |_| Ok(()),
         |path| {
             if path == child {
@@ -307,6 +316,7 @@ fn continues_after_a_child_is_moved_to_a_different_parent() {
         &["Cargo.toml"],
         &[],
         &[],
+        &[],
         |path| {
             if path == child {
                 fs::rename(&child, outside.path().join("moved"))?;
@@ -329,6 +339,7 @@ fn continues_after_a_nested_directory_disappears() {
         &["Cargo.toml"],
         &[],
         &[],
+        &[],
         |path| {
             if path == child {
                 fs::remove_dir(&child)?;
@@ -348,6 +359,7 @@ fn skips_candidates_that_become_unreadable_before_opening() {
     let inventory = find_workspace_inventory_with(
         workspace.path(),
         &["Cargo.toml"],
+        &[],
         &[],
         &[],
         |_| Ok(()),
@@ -382,4 +394,81 @@ fn rejects_intermediate_links_to_directories_inside_the_workspace() {
             .unwrap_err();
     eprintln!("intermediate link error: {error}");
     assert_ne!(error.kind(), std::io::ErrorKind::NotFound);
+}
+
+#[test]
+fn prunes_negated_package_directories_before_opening() {
+    let workspace = tempfile::tempdir().unwrap();
+    let selected = workspace.path().join("native/selected");
+    let excluded = workspace.path().join("fixtures/excluded");
+    for directory in [workspace.path(), &selected, &excluded] {
+        fs::create_dir_all(directory).unwrap();
+        fs::write(directory.join("Cargo.toml"), "not parsed by discovery").unwrap();
+        fs::write(directory.join("pyproject.toml"), "not parsed by discovery").unwrap();
+    }
+    for pattern in [
+        "!fixtures/**",
+        "!fixtures",
+        "!./fixtures/",
+        "!fixtures/excluded",
+        "!**/excluded",
+        "!{fixtures,archives}/**",
+    ] {
+        let patterns = ["packages/*".to_string(), pattern.to_string()];
+        let inventory = find_workspace_inventory_with(
+            workspace.path(),
+            &["Cargo.toml", "pyproject.toml"],
+            &[],
+            &[],
+            &patterns,
+            |_| Ok(()),
+            |path| {
+                assert_ne!(path, excluded, "excluded directory must not be opened: {pattern}");
+                Ok(())
+            },
+        )
+        .unwrap();
+        for basename in ["Cargo.toml", "pyproject.toml"] {
+            let mut expected = [workspace.path().join(basename), selected.join(basename)];
+            expected.sort();
+            assert_eq!(inventory.manifests(basename).unwrap(), expected, "{pattern}");
+        }
+    }
+}
+
+#[test]
+fn invalid_inventory_exclusion_reports_the_pattern() {
+    let workspace = tempfile::tempdir().unwrap();
+    let error = find_workspace_inventory(
+        workspace.path(),
+        &["Cargo.toml"],
+        &[],
+        &[],
+        &["![invalid".to_string()],
+    )
+    .unwrap_err();
+    eprintln!("{error}");
+    assert!(error.to_string().contains("![invalid"));
+}
+
+#[test]
+fn recursive_exclusion_also_prunes_its_base_directory() {
+    let workspace = tempfile::tempdir().unwrap();
+    let excluded = workspace.path().join("fixtures");
+    fs::create_dir(&excluded).unwrap();
+    fs::write(excluded.join("Cargo.toml"), "not valid TOML").unwrap();
+    let inventory = find_workspace_inventory_with(
+        workspace.path(),
+        &["Cargo.toml"],
+        &[],
+        &[],
+        &["!fixtures/**".to_string()],
+        |_| Ok(()),
+        |path| {
+            assert_ne!(path, excluded, "excluded directory must not be opened");
+            Ok(())
+        },
+    )
+    .unwrap();
+    assert_eq!(inventory.manifests("Cargo.toml").unwrap().len(), 0);
 }

--- a/pnpm/crates/workspace/src/lib.rs
+++ b/pnpm/crates/workspace/src/lib.rs
@@ -33,6 +33,7 @@ pub use root_finder::{
 };
 
 mod api;
+mod directory_patterns;
 mod importer_id;
 mod inventory;
 mod manifest;

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -14,10 +14,12 @@
 //!
 //! [#431]: https://github.com/pnpm/pacquet/issues/431
 
-use crate::project_manifest::{ReadProjectManifestError, read_exact_project_manifest};
+use crate::{
+    directory_patterns::{negated_directory_pattern, normalize_directory_pattern},
+    project_manifest::{ReadProjectManifestError, read_exact_project_manifest},
+};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pnpm_fs::lexical_normalize_posix;
 use pnpm_package_manifest::{PackageManifest, PackageManifestError};
 use rayon::prelude::*;
 use std::{
@@ -199,13 +201,13 @@ fn split_include_and_negation(
     let mut include_patterns = Vec::new();
     let mut user_negation_globs: Vec<String> = Vec::new();
     for pattern in patterns {
-        let Some(body) = pattern.strip_prefix('!') else {
+        if !pattern.starts_with('!') {
             if let Some(normalized) = normalize_directory_pattern(pattern) {
                 include_patterns.push(WorkspacePattern { source: pattern, normalized });
             }
             continue;
-        };
-        collect_negation_globs(pattern, body, &mut user_negation_globs)?;
+        }
+        collect_negation_globs(pattern, &mut user_negation_globs)?;
     }
     Ok((include_patterns, user_negation_globs))
 }
@@ -240,13 +242,9 @@ fn parse_check_walk_patterns(
 /// absolute form.
 fn collect_negation_globs(
     pattern: &str,
-    body: &str,
     user_negation_globs: &mut Vec<String>,
 ) -> Result<(), FindWorkspaceProjectsError> {
-    if body.starts_with('/') {
-        return Ok(());
-    }
-    let Some(directory) = normalize_directory_pattern(body) else {
+    let Some(directory) = negated_directory_pattern(pattern)? else {
         return Ok(());
     };
     for normalized in normalize_manifest_patterns(&directory) {
@@ -479,15 +477,6 @@ const PROJECT_MANIFEST_BASENAMES: &[&str] = &["package.json", "package.yaml"];
 struct WorkspacePattern<'source> {
     source: &'source str,
     normalized: String,
-}
-
-fn normalize_directory_pattern(pattern: &str) -> Option<String> {
-    let mut normalized = lexical_normalize_posix(pattern);
-    normalized.truncate(normalized.trim_end_matches('/').len());
-    if normalized.is_empty() || normalized == "." {
-        return None;
-    }
-    Some(normalized)
 }
 
 #[cfg(test)]

--- a/pnpm/plans/ECOSYSTEM_INSTALL.md
+++ b/pnpm/plans/ECOSYSTEM_INSTALL.md
@@ -25,6 +25,29 @@ CLI selection -> native plans + npm task
                        restore metadata
 ```
 
+## Native project discovery
+
+Cargo and Python discovery honor the explicit `!` exclusions in
+`pnpm-workspace.yaml` `packages`. Matching directories and their descendants
+are skipped before their manifests are read. For example:
+
+```yaml
+packages:
+  - 'packages/*'
+  - '!fixtures/**'
+  - '!worktrees/**'
+cargo:
+  enabled: true
+```
+
+Positive `packages` patterns select npm projects. Cargo and Python projects
+outside those positive patterns are still discovered, including when `packages`
+is empty. The workspace root is always considered. Cargo's `workspace.exclude`
+controls Cargo membership, not pnpm discovery of independent Cargo workspaces;
+use a `!` package pattern to exclude those trees from pnpm discovery.
+Exclusions do not remove dependencies or members that a selected native project
+itself requires.
+
 ## Ownership
 
 | Component | Owns |


### PR DESCRIPTION
## Summary

Cargo and Python discovery now honor explicit `!` exclusions in `pnpm-workspace.yaml` `packages`. Excluded directories are pruned before traversal, preventing invalid fixture manifests from failing installs and independent excluded workspaces from receiving generated files.

Positive npm package patterns continue to leave native discovery unrestricted, including `packages: []`. The workspace root remains eligible. The discovery boundary and its relationship to Cargo membership are documented.

Validation: `just ready` (11,123 tests passed; 13 skipped), plus targeted Cargo and workspace tests.

Closes pnpm/pnpm#14844.

## Squash Commit Body

```text
Pass workspace package patterns into the shared native manifest inventory
and prune directories matching explicit negations before opening them.
Reuse directory-pattern normalization with npm workspace discovery.

Preserve discovery outside positive npm patterns: existing Cargo installs
support packages: [] and may live outside the npm package layout. Cargo
workspace.exclude still controls Cargo membership; pnpm package negations
provide the boundary for discovering independent native workspaces.

Add an offline CLI regression for invalid and valid excluded Cargo
workspaces, plus inventory coverage for Cargo/Python, normalized and glob
exclusions, root inclusion, and invalid patterns. The CLI regression fails
on the original implementation with the reported cargo metadata error.

This affects the Rust v12 CLI only. The TypeScript v11 CLI has no Cargo
or Python ecosystem install integration.

Closes pnpm/pnpm#14844.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791762811&installation_model_id=426870&pr_number=14846&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14846&signature=0ebef683a1db9345d6b405f6c883e2bf66f1d1303bce043b875f941d5028d24e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Native Cargo and Python project discovery now respects excluded directories defined in `pnpm-workspace.yaml`.
  * Excluded projects are skipped during installation and are no longer parsed or modified, preventing generated configuration and source files from being added.
  * Recursive exclusions are applied to matching directories and their contents.
  * Invalid exclusion patterns now report clear validation errors.

* **Documentation**
  * Added guidance explaining native project discovery and exclusion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->