### PR TITLE
fix: honor workspace exclusions during native discovery

### DIFF
--- a/.changeset/native-workspace-exclusions.md
+++ b/.changeset/native-workspace-exclusions.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` respects negated `packages` patterns when discovering Cargo and Python projects. Excluded independent workspaces are not parsed or modified.

--- a/pnpm/crates/cli/src/ecosystem_install/workspace_inventory.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/workspace_inventory.rs
@@ -1,4 +1,5 @@
 use miette::{IntoDiagnostic, Result, WrapErr};
+use pnpm_workspace::WorkspaceInventoryExclusion;
 use std::path::PathBuf;
 use tokio::sync::OnceCell;
 
@@ -25,21 +26,31 @@ impl EcosystemManifest {
 /// Manifest paths available to every ecosystem participating in an install.
 pub(crate) struct EcosystemWorkspaceInventory {
     workspace_root: PathBuf,
-    managed_directories: Vec<PathBuf>,
+    excluded_directories: Vec<WorkspaceInventoryExclusion>,
     contents: OnceCell<pnpm_workspace::WorkspaceInventory>,
 }
 
 impl EcosystemWorkspaceInventory {
     pub(crate) fn new(workspace_root: PathBuf, config: &pnpm_config::Config) -> Self {
-        let managed_directories = vec![
+        let mut excluded_directories = vec![
             config.store_dir.root().to_path_buf(),
             config.cache_dir.clone(),
             config.state_dir.clone(),
             config.modules_dir.clone(),
             config.virtual_store_dir.clone(),
             config.global_virtual_store_dir.clone(),
-        ];
-        Self { workspace_root, managed_directories, contents: OnceCell::new() }
+        ]
+        .into_iter()
+        .map(WorkspaceInventoryExclusion::Directory)
+        .collect::<Vec<_>>();
+        excluded_directories.extend(config.workspace_package_patterns.iter().flatten().filter_map(
+            |pattern| {
+                pattern
+                    .strip_prefix('!')
+                    .map(|pattern| WorkspaceInventoryExclusion::Pattern(pattern.to_string()))
+            },
+        ));
+        Self { workspace_root, excluded_directories, contents: OnceCell::new() }
     }
 
     pub(crate) async fn manifests(&self, manifest: EcosystemManifest) -> Result<&[PathBuf]> {
@@ -47,7 +58,7 @@ impl EcosystemWorkspaceInventory {
             .contents
             .get_or_try_init(|| {
                 let workspace_root = self.workspace_root.clone();
-                let managed_directories = self.managed_directories.clone();
+                let excluded_directories = self.excluded_directories.clone();
                 async move {
                     tokio::task::spawn_blocking(move || {
                         let manifest_basenames = EcosystemManifest::ALL
@@ -58,7 +69,7 @@ impl EcosystemWorkspaceInventory {
                             &workspace_root,
                             &manifest_basenames,
                             IGNORED_DIRECTORY_BASENAMES,
-                            &managed_directories,
+                            &excluded_directories,
                         )
                     })
                     .await

--- a/pnpm/crates/cli/src/ecosystem_install/workspace_inventory/tests.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/workspace_inventory/tests.rs
@@ -2,6 +2,29 @@ use super::{EcosystemManifest, EcosystemWorkspaceInventory};
 use std::fs;
 
 #[tokio::test]
+async fn applies_negations_to_native_discovery_without_using_npm_include_patterns() {
+    let workspace = tempfile::tempdir().unwrap();
+    for directory in ["rust", "fixtures/excluded"] {
+        fs::create_dir_all(workspace.path().join(directory)).unwrap();
+        fs::write(workspace.path().join(directory).join("Cargo.toml"), "[workspace]\n").unwrap();
+        fs::write(workspace.path().join(directory).join("pyproject.toml"), "[project]\n").unwrap();
+    }
+    let config = pnpm_config::Config {
+        workspace_package_patterns: Some(vec!["npm/*".to_string(), "!fixtures/**".to_string()]),
+        ..Default::default()
+    };
+    let inventory = EcosystemWorkspaceInventory::new(workspace.path().to_path_buf(), &config);
+    assert_eq!(
+        inventory.manifests(EcosystemManifest::Cargo).await.unwrap(),
+        [workspace.path().join("rust/Cargo.toml")],
+    );
+    assert_eq!(
+        inventory.manifests(EcosystemManifest::Python).await.unwrap(),
+        [workspace.path().join("rust/pyproject.toml")],
+    );
+}
+
+#[tokio::test]
 async fn exposes_cargo_manifests_from_the_shared_inventory() {
     let workspace = tempfile::tempdir().unwrap();
     let cargo_project = workspace.path().join("rust");

--- a/pnpm/crates/cli/tests/suite/cargo_install.rs
+++ b/pnpm/crates/cli/tests/suite/cargo_install.rs
@@ -58,6 +58,35 @@ fn install_in(root: &TempDir, args: &[&str]) {
 }
 
 #[test]
+fn install_does_not_read_or_write_excluded_cargo_workspaces() {
+    let root = cargo_workspace("https://registry.example.test/index/", "", "");
+    fs::write(
+        root.path().join("pnpm-workspace.yaml"),
+        "packages: ['crates/*', '!fixtures/**']\ncargo:\n  enabled: true\n",
+    )
+    .unwrap();
+    append_manifest_section(
+        &root.path().join("Cargo.toml"),
+        "\n[workspace]\nexclude = [\"fixtures/excluded\"]\n",
+    );
+    let excluded = root.path().join("fixtures/excluded");
+    fs::create_dir_all(excluded.join("src")).unwrap();
+    fs::write(excluded.join("Cargo.toml"), "not valid TOML\n").unwrap();
+    install_in(&root, &["install", "--offline"]);
+    fs::write(
+        excluded.join("Cargo.toml"),
+        "[package]\nname = \"excluded\"\nversion = \"0.1.0\"\n\n[workspace]\n",
+    )
+    .unwrap();
+    fs::write(excluded.join("src/lib.rs"), "").unwrap();
+    install_in(&root, &["install", "--offline", "--frozen-lockfile"]);
+    assert!(!excluded.join("Cargo.lock").exists());
+    assert!(!excluded.join(".cargo").exists());
+    assert!(!excluded.join(".pnpm").exists());
+    assert!(root.path().join(".cargo/config.toml").is_file());
+}
+
+#[test]
 fn install_resolves_and_downloads_through_the_configured_registry() {
     let mut registry = mockito::Server::new();
     let archive = crate_archive("demo", "1.0.0");

--- a/pnpm/crates/deps-restorer/src/link_file/tests/links.rs
+++ b/pnpm/crates/deps-restorer/src/link_file/tests/links.rs
@@ -1,14 +1,14 @@
-#[cfg(unix)]
-use super::{
-    super::{
-        AUTO_FIRST_TIER, LINK_STATE_CLONE, LINK_STATE_COPY, clone_or_copy_link,
-        import_into_fresh_target, is_link_permission_error, recover_from_concurrent_import,
-    },
-    EaccesHardLink, EaccesLinks, EpermHardLink, EpermReflink, inode,
-};
 use super::{
     super::{Host, LINK_STATE_HARDLINK, LinkFileError, auto_link, link_file, try_import},
     OutOfLinks, write_source,
+};
+#[cfg(unix)]
+use super::{
+    super::{
+        LINK_STATE_CLONE, LINK_STATE_COPY, clone_or_copy_link, import_into_fresh_target,
+        is_link_permission_error, recover_from_concurrent_import,
+    },
+    EaccesHardLink, EaccesLinks, EpermHardLink, EpermReflink, inode,
 };
 use pnpm_config::PackageImportMethod;
 use pnpm_reporter::SilentReporter;
@@ -179,6 +179,7 @@ fn auto_hardlink_tier_call_errors_propagate() {
 #[test]
 #[cfg(target_os = "linux")]
 fn auto_fresh_state_hardlinks_on_linux() {
+    use super::super::AUTO_FIRST_TIER;
     use std::os::unix::fs::MetadataExt;
 
     let state = AtomicU8::new(AUTO_FIRST_TIER);

--- a/pnpm/crates/network/src/tests/manifests.rs
+++ b/pnpm/crates/network/src/tests/manifests.rs
@@ -1,6 +1,4 @@
-use super::{
-    EnvGuard, NetworkSettings, PerRegistryTls, ProxyConfig, TEST_CA_PEM, ThrottledClient, TlsConfig,
-};
+use super::TEST_CA_PEM;
 
 // `SSL_CERT_FILE` alone switches `rustls-native-certs` to env-only
 // loading, so pointing it at an empty file is a portable stand-in for a
@@ -10,6 +8,10 @@ use super::{
 #[cfg(all(unix, not(target_vendor = "apple"), not(target_os = "android")))]
 #[test]
 fn for_installs_falls_back_to_bundled_roots_without_a_system_trust_store() {
+    use super::{
+        EnvGuard, NetworkSettings, PerRegistryTls, ProxyConfig, ThrottledClient, TlsConfig,
+    };
+
     let env = EnvGuard::snapshot(["SSL_CERT_FILE", "SSL_CERT_DIR", "NODE_EXTRA_CA_CERTS"]);
     let empty_bundle =
         std::env::temp_dir().join(format!("pacquet-empty-ca-{}.pem", std::process::id()));

--- a/pnpm/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror.rs
@@ -353,35 +353,37 @@ fn meta_modified(meta: &Package) -> Option<String> {
 #[cfg(unix)]
 fn raise_open_file_limit_once() {
     static RAISE: std::sync::Once = std::sync::Once::new();
-    RAISE.call_once(|| {
-        // SAFETY: plain libc calls; `limit` is a properly initialised
-        // out-parameter and no pointer outlives its call.
-        unsafe {
-            let mut limit = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
-            if libc::getrlimit(libc::RLIMIT_NOFILE, &raw mut limit) != 0 {
-                return;
-            }
-            let ceiling: libc::rlim_t = 1 << 20;
-            let target = limit.rlim_max.min(ceiling);
-            if target <= limit.rlim_cur {
-                return;
-            }
-            let request = libc::rlimit { rlim_cur: target, rlim_max: limit.rlim_max };
-            if libc::setrlimit(libc::RLIMIT_NOFILE, &raw const request) != 0 {
-                // macOS rejects soft limits above `kern.maxfilesperproc`
-                // even when the hard limit reads unlimited; 10240 is
-                // the historically safe `OPEN_MAX` ceiling there.
-                #[cfg(target_os = "macos")]
-                {
-                    let fallback = limit.rlim_max.min(10240);
-                    if fallback > limit.rlim_cur {
-                        let request = libc::rlimit { rlim_cur: fallback, rlim_max: limit.rlim_max };
-                        let _ = libc::setrlimit(libc::RLIMIT_NOFILE, &raw const request);
-                    }
-                }
+    RAISE.call_once(raise_open_file_limit);
+}
+
+#[cfg(unix)]
+fn raise_open_file_limit() {
+    // SAFETY: plain libc calls; `limit` is a properly initialised
+    // out-parameter and no pointer outlives its call.
+    unsafe {
+        let mut limit = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+        if libc::getrlimit(libc::RLIMIT_NOFILE, &raw mut limit) != 0 {
+            return;
+        }
+        let ceiling: libc::rlim_t = 1 << 20;
+        let target = limit.rlim_max.min(ceiling);
+        if target <= limit.rlim_cur {
+            return;
+        }
+        let request = libc::rlimit { rlim_cur: target, rlim_max: limit.rlim_max };
+        if libc::setrlimit(libc::RLIMIT_NOFILE, &raw const request) != 0 {
+            // macOS rejects soft limits above `kern.maxfilesperproc`
+            // even when the hard limit reads unlimited; 10240 is
+            // the historically safe `OPEN_MAX` ceiling there.
+            #[cfg(target_os = "macos")]
+            let fallback = limit.rlim_max.min(10240);
+            #[cfg(target_os = "macos")]
+            if fallback > limit.rlim_cur {
+                let request = libc::rlimit { rlim_cur: fallback, rlim_max: limit.rlim_max };
+                let _ = libc::setrlimit(libc::RLIMIT_NOFILE, &raw const request);
             }
         }
-    });
+    }
 }
 
 /// Windows has no `RLIMIT_NOFILE`; per-process handle capacity is far

--- a/pnpm/crates/workspace/src/directory_pattern.rs
+++ b/pnpm/crates/workspace/src/directory_pattern.rs
@@ -1,0 +1,10 @@
+use pnpm_fs::lexical_normalize_posix;
+
+pub(crate) fn normalize_directory_pattern(pattern: &str) -> Option<String> {
+    let mut normalized = lexical_normalize_posix(pattern);
+    normalized.truncate(normalized.trim_end_matches('/').len());
+    if normalized.is_empty() || normalized == "." {
+        return None;
+    }
+    Some(normalized)
+}

--- a/pnpm/crates/workspace/src/inventory.rs
+++ b/pnpm/crates/workspace/src/inventory.rs
@@ -1,5 +1,7 @@
+mod exclusions;
 mod open_directory;
 use derive_more::{Display, Error};
+use exclusions::{DirectoryPattern, compile_patterns};
 use miette::Diagnostic;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -18,6 +20,13 @@ pub struct WorkspaceInventory {
     manifests: BTreeMap<String, Vec<PathBuf>>,
 }
 
+/// Directory trees or workspace-relative package patterns excluded from discovery.
+#[derive(Debug, Clone)]
+pub enum WorkspaceInventoryExclusion {
+    Directory(PathBuf),
+    Pattern(String),
+}
+
 impl WorkspaceInventory {
     /// Paths whose final component equals `basename`.
     pub fn manifests(&self, basename: &str) -> Option<&[PathBuf]> {
@@ -29,6 +38,9 @@ impl WorkspaceInventory {
 #[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]
 pub enum FindWorkspaceInventoryError {
+    #[display("Invalid workspace inventory exclusion {pattern}: {message}")]
+    #[diagnostic(code(ERR_PNPM_WORKSPACE_INVENTORY_INVALID_GLOB))]
+    InvalidGlob { pattern: String, message: String },
     #[display("Failed to read workspace inventory directory {}: {source}", path.display())]
     #[diagnostic(code(ERR_PNPM_WORKSPACE_INVENTORY_READ_DIRECTORY))]
     ReadDirectory {
@@ -64,7 +76,7 @@ pub fn find_workspace_inventory(
     workspace_root: &Path,
     manifest_basenames: &[&str],
     ignored_directory_basenames: &[&str],
-    ignored_directories: &[PathBuf],
+    ignored_directories: &[WorkspaceInventoryExclusion],
 ) -> Result<WorkspaceInventory, FindWorkspaceInventoryError> {
     find_workspace_inventory_with(
         workspace_root,
@@ -80,7 +92,7 @@ fn find_workspace_inventory_with(
     workspace_root: &Path,
     manifest_basenames: &[&str],
     ignored_directory_basenames: &[&str],
-    ignored_directories: &[PathBuf],
+    ignored_directories: &[WorkspaceInventoryExclusion],
     before_read: impl FnMut(&Path) -> io::Result<()>,
     before_open_directory: impl FnMut(&Path) -> io::Result<()>,
 ) -> Result<WorkspaceInventory, FindWorkspaceInventoryError> {
@@ -92,6 +104,7 @@ fn find_workspace_inventory_with(
         root: workspace_root,
         basenames: ignored_directory_basenames.iter().map(OsStr::new).collect(),
         paths: ignored_paths_under(workspace_root, &canonical_root, ignored_directories)?,
+        patterns: compile_patterns(ignored_directories)?,
     };
     let mut manifests: BTreeMap<String, Vec<PathBuf>> =
         manifest_basenames.iter().map(|basename| ((*basename).to_string(), Vec::new())).collect();
@@ -103,6 +116,7 @@ fn find_workspace_inventory_with(
         before_open_directory,
         |path, file_name| {
             if requested.contains(file_name)
+                && !ignored.excludes_manifest(&path)
                 && let Some(manifest_paths) =
                     file_name.to_str().and_then(|basename| manifests.get_mut(basename))
             {
@@ -121,10 +135,11 @@ fn find_workspace_inventory_with(
 fn ignored_paths_under(
     workspace_root: &Path,
     canonical_root: &Path,
-    ignored_directories: &[PathBuf],
+    ignored_directories: &[WorkspaceInventoryExclusion],
 ) -> Result<BTreeSet<PathBuf>, FindWorkspaceInventoryError> {
     let mut paths = BTreeSet::new();
-    for path in ignored_directories {
+    for exclusion in ignored_directories {
+        let WorkspaceInventoryExclusion::Directory(path) = exclusion else { continue };
         let path = workspace_root.join(path);
         let canonical = match fs::canonicalize(&path) {
             Ok(path) => path,
@@ -144,12 +159,24 @@ struct IgnoredDirectories<'a> {
     root: &'a Path,
     basenames: BTreeSet<&'a OsStr>,
     paths: BTreeSet<PathBuf>,
+    patterns: Vec<DirectoryPattern>,
 }
 
 impl IgnoredDirectories<'_> {
     fn contains(&self, basename: &OsStr, path: &Path) -> bool {
         self.basenames.contains(basename)
-            || path.strip_prefix(self.root).is_ok_and(|relative| self.paths.contains(relative))
+            || path.strip_prefix(self.root).is_ok_and(|relative| {
+                self.paths.contains(relative)
+                    || self.patterns.iter().any(|pattern| pattern.excludes_directory(relative))
+            })
+    }
+
+    fn excludes_manifest(&self, path: &Path) -> bool {
+        path.parent().filter(|parent| *parent != self.root).is_some_and(|parent| {
+            parent.strip_prefix(self.root).is_ok_and(|relative| {
+                self.patterns.iter().any(|pattern| pattern.excludes_manifest(relative))
+            })
+        })
     }
 }
 

--- a/pnpm/crates/workspace/src/inventory/exclusions.rs
+++ b/pnpm/crates/workspace/src/inventory/exclusions.rs
@@ -1,0 +1,52 @@
+use super::{FindWorkspaceInventoryError, WorkspaceInventoryExclusion};
+use crate::directory_pattern::normalize_directory_pattern;
+use std::path::Path;
+use wax::{Glob, Program as _};
+
+pub(super) struct DirectoryPattern {
+    directory: Glob<'static>,
+    subtree: Option<Glob<'static>>,
+}
+
+impl DirectoryPattern {
+    pub(super) fn excludes_directory(&self, path: &Path) -> bool {
+        self.subtree.as_ref().is_some_and(|pattern| pattern.is_match(path))
+    }
+
+    pub(super) fn excludes_manifest(&self, parent: &Path) -> bool {
+        self.directory.is_match(parent) || self.excludes_directory(parent)
+    }
+}
+
+pub(super) fn compile_patterns(
+    exclusions: &[WorkspaceInventoryExclusion],
+) -> Result<Vec<DirectoryPattern>, FindWorkspaceInventoryError> {
+    let mut patterns = Vec::new();
+    for exclusion in exclusions {
+        let WorkspaceInventoryExclusion::Pattern(source) = exclusion else { continue };
+        if source.starts_with('/') {
+            continue;
+        }
+        let Some(normalized) = normalize_directory_pattern(source) else { continue };
+        let subtree = normalized
+            .strip_suffix("/**")
+            .or_else(|| (normalized == "**").then_some("**"))
+            .map(|pattern| compile_pattern(source, pattern))
+            .transpose()?;
+        patterns
+            .push(DirectoryPattern { directory: compile_pattern(source, &normalized)?, subtree });
+    }
+    Ok(patterns)
+}
+
+fn compile_pattern(
+    source: &str,
+    normalized: &str,
+) -> Result<Glob<'static>, FindWorkspaceInventoryError> {
+    Glob::new(normalized).map(Glob::into_owned).map_err(|error| {
+        FindWorkspaceInventoryError::InvalidGlob {
+            pattern: source.to_string(),
+            message: error.to_string(),
+        }
+    })
+}

--- a/pnpm/crates/workspace/src/inventory/tests.rs
+++ b/pnpm/crates/workspace/src/inventory/tests.rs
@@ -1,7 +1,85 @@
-use super::{find_workspace_inventory, find_workspace_inventory_with};
+use super::{WorkspaceInventoryExclusion, find_workspace_inventory, find_workspace_inventory_with};
 use pnpm_fs::symlink_dir as symlink;
 use pretty_assertions::assert_eq;
 use std::fs;
+
+#[test]
+fn prunes_excluded_subtrees_before_opening_them() {
+    let workspace = tempfile::tempdir().unwrap();
+    for directory in ["", "rust", "fixtures/excluded", ".worktrees/copy"] {
+        fs::create_dir_all(workspace.path().join(directory)).unwrap();
+        fs::write(workspace.path().join(directory).join("Cargo.toml"), "[workspace]\n").unwrap();
+    }
+    let exclusions = [
+        WorkspaceInventoryExclusion::Pattern("./unused/../fixtures//**".to_string()),
+        WorkspaceInventoryExclusion::Pattern("**/.worktrees/**".to_string()),
+    ];
+    let inventory = find_workspace_inventory_with(
+        workspace.path(),
+        &["Cargo.toml"],
+        &[],
+        &exclusions,
+        |_| Ok(()),
+        |directory| {
+            assert!(!directory.starts_with(workspace.path().join("fixtures")));
+            assert!(!directory.starts_with(workspace.path().join(".worktrees")));
+            Ok(())
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        inventory.manifests("Cargo.toml").unwrap(),
+        [workspace.path().join("Cargo.toml"), workspace.path().join("rust/Cargo.toml")],
+    );
+}
+
+#[test]
+fn literal_exclusions_do_not_hide_nested_projects() {
+    let workspace = tempfile::tempdir().unwrap();
+    fs::create_dir_all(workspace.path().join("fixtures/child")).unwrap();
+    fs::write(workspace.path().join("fixtures/Cargo.toml"), "[workspace]\n").unwrap();
+    fs::write(workspace.path().join("fixtures/child/Cargo.toml"), "[workspace]\n").unwrap();
+    let inventory = find_workspace_inventory(
+        workspace.path(),
+        &["Cargo.toml"],
+        &[],
+        &[WorkspaceInventoryExclusion::Pattern("fixtures".to_string())],
+    )
+    .unwrap();
+    assert_eq!(
+        inventory.manifests("Cargo.toml").unwrap(),
+        [workspace.path().join("fixtures/child/Cargo.toml")],
+    );
+}
+
+#[test]
+fn workspace_root_is_not_excluded_by_package_patterns() {
+    let workspace = tempfile::tempdir().unwrap();
+    fs::write(workspace.path().join("Cargo.toml"), "[workspace]\n").unwrap();
+    fs::create_dir(workspace.path().join("child")).unwrap();
+    fs::write(workspace.path().join("child/Cargo.toml"), "[workspace]\n").unwrap();
+    let inventory = find_workspace_inventory(
+        workspace.path(),
+        &["Cargo.toml"],
+        &[],
+        &[WorkspaceInventoryExclusion::Pattern("**".to_string())],
+    )
+    .unwrap();
+    assert_eq!(inventory.manifests("Cargo.toml").unwrap(), [workspace.path().join("Cargo.toml")]);
+}
+
+#[test]
+fn invalid_exclusion_patterns_are_reported() {
+    let workspace = tempfile::tempdir().unwrap();
+    let error = find_workspace_inventory(
+        workspace.path(),
+        &["Cargo.toml"],
+        &[],
+        &[WorkspaceInventoryExclusion::Pattern("[broken".to_string())],
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("[broken"));
+}
 
 #[test]
 fn discovers_multiple_manifest_kinds_in_one_inventory() {
@@ -152,7 +230,7 @@ fn prunes_managed_paths_before_opening_without_excluding_matching_project_names(
             workspace.path(),
             &["Cargo.toml", "pyproject.toml"],
             &[],
-            &[excluded],
+            &[WorkspaceInventoryExclusion::Directory(excluded)],
             |_| Ok(()),
             |path| {
                 assert_ne!(path, cache, "managed directory must not be opened");
@@ -216,6 +294,7 @@ fn discovers_deep_trees_with_a_small_handle_limit() {
             root,
             basenames: std::collections::BTreeSet::default(),
             paths: std::collections::BTreeSet::default(),
+            patterns: Vec::new(),
         };
         let navigation_opens =
             super::traversal::walk_workspace(root, &ignored, |_| Ok(()), |_| Ok(()), |_, _| {})

--- a/pnpm/crates/workspace/src/lib.rs
+++ b/pnpm/crates/workspace/src/lib.rs
@@ -12,7 +12,10 @@
 
 pub use api::{EnvVarOs, Host};
 pub use importer_id::importer_id_from_root_dir;
-pub use inventory::{FindWorkspaceInventoryError, WorkspaceInventory, find_workspace_inventory};
+pub use inventory::{
+    FindWorkspaceInventoryError, WorkspaceInventory, WorkspaceInventoryExclusion,
+    find_workspace_inventory,
+};
 pub use manifest::{
     InvalidWorkspaceManifestError, ReadWorkspaceManifestError, WORKSPACE_MANIFEST_FILENAME,
     WorkspaceManifest, read_workspace_manifest, workspace_package_patterns,
@@ -33,6 +36,7 @@ pub use root_finder::{
 };
 
 mod api;
+mod directory_pattern;
 mod importer_id;
 mod inventory;
 mod manifest;

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -14,10 +14,12 @@
 //!
 //! [#431]: https://github.com/pnpm/pacquet/issues/431
 
-use crate::project_manifest::{ReadProjectManifestError, read_exact_project_manifest};
+use crate::{
+    directory_pattern::normalize_directory_pattern,
+    project_manifest::{ReadProjectManifestError, read_exact_project_manifest},
+};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pnpm_fs::lexical_normalize_posix;
 use pnpm_package_manifest::{PackageManifest, PackageManifestError};
 use rayon::prelude::*;
 use std::{
@@ -479,15 +481,6 @@ const PROJECT_MANIFEST_BASENAMES: &[&str] = &["package.json", "package.yaml"];
 struct WorkspacePattern<'source> {
     source: &'source str,
     normalized: String,
-}
-
-fn normalize_directory_pattern(pattern: &str) -> Option<String> {
-    let mut normalized = lexical_normalize_posix(pattern);
-    normalized.truncate(normalized.trim_end_matches('/').len());
-    if normalized.is_empty() || normalized == "." {
-        return None;
-    }
-    Some(normalized)
 }
 
 #[cfg(test)]

--- a/pnpm/plans/ECOSYSTEM_INSTALL.md
+++ b/pnpm/plans/ECOSYSTEM_INSTALL.md
@@ -48,6 +48,12 @@ workspace input, even when it contains native manifests and lives inside the
 workspace. Exclusions are paths, so real projects with the same directory
 basename elsewhere remain discoverable.
 
+Negated `packages` patterns also exclude native manifests from discovery. A
+subtree exclusion such as `!fixtures/**` prunes the directory before it is opened;
+a literal exclusion leaves nested projects discoverable. The inventory root is
+always included. Positive npm package patterns do not select Cargo or Python
+projects. Cargo still owns the members and dependencies of each selected workspace.
+
 Preparation starts only after the lock and all metadata snapshots exist.
 Every task must settle its spawned work before returning, including error
 paths. The coordinator waits for every task even after a sibling fails.


### PR DESCRIPTION
## Summary

Superseded by the maintainer's concurrent implementation in pnpm/pnpm#14846, which was opened while this alternative was completing validation. Closing this PR to keep one implementation under review.

Fixes pnpm/pnpm#14844. Cargo and Python discovery now honor negated workspace `packages` patterns. A tree excluded with `!fixtures/**` is pruned before it is opened, so an invalid Cargo manifest there cannot fail the active install and an independent Cargo workspace there receives no generated source configuration.

Positive npm package patterns continue to select npm projects only. Root native manifests remain discoverable, and Cargo still owns its member graph. Literal exclusions retain npm's directory-only semantics; subtree exclusions prune descendants. Existing managed-directory and symlink protections remain in force.

Includes inventory tests and a CLI regression covering both malformed and valid excluded Cargo workspaces. The macOS lint gate also required scoping two Linux-only test imports and extracting the file-limit adjustment from its once-only closure without changing its fallback behavior.

## Squash Commit Body

```text
Pass workspace package negations into the shared native manifest inventory.
Compile the exclusions once, reuse npm's directory-pattern normalization,
and prune whole-subtree exclusions before opening those directories.
Keep literal directory matches separate from traversal pruning so nested
projects are not accidentally hidden. Preserve root manifests and leave
native membership to the ecosystem resolver.

Add inventory and install regressions proving excluded manifests are neither
read nor given generated Cargo configuration. Scope two Linux-only test
imports and flatten the file-limit adjustment to satisfy the macOS
all-targets lint gate without changing the fallback behavior.

Fixes pnpm/pnpm#14844.
```

## Validation

- `just ready` passed on macOS arm64 with repository-pinned Rust 1.97.0: 11,133 workspace tests passed (13 upstream skips), plus format, spelling, check and Clippy.
- Focused native inventory and excluded-Cargo-workspace regressions passed.
- TypeScript compilation and lint passed.
- Rust documentation built with warnings denied.
- All 68 focused mirror tests passed after the file-limit lint repair.
- All pre-push hooks passed, including custom Dylint and TOML formatting.

## Checklist

- [x] Checked related work. The concurrent pnpm/pnpm#14846 covers the reported issue; this alternative is superseded.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes are implemented in every affected version (this native discovery is v12-only).
- [x] Added a changeset for the published package.
- [x] Added or updated tests.
- [x] Updated the documentation.

---
Written by an agent (Codex, GPT-6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791763934&installation_model_id=426870&pr_number=14848&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14848&signature=ba1681e58222fb5a4dcfaac8d9c1f82728e2b0cec6cca9a647f1571e5a25cef1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `pnpm install` now respects negated `packages` patterns when discovering Cargo and Python projects.
  - Excluded native workspaces are no longer opened, parsed, or modified.
  - Nested projects remain discoverable when only a parent directory is excluded literally.
  - Invalid workspace exclusion patterns now report a clear error.

- **Documentation**
  - Clarified native workspace discovery and exclusion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
