### PR TITLE
fix(cli): re-add 'pnpm t' and 'pnpm tst'

### DIFF
--- a/.changeset/pnpm-t-alias.md
+++ b/.changeset/pnpm-t-alias.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+add missing `t` and `tst` aliases for `test` CLI command

--- a/pnpm/crates/cli/src/cli_args/cli_command/commands.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command/commands.rs
@@ -118,6 +118,7 @@ pub enum CliCommand {
     #[clap(visible_alias = "ss")]
     SetScript(SetScriptArgs),
     /// Runs a package's "test" script, if one was provided.
+    #[clap(visible_aliases = ["t", "tst"])]
     Test(ScriptShortcutArgs),
     /// Runs a defined package script.
     Run(RunArgs),

--- a/pnpm/crates/cli/tests/suite/test_command.rs
+++ b/pnpm/crates/cli/tests/suite/test_command.rs
@@ -25,6 +25,48 @@ fn test_runs_declared_test_script() {
     drop(root);
 }
 
+#[cfg_attr(target_os = "windows", ignore = "uses a POSIX shell command")]
+#[test]
+fn t_alias_runs_declared_test_script() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let marker = workspace.join("tested-t.txt");
+    let manifest = json!({
+        "name": "test-command",
+        "version": "0.0.0",
+        "scripts": {
+            "test": format!(r#"printf tested > "{}""#, marker.display()),
+        },
+    });
+    fs::write(workspace.join("package.json"), manifest.to_string()).expect("write package.json");
+
+    pacquet.with_arg("t").assert().success();
+
+    assert_eq!(fs::read_to_string(marker).expect("read marker"), "tested");
+
+    drop(root);
+}
+
+#[cfg_attr(target_os = "windows", ignore = "uses a POSIX shell command")]
+#[test]
+fn tst_alias_runs_declared_test_script() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let marker = workspace.join("tested-tst.txt");
+    let manifest = json!({
+        "name": "test-command",
+        "version": "0.0.0",
+        "scripts": {
+            "test": format!(r#"printf tested > "{}""#, marker.display()),
+        },
+    });
+    fs::write(workspace.join("package.json"), manifest.to_string()).expect("write package.json");
+
+    pacquet.with_arg("tst").assert().success();
+
+    assert_eq!(fs::read_to_string(marker).expect("read marker"), "tested");
+
+    drop(root);
+}
+
 #[test]
 fn test_skips_missing_test_script() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();

--- a/pnpm/crates/cli/tests/suite/test_command.rs
+++ b/pnpm/crates/cli/tests/suite/test_command.rs
@@ -13,14 +13,16 @@ fn test_runs_declared_test_script() {
         "name": "test-command",
         "version": "0.0.0",
         "scripts": {
-            "test": format!(r#"printf tested > "{}""#, marker.display()),
+            "t": format!(r#"printf ran_t > "{}""#, marker.display()),
+            "tst": format!(r#"printf ran_tst > "{}""#, marker.display()),
+            "test": format!(r#"printf ran_test > "{}""#, marker.display()),
         },
     });
     fs::write(workspace.join("package.json"), manifest.to_string()).expect("write package.json");
 
     pacquet.with_arg("test").assert().success();
 
-    assert_eq!(fs::read_to_string(marker).expect("read marker"), "tested");
+    assert_eq!(fs::read_to_string(marker).expect("read marker"), "ran_test");
 
     drop(root);
 }
@@ -34,14 +36,16 @@ fn t_alias_runs_declared_test_script() {
         "name": "test-command",
         "version": "0.0.0",
         "scripts": {
-            "test": format!(r#"printf tested > "{}""#, marker.display()),
+            "t": format!(r#"printf ran_t > "{}""#, marker.display()),
+            "tst": format!(r#"printf ran_tst > "{}""#, marker.display()),
+            "test": format!(r#"printf ran_test > "{}""#, marker.display()),
         },
     });
     fs::write(workspace.join("package.json"), manifest.to_string()).expect("write package.json");
 
     pacquet.with_arg("t").assert().success();
 
-    assert_eq!(fs::read_to_string(marker).expect("read marker"), "tested");
+    assert_eq!(fs::read_to_string(marker).expect("read marker"), "ran_test");
 
     drop(root);
 }
@@ -55,14 +59,16 @@ fn tst_alias_runs_declared_test_script() {
         "name": "test-command",
         "version": "0.0.0",
         "scripts": {
-            "test": format!(r#"printf tested > "{}""#, marker.display()),
+            "t": format!(r#"printf ran_t > "{}""#, marker.display()),
+            "tst": format!(r#"printf ran_tst > "{}""#, marker.display()),
+            "test": format!(r#"printf ran_test > "{}""#, marker.display()),
         },
     });
     fs::write(workspace.join("package.json"), manifest.to_string()).expect("write package.json");
 
     pacquet.with_arg("tst").assert().success();
 
-    assert_eq!(fs::read_to_string(marker).expect("read marker"), "tested");
+    assert_eq!(fs::read_to_string(marker).expect("read marker"), "ran_test");
 
     drop(root);
 }


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

pnpm 11 used to support `pnpm t` or `pnpm tst` to run tests in a package, and is still referenced by https://pnpm.io/cli/test, but it is missing in pnpm 12.

⚠️  I have implemented this as an alias which is not _identical_ to pnpm 11's behaviour.
If a package defines both a 't' script and a 'test' script, `pnpm t` would run the 't' script
in v11 and the 'test' script in v12 (with this fix). Hopefully this is acceptable since the v11
behaviour wasn't documented and may even be surprising.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Re-add the `pnpm t` and `pnpm tst` aliases for the `pnpm test` command, which were
not carried over from pnpm 11 to pnpm 12.

Note: this is not entirely identical to pnpm 11. If a package defines both a 't' script and a
'test' script, `pnpm t` would run the 't' script in v11 and the 'test' script in v12 with this fix.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791771584&installation_model_id=426870&pr_number=14849&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14849&signature=53653c40718b6896d0fec69c8c38dbe8936f8a65f6f5ec25a12b5472b403c807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pnpm t` and `pnpm tst` as aliases for running a package’s test script.

* **Tests**
  * Added coverage confirming both aliases execute the declared test script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->