### PR TITLE
fix(cli): preserve repeated keys in pnpm config set/delete

### DIFF
--- a/.changeset/fix-config-repeated-keys.md
+++ b/.changeset/fix-config-repeated-keys.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm config set` and `pnpm config delete` no longer destroy repeated keys in `.npmrc`. When the file contains multiple lines for the same key (such as `ca=` for certificate authority lists), an unrelated `pnpm config set` now preserves all of them instead of collapsing to the last value [#14851](https://github.com/pnpm/pnpm/issues/14851).

--- a/pnpm/crates/cli/src/cli_args/config.rs
+++ b/pnpm/crates/cli/src/cli_args/config.rs
@@ -319,24 +319,29 @@ fn set_auth_setting(
 /// Read the INI file, set or delete `key`, and write it back. A delete of an
 /// absent key is a no-op (no write). Mirrors the INI arms of `configSet`.
 fn write_ini_setting(config_path: &Path, key: &str, value: &Value) -> miette::Result<()> {
-    let mut settings = ini::read(config_path)
-        .map_err(miette::Report::msg)
-        .map_err(|err| err.wrap_err(format!("reading {}", config_path.display())))?;
     if value.is_null() {
-        if settings.shift_remove(key).is_none() {
-            return Ok(());
-        }
-    } else {
-        let value_string = ini_value_string(value);
-        // A control character (notably a newline) in the value would split into
-        // extra `key=value` lines when the INI file is re-parsed, injecting
-        // settings the user never set. Refuse rather than corrupt the file.
-        if has_control_char(key) || has_control_char(&value_string) {
-            return Err(ConfigError::SetIniControlCharacter.into());
-        }
-        settings.insert(key.to_string(), value_string);
+        ini::remove(config_path, key)
+            .map_err(miette::Report::msg)
+            .map_err(|err| err.wrap_err(format!("deleting from {}", config_path.display())))?;
+        return Ok(());
     }
-    ini::write(config_path, &settings)
+
+    if has_control_char(key) {
+        return Err(ConfigError::SetIniControlCharacter.into());
+    }
+    // Handle array values: if the value is a JSON array, write it as
+    // repeated keys. Otherwise, write it as a single value.
+    let values = match value {
+        Value::Array(arr) => arr.iter().map(ini_value_string).collect::<Vec<_>>(),
+        _ => vec![ini_value_string(value)],
+    };
+    // A control character (notably a newline) in any value would split into
+    // extra `key=value` lines when the INI file is re-parsed, injecting
+    // settings the user never set. Refuse rather than corrupt the file.
+    if values.iter().any(|value| has_control_char(value)) {
+        return Err(ConfigError::SetIniControlCharacter.into());
+    }
+    ini::write(config_path, key, &values)
         .map_err(miette::Report::msg)
         .map_err(|err| err.wrap_err(format!("writing {}", config_path.display())))?;
     Ok(())

--- a/pnpm/crates/cli/src/cli_args/config/ini.rs
+++ b/pnpm/crates/cli/src/cli_args/config/ini.rs
@@ -3,16 +3,36 @@
 //! `pnpm config` reads and writes these files through the `ini` npm package
 //! (`read-ini-file` / `write-ini-file`). The config keys it touches are flat
 //! `key=value` pairs (`registry`, `@scope:registry`, `//host/:_authToken`,
-//! `cafile`, ...) — no sections, no arrays — so this reproduces just that
-//! subset: a missing file reads as empty, comments (`;` / `#`) and blank lines
-//! are ignored, and the map round-trips as `key=value` lines.
+//! `cafile`, ...) — no sections. The format supports arrays as repeated keys
+//! (e.g., multiple `ca=` lines accumulate into an array), matching pnpm's INI
+//! parser and the `NpmrcAuth::ca` field. Comments (`;` / `#`) and blank lines
+//! are preserved where possible.
 
+#[cfg(test)]
 use indexmap::IndexMap;
 use std::{fs, io, path::Path};
 
-/// Read `path` into an ordered key→value map. A missing file is an empty map;
-/// any other read error propagates.
-pub fn read(path: &Path) -> io::Result<IndexMap<String, String>> {
+/// An INI file's content, parsed into lines and structured entries.
+#[derive(Debug)]
+struct IniContent {
+    /// Lines in their original order: structured entries and unparsed lines
+    /// (comments, blank lines, and malformed lines) interleaved.
+    lines: Vec<Line>,
+}
+
+#[derive(Debug)]
+enum Line {
+    /// A `key=value` entry.
+    Entry { key: String, raw: String },
+    /// A comment, blank line, or malformed line, preserved verbatim.
+    Unparsed(String),
+}
+
+/// Read `path` into an ordered key→value(s) map. A missing file is an empty
+/// map; any other read error propagates. Repeated keys accumulate into the
+/// value vector (e.g., multiple `ca=` lines).
+#[cfg(test)]
+pub fn read(path: &Path) -> io::Result<IndexMap<String, Vec<String>>> {
     match fs::read_to_string(path) {
         Ok(text) => Ok(parse(&text)),
         Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(IndexMap::new()),
@@ -20,7 +40,8 @@ pub fn read(path: &Path) -> io::Result<IndexMap<String, String>> {
     }
 }
 
-fn parse(text: &str) -> IndexMap<String, String> {
+#[cfg(test)]
+fn parse(text: &str) -> IndexMap<String, Vec<String>> {
     let mut map = IndexMap::new();
     for line in text.lines() {
         let line = line.trim();
@@ -28,22 +49,79 @@ fn parse(text: &str) -> IndexMap<String, String> {
             continue;
         }
         if let Some((key, value)) = line.split_once('=') {
-            map.insert(key.trim().to_string(), value.trim().to_string());
+            map.entry(key.trim().to_string())
+                .or_insert_with(Vec::new)
+                .push(value.trim().to_string());
         }
     }
     map
 }
 
-/// Write `settings` to `path` as `key=value` lines, creating parent
-/// directories and replacing the file atomically and symlink-safely (see
-/// [`pnpm_fs::write_atomic`]).
-pub fn write(path: &Path, settings: &IndexMap<String, String>) -> io::Result<()> {
-    let mut contents = String::new();
-    for (key, value) in settings {
-        contents.push_str(key);
-        contents.push('=');
-        contents.push_str(value);
-        contents.push('\n');
+/// Parse `text` into structured lines, preserving comments and blank lines.
+fn parse_with_structure(text: &str) -> IniContent {
+    let mut lines = Vec::new();
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with(';') || trimmed.starts_with('#') {
+            lines.push(Line::Unparsed(line.to_string()));
+        } else if let Some((key, _value)) = trimmed.split_once('=') {
+            lines.push(Line::Entry { key: key.trim().to_string(), raw: line.to_string() });
+        } else {
+            lines.push(Line::Unparsed(line.to_string()));
+        }
     }
-    pnpm_fs::write_atomic(path, contents.as_bytes())
+    IniContent { lines }
+}
+
+/// Replace every entry for `key`, preserving unrelated lines in their original
+/// order and spelling. Array values are written as repeated `key=value` lines.
+pub fn write(path: &Path, key: &str, values: &[String]) -> io::Result<()> {
+    let mut content = match fs::read_to_string(path) {
+        Ok(text) => parse_with_structure(&text),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => IniContent { lines: Vec::new() },
+        Err(err) => return Err(err),
+    };
+
+    content.lines.retain(|line| match line {
+        Line::Entry { key: entry_key, .. } => entry_key != key,
+        Line::Unparsed(_) => true,
+    });
+    for value in values {
+        content.lines.push(Line::Entry { key: key.to_string(), raw: format!("{key}={value}") });
+    }
+    write_content(path, &content)
+}
+
+fn write_content(path: &Path, content: &IniContent) -> io::Result<()> {
+    let mut output = String::new();
+    for line in &content.lines {
+        match line {
+            Line::Entry { raw, .. } | Line::Unparsed(raw) => {
+                output.push_str(raw);
+                output.push('\n');
+            }
+        }
+    }
+    pnpm_fs::write_atomic(path, output.as_bytes())
+}
+
+/// Remove every entry for `key` while preserving comments, blank lines, and
+/// unrelated entries in their original order.
+pub fn remove(path: &Path, key: &str) -> io::Result<bool> {
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(err) => return Err(err),
+    };
+    let mut content = parse_with_structure(&text);
+    let original_len = content.lines.len();
+    content
+        .lines
+        .retain(|line| !matches!(line, Line::Entry { key: entry_key, .. } if entry_key == key));
+    if content.lines.len() == original_len {
+        return Ok(false);
+    }
+
+    write_content(path, &content)?;
+    Ok(true)
 }

--- a/pnpm/crates/cli/src/cli_args/config/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/config/tests.rs
@@ -23,8 +23,12 @@ fn read_yaml(path: &Path) -> Option<Value> {
     Some(serde_saphyr::from_str(&text).expect("parse yaml"))
 }
 
-fn read_ini(path: &Path) -> IndexMap<String, String> {
-    ini::read(path).expect("read ini")
+fn read_ini_flat(path: &Path) -> IndexMap<String, String> {
+    ini::read(path)
+        .expect("read ini")
+        .into_iter()
+        .map(|(k, v)| (k, v.into_iter().next().unwrap_or_default()))
+        .collect()
 }
 
 // --- config set: INI routing -----------------------------------------------
@@ -44,7 +48,7 @@ fn set_registry_global_writes_auth_ini() {
     )
     .unwrap();
 
-    let ini = read_ini(&config_dir.join("auth.ini"));
+    let ini = read_ini_flat(&config_dir.join("auth.ini"));
     assert_eq!(ini.get("registry").map(String::as_str), Some("https://npm-registry.example.com/"));
 }
 
@@ -58,7 +62,7 @@ fn set_cafile_global_writes_auth_ini() {
         .unwrap();
 
     assert_eq!(
-        read_ini(&config_dir.join("auth.ini")).get("cafile").map(String::as_str),
+        read_ini_flat(&config_dir.join("auth.ini")).get("cafile").map(String::as_str),
         Some("some-cafile"),
     );
 }
@@ -78,7 +82,7 @@ fn set_scoped_registry_project_creates_npmrc() {
     .unwrap();
 
     assert_eq!(
-        read_ini(&tmp.path().join(".npmrc")).get("@myorg:registry").map(String::as_str),
+        read_ini_flat(&tmp.path().join(".npmrc")).get("@myorg:registry").map(String::as_str),
         Some("https://test-registry.example.com/"),
     );
     assert!(!tmp.path().join("pnpm-workspace.yaml").exists());
@@ -99,7 +103,7 @@ fn set_per_registry_auth_project_creates_npmrc() {
     .unwrap();
 
     assert_eq!(
-        read_ini(&tmp.path().join(".npmrc"))
+        read_ini_flat(&tmp.path().join(".npmrc"))
             .get("//registry.example.com/:_auth")
             .map(String::as_str),
         Some("test-auth-value"),
@@ -418,7 +422,7 @@ fn delete_auth_key_set_and_unset() {
     .unwrap();
     config_set(&config, tmp.path(), flags(true, None, false), "registry", None).unwrap();
     assert_eq!(
-        read_ini(&config_dir.join("auth.ini")).get("@my-company:registry").map(String::as_str),
+        read_ini_flat(&config_dir.join("auth.ini")).get("@my-company:registry").map(String::as_str),
         Some("https://registry.my-company.example.com/"),
     );
 
@@ -429,7 +433,7 @@ fn delete_auth_key_set_and_unset() {
     )
     .unwrap();
     config_set(&config, tmp.path(), flags(true, None, false), "registry", None).unwrap();
-    assert!(read_ini(&config_dir.join("auth.ini")).is_empty());
+    assert!(read_ini_flat(&config_dir.join("auth.ini")).is_empty());
 }
 
 #[test]
@@ -881,5 +885,132 @@ fn set_does_not_follow_symlinked_npmrc_mode() {
     assert_eq!(
         mode, 0o600,
         "credentials written through a symlinked .npmrc must stay 0600, got {mode:o}",
+    );
+}
+
+// --- config set: repeated keys / array preservation -----------------------
+
+#[test]
+fn set_preserves_repeated_ca_keys() {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = tmp.path().join("global-config");
+    let config = config_with_dir(&config_dir);
+    let npmrc_path = tmp.path().join(".npmrc");
+
+    // Write an `.npmrc` with two `ca=` entries and an unrelated setting.
+    std::fs::write(
+        &npmrc_path,
+        "ca=certificate-A\nca=certificate-B\nregistry=https://registry.npmjs.org/\n",
+    )
+    .unwrap();
+
+    // Modify an unrelated key via `config set`.
+    config_set(
+        &config,
+        tmp.path(),
+        flags(false, Some(ConfigLocation::Project), false),
+        "registry",
+        Some("https://registry.example.com/".to_string()),
+    )
+    .unwrap();
+
+    // Both `ca=` entries should survive.
+    let content = std::fs::read_to_string(&npmrc_path).unwrap();
+    assert!(content.contains("ca=certificate-A"), "first ca= entry missing");
+    assert!(content.contains("ca=certificate-B"), "second ca= entry missing");
+    assert!(content.contains("registry=https://registry.example.com/"));
+}
+
+#[test]
+fn set_preserves_unrelated_ini_lines() {
+    let tmp = TempDir::new().unwrap();
+    let config = config_with_dir(&tmp.path().join("global-config"));
+    let npmrc_path = tmp.path().join(".npmrc");
+    std::fs::write(
+        &npmrc_path,
+        "# keep this comment\nca = certificate-A\nnot-an-entry\nregistry = https://old.example.com/\n; keep this too\n",
+    )
+    .unwrap();
+
+    config_set(
+        &config,
+        tmp.path(),
+        flags(false, Some(ConfigLocation::Project), false),
+        "registry",
+        Some("https://new.example.com/".to_string()),
+    )
+    .unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(npmrc_path).unwrap(),
+        "# keep this comment\nca = certificate-A\nnot-an-entry\n; keep this too\nregistry=https://new.example.com/\n",
+    );
+}
+
+#[test]
+fn set_ca_as_json_array_writes_repeated_keys() {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = tmp.path().join("global-config");
+    let config = config_with_dir(&config_dir);
+    let npmrc_path = tmp.path().join(".npmrc");
+
+    // Set `ca` to a JSON array using the `--json` flag.
+    config_set(
+        &config,
+        tmp.path(),
+        flags(false, Some(ConfigLocation::Project), true),
+        "ca",
+        Some(r#"["certificate-A","certificate-B"]"#.to_string()),
+    )
+    .unwrap();
+
+    // The INI file should contain two `ca=` lines, not a JSON-shaped scalar.
+    let content = std::fs::read_to_string(&npmrc_path).unwrap();
+    let ca_lines: Vec<_> = content.lines().filter(|line| line.trim().starts_with("ca=")).collect();
+    assert_eq!(ca_lines.len(), 2, "expected two ca= lines");
+    assert!(ca_lines.contains(&"ca=certificate-A"), "first ca= entry missing");
+    assert!(ca_lines.contains(&"ca=certificate-B"), "second ca= entry missing");
+}
+
+#[test]
+fn delete_one_repeated_key_removes_all_instances() {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = tmp.path().join("global-config");
+    let config = config_with_dir(&config_dir);
+    let npmrc_path = tmp.path().join(".npmrc");
+
+    // Write an `.npmrc` with two `ca=` entries.
+    std::fs::write(
+        &npmrc_path,
+        "ca=certificate-A\nca=certificate-B\nregistry=https://registry.npmjs.org/\n",
+    )
+    .unwrap();
+
+    // Delete `ca` via `config delete`.
+    config_set(&config, tmp.path(), flags(false, Some(ConfigLocation::Project), false), "ca", None)
+        .unwrap();
+
+    // All `ca=` entries should be removed.
+    let content = std::fs::read_to_string(&npmrc_path).unwrap();
+    assert!(!content.contains("ca="), "ca= entries should be removed");
+    assert!(content.contains("registry=https://registry.npmjs.org/"));
+}
+
+#[test]
+fn set_ca_array_rejects_control_characters() {
+    let tmp = TempDir::new().unwrap();
+    let config = config_with_dir(&tmp.path().join("global-config"));
+
+    let err = config_set(
+        &config,
+        tmp.path(),
+        flags(false, Some(ConfigLocation::Project), true),
+        "ca",
+        Some(r#"["certificate-A\ncertificate-B"]"#.to_string()),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err.code().unwrap().to_string(),
+        "ERR_PNPM_CLI_CONFIG_SET_INVALID_CONTROL_CHARACTER"
     );
 }


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Fixes `pnpm config set` and `pnpm config delete` destroying repeated keys (e.g., multiple `ca=` lines) in `.npmrc` files.

The INI parser now treats repeated keys as arrays (`IndexMap<String, Vec<String>>`), matching pnpm v11's behavior and pacquet's own `NpmrcAuth::ca` documentation. Unrelated `config set` operations now preserve all repeated entries instead of collapsing them to the last value.

Closes  https://github.com/pnpm/pnpm/issues/14851



## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Fix `pnpm config set` and `pnpm config delete` destroying repeated keys in `.npmrc`. The INI parser now treats repeated keys (such as multiple `ca=` lines for certificate lists) as arrays, matching pnpm v11 and pacquet's own `NpmrcAuth::ca` documentation.

Before this fix, any config operation would perform a read-modify-write cycle that collapsed repeated keys to their last value, silently destroying user-configured certificate lists and other array-valued settings.

```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791792184&installation_model_id=426870&pr_number=14852&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14852&signature=d802dbe46ebe8be87db2aafb0635489c41f52e099bc8f5ca07cad7ccb92b2a9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration updates so repeated entries in `.npmrc` files are preserved when setting unrelated values.
  * Configuration arrays, such as multiple certificate authority entries, are now written as separate repeated keys.
  * Deleting a repeated configuration key now removes all instances of that key.
  * Comments, blank lines, and unrecognized lines in configuration files are preserved during updates.
  * Configuration file updates now retain existing formatting and content more reliably.
  * Invalid control characters in configuration values are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->