### PR TITLE
style(rust): enforce the 400-line file cap with dylint

### DIFF
--- a/dylint.toml
+++ b/dylint.toml
@@ -8,7 +8,7 @@
 # or via the `just dylint` recipe.
 [workspace.metadata.dylint]
 libraries = [
-    { git = "https://github.com/KSXGitHub/perfectionist", rev = "495d33163b1e4ab6b0cbb4742a2130c655849f7d" },
+    { git = "https://github.com/KSXGitHub/perfectionist", rev = "d73ce73b63fa679b9effacb90818d530ff9fbae7" },
 ]
 
 # Project-local DSL / test macros that perfectionist's exactly-once
@@ -117,3 +117,10 @@ exempt_tests = true
 ["perfectionist::excessive_nesting"]
 max_depth = 3
 exempt_tests = false
+
+# A test file holds one scenario per test, so it grows with the number
+# of scenarios rather than with the number of concerns; the guide caps
+# it at 800 lines on its own.
+["perfectionist::overly_long_file"]
+max_lines = 400
+exempt_tests = true

--- a/pnpm/CODE_STYLE_GUIDE.md
+++ b/pnpm/CODE_STYLE_GUIDE.md
@@ -56,6 +56,8 @@ Keep iterator closures simple. A single expression can make a chain easy to foll
 
 Keep production Rust files within 400 lines of code and test-only Rust files within 800. Count nonblank lines containing code, including multiline string content, and exclude comment-only lines. Split files into modules around distinct responsibilities or test scenarios. Keep tests in their existing test binary.
 
+`perfectionist::overly_long_file` enforces the 400-line production limit across the Rust workspace through [`dylint.toml`](../dylint.toml). Test files are exempt from the rule, so their 800-line limit is on you to keep.
+
 ### Naming convention
 
 Follow [the Rust API guidelines](https://rust-lang.github.io/api-guidelines/naming.html). Specific naming conventions for generics, variables, and closure parameters are covered in the sections below.


### PR DESCRIPTION
## Summary

`perfectionist::overly_long_file` has landed upstream (KSXGitHub/perfectionist#406), so the file-length entry in `pnpm/CODE_STYLE_GUIDE.md` no longer rests on review alone. This pins the lint library to the revision that adds the rule and configures it at the guide's production limit of 400 lines of code, with test files exempt.

No refactor rides along: the workspace is already within the cap. `cargo dylint --all -- --all-targets --workspace` is clean on this branch, and the rule does fire once the cap is lowered (at `max_lines = 50` it flags `pnpm/crates/crypto-hash/src/lib.rs` at 89 lines). The longest production files sit at exactly 400 code lines (`resolving-npm-resolver/src/pick_package.rs`, `resolving-deps-resolver/src/resolve_importer.rs`); the longest test file is 797.

The rule takes one cap, so the guide's separate 800-line limit for test-only files cannot be expressed next to the 400-line one. Test files are exempt and their limit stays a convention, the same trade-off `overly_long_function` already makes.

The revision bump also picks up KSXGitHub/perfectionist#398, #435, #438, and #439: an autofix for `named_prelude_imports` brace-list cherry-picks, a githook subject check, and two internal refactors of the shared line counter and test-code check. The clean workspace run covers those too.

Related to pnpm/pnpm#14562.

## Squash Commit Body

```text
`perfectionist::overly_long_file` landed upstream in
KSXGitHub/perfectionist#406, so the file-length entry in the style guide
no longer rests on review alone. Pin the lint library to the revision
that adds the rule and set the cap to the guide's production limit.

The workspace is already within it, so this adds no refactor: every
production file is at 400 lines of code or fewer.

Test files stay exempt. The rule takes a single cap, and the guide's
800-line test limit counts scenarios rather than concerns, so it stays a
convention.

Related to pnpm/pnpm#14562.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWntUqQ2mPR1yxZNbAYNUg

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791799368&installation_model_id=426870&pr_number=14858&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14858&signature=3efdd76c64f102473a4e2c912d0510767ffad7e1141cf5016ab88fa1a11b9fe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented file-length guidelines, including a 400-line limit for production files and separate expectations for test files.

- **Chores**
  - Updated linting configuration to enforce the production-file length limit.
  - Updated the pinned lint rule revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->